### PR TITLE
Add Ubuntu 22.04 docker image

### DIFF
--- a/.ci/azure-pipelines/env.yml
+++ b/.ci/azure-pipelines/env.yml
@@ -48,7 +48,6 @@ jobs:
         ENSENSOSDK_VERSION: 2.3.1570
         TAG: 18.04
       Ubuntu 20.04:
-        # Test the latest LTS version of Ubuntu
         UBUNTU_VERSION: 20.04
         VTK_VERSION: 7
         TAG: 20.04
@@ -57,6 +56,11 @@ jobs:
         USE_LATEST_CMAKE: true
         VTK_VERSION: 9
         TAG: 21.10
+        # Test the latest LTS version of Ubuntu
+      Ubuntu 22.04:
+        UBUNTU_VERSION: 22.04
+        VTK_VERSION: 9
+        TAG: 22.04
   steps:
   - script: |
       dockerBuildArgs="" ; \


### PR DESCRIPTION
Just adding creating of the image for now so we can separately test for build issues.

Note: As this is a LTS release I suggest to not enable `USE_LATEST_CMAKE` here.