### PR TITLE
Fix missing definition "boost::optional"

### DIFF
--- a/filters/include/pcl/filters/convolution_3d.h
+++ b/filters/include/pcl/filters/convolution_3d.h
@@ -40,6 +40,7 @@
 #pragma once
 
 #include <pcl/pcl_base.h>
+#include <boost/optional.hpp>
 
 namespace pcl
 {


### PR DESCRIPTION
Reported at issue #5209.