### PR TITLE
[registration] print loss as debug for TransformationEstimationSVD and TransformationEstimationPointToPlaneLLS

### DIFF
--- a/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls.hpp
@@ -267,44 +267,46 @@ TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar>::
   constructTransformationMatrix(
       x(0), x(1), x(2), x(3), x(4), x(5), transformation_matrix);
 
-  size_t N = 0;
-  double loss = 0.0;
-  source_it.reset();
-  target_it.reset();
-  while (source_it.isValid() && target_it.isValid()) {
-    if (!std::isfinite(source_it->x) || !std::isfinite(source_it->y) ||
-        !std::isfinite(source_it->z) || !std::isfinite(target_it->x) ||
-        !std::isfinite(target_it->y) || !std::isfinite(target_it->z) ||
-        !std::isfinite(target_it->normal_x) || !std::isfinite(target_it->normal_y) ||
-        !std::isfinite(target_it->normal_z)) {
+  if (pcl::console::isVerbosityLevelEnabled(pcl::console::L_DEBUG)) {
+    size_t N = 0;
+    double loss = 0.0;
+    source_it.reset();
+    target_it.reset();
+    while (source_it.isValid() && target_it.isValid()) {
+      if (!std::isfinite(source_it->x) || !std::isfinite(source_it->y) ||
+          !std::isfinite(source_it->z) || !std::isfinite(target_it->x) ||
+          !std::isfinite(target_it->y) || !std::isfinite(target_it->z) ||
+          !std::isfinite(target_it->normal_x) || !std::isfinite(target_it->normal_y) ||
+          !std::isfinite(target_it->normal_z)) {
+        ++target_it;
+        ++source_it;
+        continue;
+      }
+      const float& sx = source_it->x;
+      const float& sy = source_it->y;
+      const float& sz = source_it->z;
+      const float& dx = target_it->x;
+      const float& dy = target_it->y;
+      const float& dz = target_it->z;
+      const float& nx = target_it->normal[0];
+      const float& ny = target_it->normal[1];
+      const float& nz = target_it->normal[2];
+      double a = nz * sy - ny * sz;
+      double b = nx * sz - nz * sx;
+      double c = ny * sx - nx * sy;
+      double d = nx * dx + ny * dy + nz * dz - nx * sx - ny * sy - nz * sz;
+      Vector6d Arow;
+      Arow << a, b, c, nx, ny, nz;
+      loss += pow(Arow.transpose() * x - d, 2);
       ++target_it;
       ++source_it;
-      continue;
+      ++N;
     }
-    const float& sx = source_it->x;
-    const float& sy = source_it->y;
-    const float& sz = source_it->z;
-    const float& dx = target_it->x;
-    const float& dy = target_it->y;
-    const float& dz = target_it->z;
-    const float& nx = target_it->normal[0];
-    const float& ny = target_it->normal[1];
-    const float& nz = target_it->normal[2];
-    double a = nz * sy - ny * sz;
-    double b = nx * sz - nz * sx;
-    double c = ny * sx - nx * sy;
-    double d = nx * dx + ny * dy + nz * dz - nx * sx - ny * sy - nz * sz;
-    Vector6d Arow;
-    Arow << a, b, c, nx, ny, nz;
-    loss += pow(Arow.transpose() * x - d, 2);
-    ++target_it;
-    ++source_it;
-    ++N;
+    loss /= N;
+    PCL_DEBUG("[pcl::registration::TransformationEstimationPointToPlaneLLS::"
+              "estimateRigidTransformation] Loss :%.10e\n",
+              loss);
   }
-  loss /= N;
-  PCL_DEBUG("[pcl::registration::TransformationEstimationPointToPlaneLLS::"
-            "estimateRigidTransformation] Loss :%.10e\n",
-            loss);
 }
 
 } // namespace registration

--- a/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_lls.hpp
@@ -266,6 +266,45 @@ TransformationEstimationPointToPlaneLLS<PointSource, PointTarget, Scalar>::
   // Construct the transformation matrix from x
   constructTransformationMatrix(
       x(0), x(1), x(2), x(3), x(4), x(5), transformation_matrix);
+
+  size_t N = 0;
+  double loss = 0.0;
+  source_it.reset();
+  target_it.reset();
+  while (source_it.isValid() && target_it.isValid()) {
+    if (!std::isfinite(source_it->x) || !std::isfinite(source_it->y) ||
+        !std::isfinite(source_it->z) || !std::isfinite(target_it->x) ||
+        !std::isfinite(target_it->y) || !std::isfinite(target_it->z) ||
+        !std::isfinite(target_it->normal_x) || !std::isfinite(target_it->normal_y) ||
+        !std::isfinite(target_it->normal_z)) {
+      ++target_it;
+      ++source_it;
+      continue;
+    }
+    const float& sx = source_it->x;
+    const float& sy = source_it->y;
+    const float& sz = source_it->z;
+    const float& dx = target_it->x;
+    const float& dy = target_it->y;
+    const float& dz = target_it->z;
+    const float& nx = target_it->normal[0];
+    const float& ny = target_it->normal[1];
+    const float& nz = target_it->normal[2];
+    double a = nz * sy - ny * sz;
+    double b = nx * sz - nz * sx;
+    double c = ny * sx - nx * sy;
+    double d = nx * dx + ny * dy + nz * dz - nx * sx - ny * sy - nz * sz;
+    Vector6d Arow;
+    Arow << a, b, c, nx, ny, nz;
+    loss += pow(Arow.transpose() * x - d, 2);
+    ++target_it;
+    ++source_it;
+    ++N;
+  }
+  loss /= N;
+  PCL_DEBUG("[pcl::registration::TransformationEstimationPointToPlaneLLS::"
+            "estimateRigidTransformation] Loss :%.10e\n",
+            loss);
 }
 
 } // namespace registration

--- a/registration/include/pcl/registration/impl/transformation_estimation_svd.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_svd.hpp
@@ -214,6 +214,11 @@ TransformationEstimationSVD<PointSource, PointTarget, Scalar>::
   transformation_matrix.topLeftCorner(3, 3) = R;
   const Eigen::Matrix<Scalar, 3, 1> Rc(R * centroid_src.head(3));
   transformation_matrix.block(0, 3, 3, 1) = centroid_tgt.head(3) - Rc;
+
+  size_t N = cloud_src_demean.cols();
+  PCL_DEBUG("[pcl::registration::TransformationEstimationSVD::"
+            "getTransformationFromCorrelation] Loss: %.10e\n",
+            (cloud_tgt_demean - R * cloud_src_demean).squaredNorm() / N);
 }
 
 } // namespace registration

--- a/registration/include/pcl/registration/impl/transformation_estimation_svd.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_svd.hpp
@@ -215,10 +215,12 @@ TransformationEstimationSVD<PointSource, PointTarget, Scalar>::
   const Eigen::Matrix<Scalar, 3, 1> Rc(R * centroid_src.head(3));
   transformation_matrix.block(0, 3, 3, 1) = centroid_tgt.head(3) - Rc;
 
-  size_t N = cloud_src_demean.cols();
-  PCL_DEBUG("[pcl::registration::TransformationEstimationSVD::"
-            "getTransformationFromCorrelation] Loss: %.10e\n",
-            (cloud_tgt_demean - R * cloud_src_demean).squaredNorm() / N);
+  if (pcl::console::isVerbosityLevelEnabled(pcl::console::L_DEBUG)) {
+    size_t N = cloud_src_demean.cols();
+    PCL_DEBUG("[pcl::registration::TransformationEstimationSVD::"
+              "getTransformationFromCorrelation] Loss: %.10e\n",
+              (cloud_tgt_demean - R * cloud_src_demean).squaredNorm() / N);
+  }
 }
 
 } // namespace registration


### PR DESCRIPTION
Compute loss for `TransformationEstimationSVD` and `TransformationEstimationPointToPlaneLLS`, it's only activated if verbose level is `L_DEBUG` or `L_VERBOSE`.