### PR TITLE
[filters] add PCL_ALIGNED_OPERATOR_NEW to classes Eigen::Vector4 members

### DIFF
--- a/filters/include/pcl/filters/plane_clipper3D.h
+++ b/filters/include/pcl/filters/plane_clipper3D.h
@@ -54,6 +54,8 @@ namespace pcl
       using Ptr = shared_ptr< PlaneClipper3D<PointT> >;
       using ConstPtr = shared_ptr< const PlaneClipper3D<PointT> >;
 
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
+
       /**
        * @author Suat Gedikli <gedikli@willowgarage.com>
        * @brief Constructor taking the homogeneous representation of the plane as a Eigen::Vector4f

--- a/filters/include/pcl/filters/uniform_sampling.h
+++ b/filters/include/pcl/filters/uniform_sampling.h
@@ -71,6 +71,8 @@ namespace pcl
       using Ptr = shared_ptr<UniformSampling<PointT> >;
       using ConstPtr = shared_ptr<const UniformSampling<PointT> >;
 
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
+
       /** \brief Empty constructor. */
       UniformSampling (bool extract_removed_indices = false) :
         Filter<PointT>(extract_removed_indices),

--- a/filters/include/pcl/filters/voxel_grid.h
+++ b/filters/include/pcl/filters/voxel_grid.h
@@ -190,6 +190,8 @@ namespace pcl
       using Ptr = shared_ptr<VoxelGrid<PointT> >;
       using ConstPtr = shared_ptr<const VoxelGrid<PointT> >;
 
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
+
       /** \brief Empty constructor. */
       VoxelGrid () :
         leaf_size_ (Eigen::Vector4f::Zero ()),

--- a/filters/include/pcl/filters/voxel_grid_occlusion_estimation.h
+++ b/filters/include/pcl/filters/voxel_grid_occlusion_estimation.h
@@ -66,6 +66,9 @@ namespace pcl
       using PointCloudConstPtr = typename PointCloud::ConstPtr;
 
     public:
+
+      PCL_MAKE_ALIGNED_OPERATOR_NEW;
+
       /** \brief Empty constructor. */
       VoxelGridOcclusionEstimation ()
       {


### PR DESCRIPTION
Looked at all filters headers. Some have 4-element eigen types as members and thus require aligned operators new.