### PR TITLE
force setting cmake predefind VTK dir

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -93,13 +93,13 @@ macro(find_boost)
   elseif(NOT BOOST_INCLUDEDIR)
     set(BOOST_INCLUDEDIR "@Boost_INCLUDE_DIR@")
   endif()
-  
+
   set(Boost_ADDITIONAL_VERSIONS
     "@Boost_MAJOR_VERSION@.@Boost_MINOR_VERSION@.@Boost_SUBMINOR_VERSION@" "@Boost_MAJOR_VERSION@.@Boost_MINOR_VERSION@"
-    "1.78.0" "1.78" "1.77.0" "1.77" "1.76.0" "1.76" "1.75.0" "1.75" 
+    "1.78.0" "1.78" "1.77.0" "1.77" "1.76.0" "1.76" "1.75.0" "1.75"
     "1.74.0" "1.74" "1.73.0" "1.73" "1.72.0" "1.72" "1.71.0" "1.71" "1.70.0" "1.70"
     "1.69.0" "1.69" "1.68.0" "1.68" "1.67.0" "1.67" "1.66.0" "1.66" "1.65.1" "1.65.0" "1.65")
-  
+
   find_package(Boost 1.65.0 ${QUIET_} COMPONENTS @PCLCONFIG_AVAILABLE_BOOST_MODULES@)
 
   set(BOOST_FOUND ${Boost_FOUND})
@@ -239,7 +239,7 @@ macro(find_VTK)
       set(VTK_DIR "${PCL_ROOT}/3rdParty/VTK/lib/vtk-@VTK_MAJOR_VERSION@.@VTK_MINOR_VERSION@" CACHE PATH "The directory containing VTKConfig.cmake")
     endif()
   elseif(NOT VTK_DIR AND NOT ANDROID)
-    set(VTK_DIR "@VTK_DIR@" CACHE PATH "The directory containing VTKConfig.cmake")
+    set(VTK_DIR "@VTK_DIR@" CACHE PATH "The directory containing VTKConfig.cmake" FORCE)
   endif()
   if(NOT ANDROID)
     find_package(VTK ${QUIET_} COMPONENTS ${PCL_VTK_COMPONENTS})
@@ -305,13 +305,13 @@ macro(find_external_library _component _lib _is_optional)
   string(REGEX REPLACE "[.-]" "_" LIB ${LIB})
   if(${LIB}_FOUND)
     list(APPEND PCL_${COMPONENT}_INCLUDE_DIRS ${${LIB}_INCLUDE_DIRS})
-    
+
     if(${LIB} MATCHES "VTK")
       if(${${LIB}_VERSION_MAJOR} GREATER_EQUAL 9)
         set(ISVTK9ORGREATER TRUE)
       endif()
     endif()
-    
+
     if(${LIB}_USE_FILE AND NOT ISVTK9ORGREATER )
       include(${${LIB}_USE_FILE})
     else()


### PR DESCRIPTION
I encountered error https://github.com/PointCloudLibrary/pcl/issues/4926 when trying to link PCL with another library when it was compiled using a self-provided VTK (same as in issue).

I found 2 workarounds.
First, being to NOT provide `VTK_DIR` to cmake (or remove from cache if already there even if empty) and leaving PCL set it. 
The second is to FORCE setting the value, basically ignoring what was provided by the user.

Since the displayed error happens when `VTK_DIR` is specified, it is safe to assume it is already too late for case 1. 

fixes #4926 
