### PR TITLE
Add missing aligned operators new in registration module

### DIFF
--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -102,8 +102,6 @@ public:
 
   using Vector6d = Eigen::Matrix<double, 6, 1>;
 
-  PCL_MAKE_ALIGNED_OPERATOR_NEW;
-
   /** \brief Empty constructor. */
   GeneralizedIterativeClosestPoint()
   : k_correspondences_(20)

--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -102,6 +102,8 @@ public:
 
   using Vector6d = Eigen::Matrix<double, 6, 1>;
 
+  PCL_MAKE_ALIGNED_OPERATOR_NEW;
+
   /** \brief Empty constructor. */
   GeneralizedIterativeClosestPoint()
   : k_correspondences_(20)

--- a/registration/include/pcl/registration/vertex_estimates.h
+++ b/registration/include/pcl/registration/vertex_estimates.h
@@ -64,6 +64,8 @@ struct PoseEstimate {
                    typename pcl::PointCloud<PointT>::ConstPtr())
   : pose(p), cloud(c)
   {}
+
+  PCL_MAKE_ALIGNED_OPERATOR_NEW;
 };
 } // namespace registration
 } // namespace pcl


### PR DESCRIPTION
`registration/include/pcl/registration/gicp.h` probably does need it, since `sizeof(double) * 6 / 16 = 3`, so the type's size is a multiple of 16 bytes.