### PR TITLE
rename computeRDerivative's argument R

### DIFF
--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -216,7 +216,25 @@ public:
    * param g gradient vector
    */
   void
-  computeRDerivative(const Vector6d& x, const Eigen::Matrix3d& R, Vector6d& g) const;
+  computeDerivative(const Vector6d& x,
+                    const Eigen::Matrix3d& dCost_dR_T,
+                    Vector6d& g) const;
+
+  /** \brief Computes the derivative of the cost function w.r.t rotation angles.
+   * rotation matrix is obtainded from rotation angles x[3], x[4] and x[5]
+   * \return d/d_Phi, d/d_Theta, d/d_Psi respectively in g[3], g[4] and g[5]
+   * param x array representing 3D transformation
+   * param R the transpose of the derivative of the cost function w.r.t rotation matrix
+   * param g gradient vector
+   */
+  PCL_DEPRECATED(1, 15, "use computeDerivative() instead")
+  void
+  computeRDerivative(const Vector6d& x,
+                     const Eigen::Matrix3d& dCost_dR_T,
+                     Vector6d& g) const
+  {
+    return computeDerivative(x, dCost_dR_T, g);
+  };
 
   /** \brief Set the rotation epsilon (maximum allowable difference between two
    * consecutive rotations) in order for an optimization to be considered as having

--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -211,30 +211,15 @@ public:
   /** \brief Computes the derivative of the cost function w.r.t rotation angles.
    * rotation matrix is obtainded from rotation angles x[3], x[4] and x[5]
    * \return d/d_Phi, d/d_Theta, d/d_Psi respectively in g[3], g[4] and g[5]
-   * param x array representing 3D transformation
-   * param R the transpose of the derivative of the cost function w.r.t rotation matrix
-   * param g gradient vector
+   * \param[in] x array representing 3D transformation
+   * \param[in] dCost_dR_T the transpose of the derivative of the cost function w.r.t
+   * rotation matrix
+   * \param[in] g gradient vector
    */
-  void
-  computeDerivative(const Vector6d& x,
-                    const Eigen::Matrix3d& dCost_dR_T,
-                    Vector6d& g) const;
-
-  /** \brief Computes the derivative of the cost function w.r.t rotation angles.
-   * rotation matrix is obtainded from rotation angles x[3], x[4] and x[5]
-   * \return d/d_Phi, d/d_Theta, d/d_Psi respectively in g[3], g[4] and g[5]
-   * param x array representing 3D transformation
-   * param R the transpose of the derivative of the cost function w.r.t rotation matrix
-   * param g gradient vector
-   */
-  PCL_DEPRECATED(1, 15, "use computeDerivative() instead")
   void
   computeRDerivative(const Vector6d& x,
                      const Eigen::Matrix3d& dCost_dR_T,
-                     Vector6d& g) const
-  {
-    return computeDerivative(x, dCost_dR_T, g);
-  };
+                     Vector6d& g) const;
 
   /** \brief Set the rotation epsilon (maximum allowable difference between two
    * consecutive rotations) in order for an optimization to be considered as having

--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -214,7 +214,7 @@ public:
    * \param[in] x array representing 3D transformation
    * \param[in] dCost_dR_T the transpose of the derivative of the cost function w.r.t
    * rotation matrix
-   * \param[in] g gradient vector
+   * \param[out] g gradient vector
    */
   void
   computeRDerivative(const Vector6d& x,

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -128,7 +128,7 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeCovariances(
 
 template <typename PointSource, typename PointTarget>
 void
-GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeDerivative(
+GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeRDerivative(
     const Vector6d& x, const Eigen::Matrix3d& dCost_dR_T, Vector6d& g) const
 {
   Eigen::Matrix3d dR_dPhi;

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -326,7 +326,7 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
   }
   g.head<3>() *= 2.0 / m;
   dCost_dR_T *= 2.0 / m;
-  gicp_->computeDerivative(x, dCost_dR_T, g);
+  gicp_->computeRDerivative(x, dCost_dR_T, g);
 }
 
 template <typename PointSource, typename PointTarget>
@@ -370,7 +370,7 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
   f /= double(m);
   g.head<3>() *= double(2.0 / m);
   dCost_dR_T *= 2.0 / m;
-  gicp_->computeDerivative(x, dCost_dR_T, g);
+  gicp_->computeRDerivative(x, dCost_dR_T, g);
 }
 
 template <typename PointSource, typename PointTarget>

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -128,8 +128,8 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeCovariances(
 
 template <typename PointSource, typename PointTarget>
 void
-GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeRDerivative(
-    const Vector6d& x, const Eigen::Matrix3d& R, Vector6d& g) const
+GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeDerivative(
+    const Vector6d& x, const Eigen::Matrix3d& dCost_dR_T, Vector6d& g) const
 {
   Eigen::Matrix3d dR_dPhi;
   Eigen::Matrix3d dR_dTheta;
@@ -177,9 +177,9 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeRDerivative(
   dR_dPsi(1, 2) = sphi * spsi + cphi * cpsi * stheta;
   dR_dPsi(2, 2) = 0.;
 
-  g[3] = matricesInnerProd(dR_dPhi, R);
-  g[4] = matricesInnerProd(dR_dTheta, R);
-  g[5] = matricesInnerProd(dR_dPsi, R);
+  g[3] = matricesInnerProd(dR_dPhi, dCost_dR_T);
+  g[4] = matricesInnerProd(dR_dTheta, dCost_dR_T);
+  g[5] = matricesInnerProd(dR_dPsi, dCost_dR_T);
 }
 
 template <typename PointSource, typename PointTarget>
@@ -326,7 +326,7 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
   }
   g.head<3>() *= 2.0 / m;
   dCost_dR_T *= 2.0 / m;
-  gicp_->computeRDerivative(x, dCost_dR_T, g);
+  gicp_->computeDerivative(x, dCost_dR_T, g);
 }
 
 template <typename PointSource, typename PointTarget>
@@ -370,7 +370,7 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::
   f /= double(m);
   g.head<3>() *= double(2.0 / m);
   dCost_dR_T *= 2.0 / m;
-  gicp_->computeRDerivative(x, dCost_dR_T, g);
+  gicp_->computeDerivative(x, dCost_dR_T, g);
 }
 
 template <typename PointSource, typename PointTarget>


### PR DESCRIPTION
`computeRDerivative` is calculating the derivative of the cost function w.r.t rotation angles so its name is misleading, this PR renames it.
This is a continuation of #5184.