### PR TITLE
Added region of interest for frustum culling

### DIFF
--- a/filters/include/pcl/filters/frustum_culling.h
+++ b/filters/include/pcl/filters/frustum_culling.h
@@ -199,8 +199,8 @@ namespace pcl
       
       /** \brief Set the region of interest (ROI) in normalized values
         *  
-        * This is an optional feature. If ROI is not set, 
-        * all points in the FOV of the camera are returned.
+        * Default value of ROI: roi_{x, y} = 0.5, roi_{w, h} = 1.0
+        * This corresponds to maximal FoV and returns all the points in the frustum
         * Can be used to cut out objects based on 2D bounding boxes by object detection.
         * 
         * \param[in] roi_x X center position of ROI

--- a/filters/include/pcl/filters/frustum_culling.h
+++ b/filters/include/pcl/filters/frustum_culling.h
@@ -211,6 +211,15 @@ namespace pcl
       void 
       setRegionOfInterest (float roi_x, float roi_y, float roi_w, float roi_h)
       {
+        if ((roi_x > 1.0f) || (roi_x < 0.0f) ||
+            (roi_y > 1.0f) || (roi_y < 0.0f) ||
+            (roi_w <= 0.0f) || (roi_w > 1.0f) ||
+            (roi_h <= 0.0f) || (roi_h > 1.0f))
+        {
+          throw PCLException ("ROI X-Y values should be between 0 and 1. " 
+            "Width and height must not be zero.", 
+            "frustum_culling.h", "setRegionOfInterest");
+        }
         roi_x_ = roi_x;
         roi_y_ = roi_y;
         roi_w_ = roi_w;

--- a/filters/include/pcl/filters/frustum_culling.h
+++ b/filters/include/pcl/filters/frustum_culling.h
@@ -197,7 +197,7 @@ namespace pcl
         return (fp_dist_);
       }
       
-      /** \brief Set the region of interest (ROI)
+      /** \brief Set the region of interest (ROI) in normalized values (0 - 1)
         * \param[in] roi_x X position of ROI
         * \param[in] roi_y Y position of ROI
         * \param[in] roi_w Width of ROI
@@ -213,9 +213,9 @@ namespace pcl
       }
       
       /** \brief Get the region of interest (ROI)
-        * \param[in] roi_x X position of ROI
-        * \param[in] roi_y Y position of ROI
-        * \param[in] roi_w Width of ROI
+        * \param[in] roi_x X center position of ROI
+        * \param[in] roi_y Y center position of ROI
+        * \param[in] roi_w Width of ROI 
         * \param[in] roi_h Height of ROI
         */
       void 
@@ -255,13 +255,13 @@ namespace pcl
       float np_dist_;
       /** \brief Far plane distance */
       float fp_dist_;
-      /** \brief Region of interest x position*/
+      /** \brief Region of interest x center position (normalized)*/
       float roi_x_;
-      /** \brief Region of interest y position*/
+      /** \brief Region of interest y center position (normalized)*/
       float roi_y_;
-      /** \brief Region of interest width*/
+      /** \brief Region of interest width (normalized)*/
       float roi_w_;
-      /** \brief Region of interest height*/
+      /** \brief Region of interest height (normalized)*/
       float roi_h_;
 
     public:

--- a/filters/include/pcl/filters/frustum_culling.h
+++ b/filters/include/pcl/filters/frustum_culling.h
@@ -94,6 +94,10 @@ namespace pcl
         , vfov_ (60.0f)
         , np_dist_ (0.1f)
         , fp_dist_ (5.0f)
+        , roi_x_ (0.5f)
+        , roi_y_ (0.5f)
+        , roi_w_ (1.0f)
+        , roi_h_ (1.0f)
       {
         filter_name_ = "FrustumCulling";
       }
@@ -192,6 +196,36 @@ namespace pcl
       {
         return (fp_dist_);
       }
+      
+      /** \brief Set the region of interest (ROI)
+        * \param[in] roi_x X position of ROI
+        * \param[in] roi_y Y position of ROI
+        * \param[in] roi_w Width of ROI
+        * \param[in] roi_h Height of ROI
+        */
+      void 
+      setRegionOfInterest (float roi_x, float roi_y, float roi_w, float roi_h)
+      {
+        roi_x_ = roi_x;
+        roi_y_ = roi_y;
+        roi_w_ = roi_w;
+        roi_h_ = roi_h;
+      }
+      
+      /** \brief Get the region of interest (ROI)
+        * \param[in] roi_x X position of ROI
+        * \param[in] roi_y Y position of ROI
+        * \param[in] roi_w Width of ROI
+        * \param[in] roi_h Height of ROI
+        */
+      void 
+      getRegionOfInterest (float &roi_x, float &roi_y, float &roi_w, float &roi_h) const
+      {
+        roi_x = roi_x_;
+        roi_y = roi_y_;
+        roi_w = roi_w_;
+        roi_h = roi_h_;
+      }
 
     protected:
       using PCLBase<PointT>::input_;
@@ -221,6 +255,14 @@ namespace pcl
       float np_dist_;
       /** \brief Far plane distance */
       float fp_dist_;
+      /** \brief Region of interest x position*/
+      float roi_x_;
+      /** \brief Region of interest y position*/
+      float roi_y_;
+      /** \brief Region of interest width*/
+      float roi_w_;
+      /** \brief Region of interest height*/
+      float roi_h_;
 
     public:
       PCL_MAKE_ALIGNED_OPERATOR_NEW

--- a/filters/include/pcl/filters/frustum_culling.h
+++ b/filters/include/pcl/filters/frustum_culling.h
@@ -197,9 +197,14 @@ namespace pcl
         return (fp_dist_);
       }
       
-      /** \brief Set the region of interest (ROI) in normalized values (0 - 1)
-        * \param[in] roi_x X position of ROI
-        * \param[in] roi_y Y position of ROI
+      /** \brief Set the region of interest (ROI) in normalized values
+        *  
+        * This is an optional feature. If ROI is not set, 
+        * all points in the FOV of the camera are returned.
+        * Can be used to cut out objects based on 2D bounding boxes by object detection.
+        * 
+        * \param[in] roi_x X center position of ROI
+        * \param[in] roi_y Y center position of ROI
         * \param[in] roi_w Width of ROI
         * \param[in] roi_h Height of ROI
         */
@@ -212,7 +217,7 @@ namespace pcl
         roi_h_ = roi_h;
       }
       
-      /** \brief Get the region of interest (ROI)
+      /** \brief Get the region of interest (ROI) in normalized values
         * \param[in] roi_x X center position of ROI
         * \param[in] roi_y Y center position of ROI
         * \param[in] roi_w Width of ROI 

--- a/filters/include/pcl/filters/impl/frustum_culling.hpp
+++ b/filters/include/pcl/filters/impl/frustum_culling.hpp
@@ -141,11 +141,7 @@ pcl::FrustumCulling<PointT>::applyFilter (Indices &indices)
                      (pt.dot (pl_t) <= 0) && 
                      (pt.dot (pl_b) <= 0) && 
                      (pt.dot (pl_f) <= 0) &&
-                     (pt.dot (pl_n) <= 0) &&
-                     (roi_xmax <= 1.0f) && (roi_xmin >= 0.0f) &&
-                     (roi_ymax <= 1.0f) && (roi_ymin >= 0.0f) &&
-                     (roi_w_ > 0.0f) && (roi_w_ <= 1.0f) &&
-                     (roi_h_ > 0.0f) && (roi_h_ <= 1.0f);
+                     (pt.dot (pl_n) <= 0);
     if (is_in_fov ^ negative_)
     {
       indices[indices_ctr++] = idx;

--- a/filters/include/pcl/filters/impl/frustum_culling.hpp
+++ b/filters/include/pcl/filters/impl/frustum_culling.hpp
@@ -60,24 +60,33 @@ pcl::FrustumCulling<PointT>::applyFilter (Indices &indices)
 
   float vfov_rad = float (vfov_ * M_PI / 180);  // degrees to radians
   float hfov_rad = float (hfov_ * M_PI / 180);  // degrees to radians
-  
-  float np_h = float (2 * tan (vfov_rad / 2) * np_dist_);  // near plane height
-  float np_w = float (2 * tan (hfov_rad / 2) * np_dist_);  // near plane width
 
-  float fp_h = float (2 * tan (vfov_rad / 2) * fp_dist_);  // far plane height
-  float fp_w = float (2 * tan (hfov_rad / 2) * fp_dist_);  // far plane width
+  float roi_xmax = roi_x_ + (roi_w_ / 2);  // roi max x
+  float roi_xmin = roi_x_ - (roi_w_ / 2);  // roi min x
+  float roi_ymax = roi_y_ + (roi_h_ / 2);  // roi max y
+  float roi_ymin = roi_y_ - (roi_h_ / 2);  // roi min y
+  
+  float np_h_u = float(2 * tan(vfov_rad / 2) * np_dist_ * (roi_ymin - 0.5) * (-1));  // near plane upper height
+  float np_h_d = float(2 * tan(vfov_rad / 2) * np_dist_ * (roi_ymax - 0.5));         // near plane lower height
+  float np_w_l = float(2 * tan(hfov_rad / 2) * np_dist_ * (roi_xmin - 0.5) * (-1));  // near plane left width
+  float np_w_r = float(2 * tan(hfov_rad / 2) * np_dist_ * (roi_xmax - 0.5));         // near plane right width
+
+  float fp_h_u = float(2 * tan(vfov_rad / 2) * fp_dist_ * (roi_ymin - 0.5) * (-1));  // far plane upper height
+  float fp_h_d = float(2 * tan(vfov_rad / 2) * fp_dist_ * (roi_ymax - 0.5));         // far plane lower height
+  float fp_w_l = float(2 * tan(hfov_rad / 2) * fp_dist_ * (roi_xmin - 0.5) * (-1));  // far plane left width
+  float fp_w_r = float(2 * tan(hfov_rad / 2) * fp_dist_ * (roi_xmax - 0.5));         // far plane right width
 
   Eigen::Vector3f fp_c (T + view * fp_dist_);                           // far plane center
-  Eigen::Vector3f fp_tl (fp_c + (up * fp_h / 2) - (right * fp_w / 2));  // Top left corner of the far plane
-  Eigen::Vector3f fp_tr (fp_c + (up * fp_h / 2) + (right * fp_w / 2));  // Top right corner of the far plane
-  Eigen::Vector3f fp_bl (fp_c - (up * fp_h / 2) - (right * fp_w / 2));  // Bottom left corner of the far plane
-  Eigen::Vector3f fp_br (fp_c - (up * fp_h / 2) + (right * fp_w / 2));  // Bottom right corner of the far plane
+  Eigen::Vector3f fp_tl (fp_c + (up * fp_h_u / 2) - (right * fp_w_l / 2));  // Top left corner of the far plane
+  Eigen::Vector3f fp_tr (fp_c + (up * fp_h_u / 2) + (right * fp_w_r / 2));  // Top right corner of the far plane
+  Eigen::Vector3f fp_bl (fp_c - (up * fp_h_d / 2) - (right * fp_w_l / 2));  // Bottom left corner of the far plane
+  Eigen::Vector3f fp_br (fp_c - (up * fp_h_d / 2) + (right * fp_w_r / 2));  // Bottom right corner of the far plane
 
   Eigen::Vector3f np_c (T + view * np_dist_);                           // near plane center
-  //Eigen::Vector3f np_tl = np_c + (up * np_h/2) - (right * np_w/2);    // Top left corner of the near plane
-  Eigen::Vector3f np_tr (np_c + (up * np_h / 2) + (right * np_w / 2));  // Top right corner of the near plane
-  Eigen::Vector3f np_bl (np_c - (up * np_h / 2) - (right * np_w / 2));  // Bottom left corner of the near plane
-  Eigen::Vector3f np_br (np_c - (up * np_h / 2) + (right * np_w / 2));  // Bottom right corner of the near plane
+  //Eigen::Vector3f np_tl = np_c + (up * np_h-u/2) - (right * np_w_l/2);    // Top left corner of the near plane
+  Eigen::Vector3f np_tr (np_c + (up * np_h_u / 2) + (right * np_w_r / 2));  // Top right corner of the near plane
+  Eigen::Vector3f np_bl (np_c - (up * np_h_d / 2) - (right * np_w_l / 2));  // Bottom left corner of the near plane
+  Eigen::Vector3f np_br (np_c - (up * np_h_d / 2) + (right * np_w_r / 2));  // Bottom right corner of the near plane
 
   pl_f.head<3> () = (fp_bl - fp_br).cross (fp_tr - fp_br);  // Far plane equation - cross product of the 
   pl_f (3) = -fp_c.dot (pl_f.head<3> ());                   // perpendicular edges of the far plane

--- a/filters/include/pcl/filters/impl/frustum_culling.hpp
+++ b/filters/include/pcl/filters/impl/frustum_culling.hpp
@@ -77,16 +77,16 @@ pcl::FrustumCulling<PointT>::applyFilter (Indices &indices)
   float fp_w_r = float(2 * tan(hfov_rad / 2) * fp_dist_ * (roi_xmax - 0.5));         // far plane right width
 
   Eigen::Vector3f fp_c (T + view * fp_dist_);                           // far plane center
-  Eigen::Vector3f fp_tl (fp_c + (up * fp_h_u / 2) - (right * fp_w_l / 2));  // Top left corner of the far plane
-  Eigen::Vector3f fp_tr (fp_c + (up * fp_h_u / 2) + (right * fp_w_r / 2));  // Top right corner of the far plane
-  Eigen::Vector3f fp_bl (fp_c - (up * fp_h_d / 2) - (right * fp_w_l / 2));  // Bottom left corner of the far plane
-  Eigen::Vector3f fp_br (fp_c - (up * fp_h_d / 2) + (right * fp_w_r / 2));  // Bottom right corner of the far plane
+  Eigen::Vector3f fp_tl (fp_c + (up * fp_h_u) - (right * fp_w_l));  // Top left corner of the far plane
+  Eigen::Vector3f fp_tr (fp_c + (up * fp_h_u) + (right * fp_w_r));  // Top right corner of the far plane
+  Eigen::Vector3f fp_bl (fp_c - (up * fp_h_d) - (right * fp_w_l));  // Bottom left corner of the far plane
+  Eigen::Vector3f fp_br (fp_c - (up * fp_h_d) + (right * fp_w_r));  // Bottom right corner of the far plane
 
   Eigen::Vector3f np_c (T + view * np_dist_);                           // near plane center
-  //Eigen::Vector3f np_tl = np_c + (up * np_h-u/2) - (right * np_w_l/2);    // Top left corner of the near plane
-  Eigen::Vector3f np_tr (np_c + (up * np_h_u / 2) + (right * np_w_r / 2));  // Top right corner of the near plane
-  Eigen::Vector3f np_bl (np_c - (up * np_h_d / 2) - (right * np_w_l / 2));  // Bottom left corner of the near plane
-  Eigen::Vector3f np_br (np_c - (up * np_h_d / 2) + (right * np_w_r / 2));  // Bottom right corner of the near plane
+  //Eigen::Vector3f np_tl = np_c + (up * np_h_u) - (right * np_w_l);    // Top left corner of the near plane
+  Eigen::Vector3f np_tr (np_c + (up * np_h_u) + (right * np_w_r));  // Top right corner of the near plane
+  Eigen::Vector3f np_bl (np_c - (up * np_h_d) - (right * np_w_l));  // Bottom left corner of the near plane
+  Eigen::Vector3f np_br (np_c - (up * np_h_d) + (right * np_w_r));  // Bottom right corner of the near plane
 
   pl_f.head<3> () = (fp_bl - fp_br).cross (fp_tr - fp_br);  // Far plane equation - cross product of the 
   pl_f (3) = -fp_c.dot (pl_f.head<3> ());                   // perpendicular edges of the far plane

--- a/filters/include/pcl/filters/impl/frustum_culling.hpp
+++ b/filters/include/pcl/filters/impl/frustum_culling.hpp
@@ -141,7 +141,11 @@ pcl::FrustumCulling<PointT>::applyFilter (Indices &indices)
                      (pt.dot (pl_t) <= 0) && 
                      (pt.dot (pl_b) <= 0) && 
                      (pt.dot (pl_f) <= 0) &&
-                     (pt.dot (pl_n) <= 0);
+                     (pt.dot (pl_n) <= 0) &&
+                     (roi_xmax <= 1.0f) && (roi_xmin >= 0.0f) &&
+                     (roi_ymax <= 1.0f) && (roi_ymin >= 0.0f) &&
+                     (roi_w_ > 0.0f) && (roi_w_ <= 1.0f) &&
+                     (roi_h_ > 0.0f) && (roi_h_ <= 1.0f);
     if (is_in_fov ^ negative_)
     {
       indices[indices_ctr++] = idx;

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -2063,6 +2063,8 @@ TEST (FrustumCulling, Filters)
   fc.filter (*output);
   // Should extract object; number of points based on milk.pcd
   EXPECT_EQ (output->size (), 13541); 
+  removed = fc.getRemovedIndices ();
+  EXPECT_EQ (removed->size (), model->size () - output->size ()); 
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -2041,17 +2041,9 @@ TEST (FrustumCulling, Filters)
   EXPECT_EQ (output->size (), input->size ());
   removed = fc.getRemovedIndices ();
   EXPECT_EQ (removed->size (), 0);
-  // Check invalid ROI values: no points should remain
-  fc.setRegionOfInterest (0.5f, 0.5f, 0.0f, 0.0f);
-  fc.filter (*output);
-  EXPECT_EQ (output->size (), 0);
-  removed = fc.getRemovedIndices ();
-  EXPECT_EQ (removed->size (), input->size ());
-  fc.setRegionOfInterest (-0.4f, 0.0f, 8.2f, -1.3f);
-  fc.filter (*output);
-  EXPECT_EQ (output->size (), 0);
-  removed = fc.getRemovedIndices ();
-  EXPECT_EQ (removed->size (), input->size ());
+  // Check invalid ROI values
+  EXPECT_THROW (fc.setRegionOfInterest (0.5f, 0.5f, 0.0f, 0.0f), PCLException);
+  EXPECT_THROW (fc.setRegionOfInterest (-0.4f, 0.0f, 8.2f, -1.3f), PCLException);
 
   // Test on real point cloud, cut out milk cartoon in milk_cartoon_all_small_clorox.pcd
   pcl::PointCloud <pcl::PointXYZ>::Ptr model (new pcl::PointCloud <pcl::PointXYZ>);

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -2070,7 +2070,7 @@ TEST (FrustumCulling, Filters)
   fc.setCameraPose (cam2robot);
   fc.filter (*output);
   // Should extract object; number of points based on milk.pcd
-  EXPECT_NEAR (output->size (), 13704, 13704 * 0.05); 
+  EXPECT_EQ (output->size (), 13541); 
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -2033,7 +2033,44 @@ TEST (FrustumCulling, Filters)
   removed = fc.getRemovedIndices ();
   EXPECT_EQ (removed->size (), input->size ());
 
+  // Should filter all points in the input cloud
+  fc.setNegative (false);
+  fc.setKeepOrganized (false);
+  fc.setRegionOfInterest (0.5f, 0.5f, 1.0f, 1.0f);
+  fc.filter (*output);
+  EXPECT_EQ (output->size (), input->size ());
+  removed = fc.getRemovedIndices ();
+  EXPECT_EQ (removed->size (), 0);
+  // Check invalid ROI values: no points should remain
+  fc.setRegionOfInterest (0.5f, 0.5f, 0.0f, 0.0f);
+  fc.filter (*output);
+  EXPECT_EQ (output->size (), 0);
+  removed = fc.getRemovedIndices ();
+  EXPECT_EQ (removed->size (), input->size ());
+  fc.setRegionOfInterest (-0.4f, 0.0f, 8.2f, -1.3f);
+  fc.filter (*output);
+  EXPECT_EQ (output->size (), 0);
+  removed = fc.getRemovedIndices ();
+  EXPECT_EQ (removed->size (), input->size ());
 
+  // Test on real point cloud, cut out milk cartoon in milk_cartoon_all_small_clorox.pcd
+  pcl::PointCloud <pcl::PointXYZ>::Ptr model (new pcl::PointCloud <pcl::PointXYZ>);
+  pcl::copyPointCloud (*cloud_organized, *model);
+
+  Eigen::Matrix4f cam2robot;
+  cam2robot << 0, 0, 1, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1;
+  // Cut out object based on ROI 
+  fc.setInputCloud (model);
+  fc.setNegative (false);
+  fc.setVerticalFOV (43);
+  fc.setHorizontalFOV (57);
+  fc.setNearPlaneDistance (0);
+  fc.setFarPlaneDistance (0.9);
+  fc.setRegionOfInterest (0.44f, 0.30f, 0.16f, 0.38f);
+  fc.setCameraPose (cam2robot);
+  fc.filter (*output);
+  // Should extract object; number of points based on milk.pcd
+  EXPECT_NEAR (output->size (), 13704, 13704 * 0.05); 
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -56,6 +56,7 @@
 #include <pcl/filters/conditional_removal.h>
 #include <pcl/filters/median_filter.h>
 #include <pcl/filters/normal_refinement.h>
+#include <pcl/filters/crop_box.h>
 
 #include <pcl/common/transforms.h>
 #include <pcl/common/eigen.h>
@@ -2033,6 +2034,81 @@ TEST (FrustumCulling, Filters)
   removed = fc.getRemovedIndices ();
   EXPECT_EQ (removed->size (), input->size ());
 
+  // Should filter all points in the input cloud
+  fc.setNegative (false);
+  fc.setKeepOrganized (false);
+  fc.setRegionOfInterest (0.5f, 0.5f, 1.0f, 1.0f);
+  fc.filter (*output);
+  EXPECT_EQ (output->size (), input->size ());
+  removed = fc.getRemovedIndices ();
+  EXPECT_EQ (removed->size (), 0);
+  // Check invalid ROI values: no points should remain
+  fc.setRegionOfInterest (0.5f, 0.5f, 0.0f, 0.0f);
+  fc.filter (*output);
+  EXPECT_EQ (output->size (), 0);
+  removed = fc.getRemovedIndices ();
+  EXPECT_EQ (removed->size (), input->size ());
+  fc.setRegionOfInterest (-0.4f, 0.0f, 8.2f, -1.3f);
+  fc.filter (*output);
+  EXPECT_EQ (output->size (), 0);
+  removed = fc.getRemovedIndices ();
+  EXPECT_EQ (removed->size (), input->size ());
+
+  // Test on real point cloud, cut out milk cartoon in milk_cartoon_all_small_clorox.pcd
+  pcl::PointCloud <pcl::PointXYZ>::Ptr model (new pcl::PointCloud <pcl::PointXYZ>);
+  pcl::copyPointCloud (*cloud_organized, *model);
+
+  // Align point cloud with coordinate system
+  Eigen::Vector3f translation (0.5, 0.5, 0);
+  Eigen::Matrix3f rotation;
+  rotation = Eigen::AngleAxisf (-35 * M_PI / 180, Eigen::Vector3f::UnitZ ()) *
+       Eigen::AngleAxisf (90 * M_PI / 180, Eigen::Vector3f::UnitY ()) *
+       Eigen::AngleAxisf (180 * M_PI / 180, Eigen::Vector3f::UnitZ ());
+
+  Eigen::Matrix4f transformation;
+  transformation.setZero ();
+  transformation.block (0, 0, 3, 3) = rotation;
+  transformation.block (0, 3, 3, 1) = translation;
+  transformation (3, 3) = 1;
+
+  pcl::transformPointCloud (*model, *model, transformation);
+
+  pcl::CropBox<pcl::PointXYZ> bf;
+  bf.setMin (Eigen::Vector4f (0, -5, -5, 1.0));
+  bf.setMax (Eigen::Vector4f (5, 5, 5, 1.0));
+  bf.setInputCloud (model);
+  bf.filter (*model);
+
+  // Remove ground
+  pcl::PointIndices::Ptr inliers (new pcl::PointIndices);
+  pcl::ModelCoefficients::Ptr coefficients(new pcl::ModelCoefficients);
+  pcl::SACSegmentation<pcl::PointXYZ> seg;
+  seg.setOptimizeCoefficients (true);
+  seg.setModelType (pcl::SACMODEL_PERPENDICULAR_PLANE);
+  seg.setMethodType (pcl::SAC_RANSAC);
+  seg.setDistanceThreshold (0.01);
+  seg.setAxis (Eigen::Vector3f (0, 1, 0));
+  seg.setInputCloud (model);
+  seg.segment (*inliers, *coefficients);
+
+  pcl::ExtractIndices<pcl::PointXYZ> extract;
+  extract.setInputCloud (model);
+  extract.setIndices (inliers);
+  extract.setNegative (true);
+  extract.filter (*output);
+
+  // Cut out object based on ROI 
+  fc.setInputCloud (output);
+  fc.setNegative (false);
+  fc.setVerticalFOV (45);
+  fc.setHorizontalFOV (45);
+  fc.setNearPlaneDistance (1.1);
+  fc.setFarPlaneDistance (1.35);
+  fc.setRegionOfInterest (0.44, 0.35, 0.17, 0.32);
+  fc.setCameraPose (Eigen::Matrix4f::Identity ());
+  fc.filter (*output);
+  // Should extract object; number of points based on milk.pcd
+  EXPECT_NEAR (output->size (), 13704, 13704 * 0.05); 
 
 }
 


### PR DESCRIPTION
Added region of interest (ROI) to frustum culling. This makes it possible to crop a point cloud based on a bounding box provided by object detection in the camera frame.

The ROI can be set via a function with x, y position of the center and the width and height in normalized values (0 - 1).