### PR TITLE
fix: use `similarity_threshold_squared_` instead of `cardinality_` in…

### DIFF
--- a/registration/include/pcl/registration/correspondence_rejection_poly.h
+++ b/registration/include/pcl/registration/correspondence_rejection_poly.h
@@ -221,7 +221,7 @@ public:
                                   corr[idx[1]].index_query,
                                   corr[idx[0]].index_match,
                                   corr[idx[1]].index_match,
-                                  cardinality_));
+                                  similarity_threshold_squared_));
     }
     // Otherwise check all edges
     for (int i = 0; i < cardinality_; ++i) {


### PR DESCRIPTION
… `thresholdEdgeLength`.