### PR TITLE
Fix CropHull::applyFilter3D()

### DIFF
--- a/filters/include/pcl/filters/impl/crop_hull.hpp
+++ b/filters/include/pcl/filters/impl/crop_hull.hpp
@@ -168,9 +168,8 @@ pcl::CropHull<PointT>::applyFilter3D (Indices &indices)
         crossings[ray] += rayTriangleIntersect
           ((*input_)[(*indices_)[index]], rays[ray], hull_polygons_[poly], *hull_cloud_);
 
-    if (crop_outside_ && (crossings[0]&1) + (crossings[1]&1) + (crossings[2]&1) > 1)
-      indices.push_back ((*indices_)[index]);
-    else if (!crop_outside_)
+    bool crosses = (crossings[0]&1) + (crossings[1]&1) + (crossings[2]&1) > 1;
+    if ((crop_outside_ && crosses) || (!crop_outside_ && !crosses))
       indices.push_back ((*indices_)[index]);
     else
       removed_indices_->push_back ((*indices_)[index]);

--- a/test/filters/test_crop_hull.cpp
+++ b/test/filters/test_crop_hull.cpp
@@ -383,18 +383,7 @@ TYPED_TEST (PCLCropHullTestFixture, test_keep_organized)
 
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// this test will pass only for 2d case //
-template <class T>
-struct PCLCropHullTestFixture2dCrutch : PCLCropHullTestFixture<T>
-{};
-using CropHullTestTraits2dTypes = ::testing::Types<
-  std::tuple_element<0, CropHullTestTraits2dList>::type,
-  std::tuple_element<1, CropHullTestTraits2dList>::type,
-  std::tuple_element<2, CropHullTestTraits2dList>::type
-  >;
-TYPED_TEST_SUITE(PCLCropHullTestFixture2dCrutch, CropHullTestTraits2dTypes);
-
-TYPED_TEST (PCLCropHullTestFixture2dCrutch, test_crop_inside)
+TYPED_TEST (PCLCropHullTestFixture, test_crop_inside)
 {
   for (auto & entry : this->data_)
   {


### PR DESCRIPTION
This fixes CropHull::applyFilter3D() when `crop_outside_` is set to false and adds back `test_crop_inside` for 3D cases.

Previously:

| crop_outside_ | Crosses | Expected behavior | Actual behavior
| --- | --- | --- | --- |
| true | false | remove | remove |
| true | true | keep | keep |
| false | false | keep | keep |
| false | true | remove | keep |

Meaning that when `crop_outside_` was set to false, all the points in the input point cloud would be kept regardless, which is not the expected behavior.