### PR TITLE
Improve correspondence rejector test

### DIFF
--- a/test/registration/test_correspondence_rejectors.cpp
+++ b/test/registration/test_correspondence_rejectors.cpp
@@ -104,14 +104,15 @@ TEST (CorrespondenceRejectors, CorrespondenceRejectionPoly)
     point.z += nd.run();
   }
   
-  // Ensure deterministic sampling inside the rejector
-  std::srand (1e6);
+  // Test rejector with varying seeds
+  const unsigned int seed = std::time(nullptr);
+  std::srand (seed);
   
   // Create a rejection object
   pcl::registration::CorrespondenceRejectorPoly<pcl::PointXYZ, pcl::PointXYZ> reject;
-  reject.setIterations (10000);
+  reject.setIterations (20000);
   reject.setCardinality (3);
-  reject.setSimilarityThreshold (0.75f);
+  reject.setSimilarityThreshold (0.8f);
   reject.setInputSource (cloud.makeShared ());
   reject.setInputTarget (target.makeShared ());
   


### PR DESCRIPTION
So far, the test was only run for one specific seed, for which the test passes. But for other seeds, the test failed roughly 50% of the time.
Now the seed is varied (for better test coverage), and the parameters are adapted so that the test passes for all seeds.
Fixes one of the failing tests in issue #5127