### PR TITLE
Treat all compiler IDs containing 'Clang' as clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ set(CMAKE_BUILD_TYPE "${CMAKE_BUILD_TYPE}" CACHE STRING
 # Compiler identification
 # Define a variable CMAKE_COMPILER_IS_X where X is the compiler short name.
 # Note: CMake automatically defines one for GNUCXX, nothing to do in this case.
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   set(CMAKE_COMPILER_IS_CLANG 1)
 elseif(__COMPILER_PATHSCALE)
   set(CMAKE_COMPILER_IS_PATHSCALE 1)


### PR DESCRIPTION
..., most notably AppleClang
Closes #3131 . That PR has merge conflicts, and adding `-std=c++11` for NVCC does not seem necessary any more because we now set `CMAKE_CUDA_STANDARD`:
https://github.com/PointCloudLibrary/pcl/blob/49b41a60102a634aed08bee494a9b6a0cf2b67ac/CMakeLists.txt#L16-L17

@themightyoarfish FYI