### PR TITLE
Change static to const since it-stability is not guaranteed

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -2249,7 +2249,7 @@ void
 pcl::visualization::PCLVisualizer::resetCameraViewpoint (const std::string &id)
 {
   vtkSmartPointer<vtkMatrix4x4> camera_pose;
-  static CloudActorMap::iterator it = cloud_actor_map_->find (id);
+  const CloudActorMap::iterator it = cloud_actor_map_->find(id);
   if (it != cloud_actor_map_->end ())
     camera_pose = it->second.viewpoint_transformation_;
   else


### PR DESCRIPTION
In `pcl::visualization::PCLVisualizer::resetCameraViewpoint` an iterator of a `std::unordered_map` was saved in a static variable, even though it might get invalidated when rehashing occurs (see https://en.cppreference.com/w/cpp/container/unordered_map ).

The function also always uses the first `id` it was ever passed, essentially ignoring the param after the first call.

(NOTE: I am not sure, if the space between find and parantheses was intentional. If yes, I'll recreate it)