### PR TITLE
Fix wrong badge after transition from 20.10 to 21.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Continuous integration
 
 Build Platform           | Status
 ------------------------ | ------------------------------------------------------------------------------------------------- |
-Ubuntu                   | [![Status][ci-ubuntu-18.04]][ci-latest-build] <br> [![Status][ci-ubuntu-20.04]][ci-latest-build]                              <br> [![Status][ci-ubuntu-20.10]][ci-latest-build]                                                |
+Ubuntu                   | [![Status][ci-ubuntu-18.04]][ci-latest-build] <br> [![Status][ci-ubuntu-20.04]][ci-latest-build]                              <br> [![Status][ci-ubuntu-21.10]][ci-latest-build]                                                |
 Windows                  | [![Status][ci-windows-x86]][ci-latest-build]  <br> [![Status][ci-windows-x64]][ci-latest-build]   |
 macOS                    | [![Status][ci-macos-10.15]][ci-latest-build]  <br> [![Status][ci-macos-11]][ci-latest-build]   |
 Documentation            | [![Status][ci-docs]][ci-latest-docs] |


### PR DESCRIPTION
Missed this in #4747