### PR TITLE
Replace hardcoded 4 with `min_number_correspondences_`

### DIFF
--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -192,13 +192,15 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
                                     Eigen::Matrix4f& transformation_matrix)
 {
   // need at least min_number_correspondences_ samples
-  if (indices_src.size() < min_number_correspondences_)
-  {
+  if (indices_src.size() < min_number_correspondences_) {
     PCL_THROW_EXCEPTION(
         NotEnoughPointsException,
         "[pcl::GeneralizedIterativeClosestPoint::estimateRigidTransformationBFGS] Need "
-        "at least " << min_number_correspondences_ << " points to estimate a transform! "
-        "Source and target have " << indices_src.size() << " points!");
+        "at least "
+            << min_number_correspondences_
+            << " points to estimate a transform! "
+               "Source and target have "
+            << indices_src.size() << " points!");
     return;
   }
   // Set the initial solution

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -192,7 +192,7 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
                                     Eigen::Matrix4f& transformation_matrix)
 {
   // need at least min_number_correspondences_ samples
-  if (indices_src.size() < min_number_correspondences_) {
+  if (static_cast<int>(indices_src.size()) < min_number_correspondences_) {
     PCL_THROW_EXCEPTION(
         NotEnoughPointsException,
         "[pcl::GeneralizedIterativeClosestPoint::estimateRigidTransformationBFGS] Need "

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -192,7 +192,7 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
                                     Eigen::Matrix4f& transformation_matrix)
 {
   // need at least min_number_correspondences_ samples
-  if (static_cast<unsigned int>(indices_src.size()) < min_number_correspondences_) {
+  if (indices_src.size() < min_number_correspondences_) {
     PCL_THROW_EXCEPTION(
         NotEnoughPointsException,
         "[pcl::GeneralizedIterativeClosestPoint::estimateRigidTransformationBFGS] Need "

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -191,13 +191,14 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
                                     const pcl::Indices& indices_tgt,
                                     Eigen::Matrix4f& transformation_matrix)
 {
-  if (indices_src.size() < 4) // need at least 4 samples
+  // need at least min_number_correspondences_ samples
+  if (indices_src.size() < min_number_correspondences_)
   {
     PCL_THROW_EXCEPTION(
         NotEnoughPointsException,
         "[pcl::GeneralizedIterativeClosestPoint::estimateRigidTransformationBFGS] Need "
-        "at least 4 points to estimate a transform! Source and target have "
-            << indices_src.size() << " points!");
+        "at least " << min_number_correspondences_ << " points to estimate a transform! "
+        "Source and target have " << indices_src.size() << " points!");
     return;
   }
   // Set the initial solution

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -192,7 +192,7 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
                                     Eigen::Matrix4f& transformation_matrix)
 {
   // need at least min_number_correspondences_ samples
-  if (static_cast<int>(indices_src.size()) < min_number_correspondences_) {
+  if (static_cast<unsigned int>(indices_src.size()) < min_number_correspondences_) {
     PCL_THROW_EXCEPTION(
         NotEnoughPointsException,
         "[pcl::GeneralizedIterativeClosestPoint::estimateRigidTransformationBFGS] Need "

--- a/registration/include/pcl/registration/impl/icp.hpp
+++ b/registration/include/pcl/registration/impl/icp.hpp
@@ -203,7 +203,7 @@ IterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformation(
 
     std::size_t cnt = correspondences_->size();
     // Check whether we have enough correspondences
-    if (static_cast<int>(cnt) < min_number_correspondences_) {
+    if (static_cast<unsigned int>(cnt) < min_number_correspondences_) {
       PCL_ERROR("[pcl::%s::computeTransformation] Not enough correspondences found. "
                 "Relax your threshold parameters.\n",
                 getClassName().c_str());

--- a/registration/include/pcl/registration/impl/icp.hpp
+++ b/registration/include/pcl/registration/impl/icp.hpp
@@ -201,9 +201,8 @@ IterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformation(
         *temp_correspondences = *correspondences_;
     }
 
-    std::size_t cnt = correspondences_->size();
     // Check whether we have enough correspondences
-    if (static_cast<unsigned int>(cnt) < min_number_correspondences_) {
+    if (correspondences_->size() < min_number_correspondences_) {
       PCL_ERROR("[pcl::%s::computeTransformation] Not enough correspondences found. "
                 "Relax your threshold parameters.\n",
                 getClassName().c_str());

--- a/registration/include/pcl/registration/impl/joint_icp.hpp
+++ b/registration/include/pcl/registration/impl/joint_icp.hpp
@@ -211,9 +211,9 @@ JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformat
         *temp_correspondences = *correspondences_;
     }
 
-    int cnt = correspondences_->size();
+    std::size_t cnt = correspondences_->size();
     // Check whether we have enough correspondences
-    if (cnt < min_number_correspondences_) {
+    if (static_cast<unsigned int>(cnt) < min_number_correspondences_) {
       PCL_ERROR("[pcl::%s::computeTransformation] Not enough correspondences found. "
                 "Relax your threshold parameters.\n",
                 getClassName().c_str());

--- a/registration/include/pcl/registration/impl/joint_icp.hpp
+++ b/registration/include/pcl/registration/impl/joint_icp.hpp
@@ -211,9 +211,8 @@ JointIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformat
         *temp_correspondences = *correspondences_;
     }
 
-    std::size_t cnt = correspondences_->size();
     // Check whether we have enough correspondences
-    if (static_cast<unsigned int>(cnt) < min_number_correspondences_) {
+    if (correspondences_->size() < min_number_correspondences_) {
       PCL_ERROR("[pcl::%s::computeTransformation] Not enough correspondences found. "
                 "Relax your threshold parameters.\n",
                 getClassName().c_str());

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -625,7 +625,7 @@ protected:
   /** \brief The minimum number of correspondences that the algorithm needs before
    * attempting to estimate the transformation. The default value is 3.
    */
-  int min_number_correspondences_;
+  unsigned int min_number_correspondences_;
 
   /** \brief The set of correspondences determined at this ICP step. */
   CorrespondencesPtr correspondences_;


### PR DESCRIPTION
`min_number_correspondences_` is initialized as 4 in `GeneralizedIterativeClosestPoint`'s constructor, but never used. By looking at `computeTransformation`, `source_indices` is the correspondence count, so 4 might be replaced with `min_number_correspondences_`.