### PR TITLE
Fix the comment of `N`

### DIFF
--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -393,7 +393,7 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTransformatio
   pcl::IterativeClosestPoint<PointSource, PointTarget>::initComputeReciprocal();
   // Difference between consecutive transforms
   double delta = 0;
-  // Get the size of the target
+  // Get the size of the source point cloud
   const std::size_t N = indices_->size();
   // Set the mahalanobis matrices to identity
   mahalanobis_.resize(N, Eigen::Matrix3d::Identity());


### PR DESCRIPTION
From the code below, it seems `indices_` is related to the source point cloud:

https://github.com/PointCloudLibrary/pcl/blob/578b18b524f94cb4218772bbc6aa704df79c150b/registration/include/pcl/registration/impl/gicp.hpp#L439-L442