### PR TITLE
Fix benchmark compilation issue on Ubuntu 21.10

### DIFF
--- a/.dev/docker/env/Dockerfile
+++ b/.dev/docker/env/Dockerfile
@@ -28,7 +28,6 @@ RUN apt-get update \
       build-essential \
       clang \
       clang-tidy \
-      libbenchmark-dev \
       libblas-dev \
       libboost-date-time-dev \
       libboost-filesystem-dev \
@@ -62,6 +61,18 @@ RUN apt-get update \
        apt-get -V install -y nvidia-cuda-toolkit g++-6 ; \
      else \
        apt-get -V install -y nvidia-cuda-toolkit-gcc ; \
+     fi \
+ && if [ "$(lsb_release -sr)" = "21.10" ]; then \
+       wget -qO- https://github.com/google/benchmark/archive/refs/tags/v1.6.1.tar.gz | tar xz \
+       && cd benchmark-1.6.1 \
+       && mkdir build \
+       && cd build \
+       && cmake .. -DCMAKE_BUILD_TYPE=Release -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DBENCHMARK_ENABLE_TESTING=OFF \
+       && make -j$(nproc) install \
+       && cd ../.. \
+       && rm -rf benchmark-1.6.1 ; \
+     else \
+       apt-get -V install -y libbenchmark-dev ; \
      fi \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Fix compilation issue on Ubuntu 21.10 by using a self-compiled version of Google Benchmark.

As mentioned in https://github.com/PointCloudLibrary/pcl/pull/4747#issuecomment-1036461222 the benchmark package seems to be broken under Ubuntu 21.10. Since I haven't found any other solution without disabling the benchmark build, I'm now compiling it into the Docker image instead of using the one from the repository (as it is a fix just for this issue on Ubuntu 21.10, the version of benchmark is fixed).