### PR TITLE
Fix the matrix shape in matricesInnerProd

### DIFF
--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -375,15 +375,15 @@ protected:
 
   /** \return trace of mat1^t . mat2
    * \param mat1 matrix of dimension nxm
-   * \param mat2 matrix of dimension nxp
+   * \param mat2 matrix of dimension mxn
    */
   inline double
   matricesInnerProd(const Eigen::MatrixXd& mat1, const Eigen::MatrixXd& mat2) const
   {
     double r = 0.;
-    std::size_t n = mat1.rows();
+    std::size_t n = mat1.rows(), m = mat1.cols();
     // tr(mat1^t.mat2)
-    for (std::size_t i = 0; i < n; i++)
+    for (std::size_t i = 0; i < m; i++)
       for (std::size_t j = 0; j < n; j++)
         r += mat1(j, i) * mat2(i, j);
     return r;

--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -375,7 +375,7 @@ protected:
 
   /** \return trace of mat1^t . mat2
    * \param mat1 matrix of dimension nxm
-   * \param mat2 matrix of dimension mxn
+   * \param mat2 matrix of dimension nxm
    */
   inline double
   matricesInnerProd(const Eigen::MatrixXd& mat1, const Eigen::MatrixXd& mat2) const


### PR DESCRIPTION
The two arguments of `matricesInnerProd` are mat1^t and mat2, since mat1 and mat2 should have the same shape, mat2 should be nxm.

Should it throw exception if mat2's shape is not nxm? What exception should it be?

Note: this change doesn't affect gicp's behavior, since in `computeRDerivative` the two arguments are both 3x3.