### PR TITLE
NDT score function improvement

### DIFF
--- a/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
@@ -352,6 +352,7 @@ pcl::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
         leaf.cov_ = leaf.evecs_ * eigen_val * leaf.evecs_.inverse ();
       }
       leaf.evals_ = eigen_val.diagonal ();
+      leaf.cov_det_ = leaf.cov_.determinant ();
 
       leaf.icov_ = leaf.cov_.inverse ();
       if (leaf.icov_.maxCoeff () == std::numeric_limits<float>::infinity ( )

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -99,7 +99,8 @@ namespace pcl
           cov_ (Eigen::Matrix3d::Zero ()),
           icov_ (Eigen::Matrix3d::Zero ()),
           evecs_ (Eigen::Matrix3d::Identity ()),
-          evals_ (Eigen::Vector3d::Zero ())
+          evals_ (Eigen::Vector3d::Zero ()),
+          cov_det_ ()
         {
         }
 
@@ -150,6 +151,15 @@ namespace pcl
           return (evals_);
         }
 
+        /** \brief Get the determinant of the voxel covariance matrix.
+          * \return determinant of the covariance matrix
+          */
+        double
+        getCovDeterminant () const
+        {
+          return (cov_det_);
+        }
+
         /** \brief Get the number of points contained by this voxel.
           * \return number of points
           */
@@ -182,6 +192,8 @@ namespace pcl
         /** \brief Eigen values of voxel covariance matrix */
         Eigen::Vector3d evals_;
 
+        /** \brief Determinant of voxel covariance matrix */
+        double cov_det_;
       };
 
       /** \brief Pointer to VoxelGridCovariance leaf structure */


### PR DESCRIPTION
This PR implements a possible improvement related to the probability density function (PDF) of scan points in a voxel [Magnusson 2009, Eq. 6.7]. The factors c_1 and c_2 in this PDF are required to be chosen such that the probability mass of the PDF equals one within the space of a voxel. While c_2 - which is related to the uniformly distributed part - was correctly divided by the volume of the voxel, c_1 was chosen as constant value. For probability mass one the normal distribution part must be scaled by `1/sqrt((2*pi)^k*det(Sigma))`. [Magnusson 2009, Eq. 6.1] states in his thesis that "for practical purposes, the factor `sqrt((2*pi)^3*det(Sigma))` may be replaced by a constant c_0". He does not go into detail what he exactly means with practical purposes however. 

- Rather obvious is the computational advantage of using a constant.
- Furthermore, using a constant means that measurements with low variance in at least one direction (low determinant: planar surfaces, straight lines, points) will be implicitly weighted lower (the reciprocal of the determinant for scaling to one would be high). This impacts the relations/relative weighting between voxels and between the normal and uniform distribution parts.
- In our experiments, the values of the determinant varied by more than a factor of thousand times resolution^3.

Experiments showed improved results on our data, consisting of 
1. point clouds from a real, moving sensor which were registered to a map which was recorded in advance with the same sensor. The observed improvement was that registration succeeded on places where it has failed without this fix.
2. point clouds from two sensors showing a static scene. The initial guess was varied in position and orientation. The observed improvement was that registration converged faster.

This implementation uses the boolean `constant_scaling_` to either use a constant scale factor (true) or computation of scale factors according to [Magnusson 2009, Eq. 6.1] (false).

This PR is related to #5056.
This PR depends on #5131.
This PR is the result of splitting the original PR #5074 as suggested by @kunaltyagi.