### PR TITLE
[registration] add Scalar template variable to NormalDistributionsTransform

### DIFF
--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -105,7 +105,7 @@ NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeTransform
   Eigen::Matrix<double, 6, 1> transform, score_gradient;
   Vector3 init_translation = eig_transformation.translation();
   Vector3 init_rotation = eig_transformation.rotation().eulerAngles(0, 1, 2);
-  transform << init_translation.cast<double>(), init_rotation.cast<double>();
+  transform << init_translation.template cast<double>(), init_rotation.template cast<double>();
 
   Eigen::Matrix<double, 6, 6> hessian;
 

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -105,7 +105,8 @@ NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeTransform
   Eigen::Matrix<double, 6, 1> transform, score_gradient;
   Vector3 init_translation = eig_transformation.translation();
   Vector3 init_rotation = eig_transformation.rotation().eulerAngles(0, 1, 2);
-  transform << init_translation.template cast<double>(), init_rotation.template cast<double>();
+  transform << init_translation.template cast<double>(),
+      init_rotation.template cast<double>();
 
   Eigen::Matrix<double, 6, 6> hessian;
 

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -43,8 +43,9 @@
 
 namespace pcl {
 
-template <typename PointSource, typename PointTarget>
-NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributionsTransform()
+template <typename PointSource, typename PointTarget, typename Scalar>
+NormalDistributionsTransform<PointSource, PointTarget, Scalar>::
+    NormalDistributionsTransform()
 : target_cells_()
 , resolution_(1.0f)
 , step_size_(0.1)
@@ -68,10 +69,10 @@ NormalDistributionsTransform<PointSource, PointTarget>::NormalDistributionsTrans
   max_iterations_ = 35;
 }
 
-template <typename PointSource, typename PointTarget>
+template <typename PointSource, typename PointTarget, typename Scalar>
 void
-NormalDistributionsTransform<PointSource, PointTarget>::computeTransformation(
-    PointCloudSource& output, const Eigen::Matrix4f& guess)
+NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeTransformation(
+    PointCloudSource& output, const Matrix4& guess)
 {
   nr_iterations_ = 0;
   converged_ = false;
@@ -85,7 +86,7 @@ NormalDistributionsTransform<PointSource, PointTarget>::computeTransformation(
       -2 * std::log((-std::log(gauss_c1 * std::exp(-0.5) + gauss_c2) - gauss_d3) /
                     gauss_d1_);
 
-  if (guess != Eigen::Matrix4f::Identity()) {
+  if (guess != Matrix4::Identity()) {
     // Initialise final transformation to the guessed one
     final_transformation_ = guess;
     // Apply guessed transformation prior to search for neighbours
@@ -97,13 +98,13 @@ NormalDistributionsTransform<PointSource, PointTarget>::computeTransformation(
   point_jacobian_.block<3, 3>(0, 0).setIdentity();
   point_hessian_.setZero();
 
-  Eigen::Transform<float, 3, Eigen::Affine, Eigen::ColMajor> eig_transformation;
+  Eigen::Transform<Scalar, 3, Eigen::Affine, Eigen::ColMajor> eig_transformation;
   eig_transformation.matrix() = final_transformation_;
 
   // Convert initial guess matrix to 6 element transformation vector
   Eigen::Matrix<double, 6, 1> transform, score_gradient;
-  Eigen::Vector3f init_translation = eig_transformation.translation();
-  Eigen::Vector3f init_rotation = eig_transformation.rotation().eulerAngles(0, 1, 2);
+  Vector3 init_translation = eig_transformation.translation();
+  Vector3 init_rotation = eig_transformation.rotation().eulerAngles(0, 1, 2);
   transform << init_translation.cast<double>(), init_rotation.cast<double>();
 
   Eigen::Matrix<double, 6, 6> hessian;
@@ -179,9 +180,9 @@ NormalDistributionsTransform<PointSource, PointTarget>::computeTransformation(
   trans_likelihood_ = score / static_cast<double>(input_->size());
 }
 
-template <typename PointSource, typename PointTarget>
+template <typename PointSource, typename PointTarget, typename Scalar>
 double
-NormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives(
+NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeDerivatives(
     Eigen::Matrix<double, 6, 1>& score_gradient,
     Eigen::Matrix<double, 6, 6>& hessian,
     const PointCloudSource& trans_cloud,
@@ -230,9 +231,9 @@ NormalDistributionsTransform<PointSource, PointTarget>::computeDerivatives(
   return score;
 }
 
-template <typename PointSource, typename PointTarget>
+template <typename PointSource, typename PointTarget, typename Scalar>
 void
-NormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivatives(
+NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeAngleDerivatives(
     const Eigen::Matrix<double, 6, 1>& transform, bool compute_hessian)
 {
   // Simplified math for near 0 angles
@@ -315,9 +316,9 @@ NormalDistributionsTransform<PointSource, PointTarget>::computeAngleDerivatives(
   }
 }
 
-template <typename PointSource, typename PointTarget>
+template <typename PointSource, typename PointTarget, typename Scalar>
 void
-NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(
+NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computePointDerivatives(
     const Eigen::Vector3d& x, bool compute_hessian)
 {
   // Calculate first derivative of Transformation Equation 6.17 w.r.t. transform vector.
@@ -361,9 +362,9 @@ NormalDistributionsTransform<PointSource, PointTarget>::computePointDerivatives(
   }
 }
 
-template <typename PointSource, typename PointTarget>
+template <typename PointSource, typename PointTarget, typename Scalar>
 double
-NormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives(
+NormalDistributionsTransform<PointSource, PointTarget, Scalar>::updateDerivatives(
     Eigen::Matrix<double, 6, 1>& score_gradient,
     Eigen::Matrix<double, 6, 6>& hessian,
     const Eigen::Vector3d& x_trans,
@@ -409,9 +410,9 @@ NormalDistributionsTransform<PointSource, PointTarget>::updateDerivatives(
   return score_inc;
 }
 
-template <typename PointSource, typename PointTarget>
+template <typename PointSource, typename PointTarget, typename Scalar>
 void
-NormalDistributionsTransform<PointSource, PointTarget>::computeHessian(
+NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeHessian(
     Eigen::Matrix<double, 6, 6>& hessian, const PointCloudSource& trans_cloud)
 {
   hessian.setZero();
@@ -451,9 +452,9 @@ NormalDistributionsTransform<PointSource, PointTarget>::computeHessian(
   }
 }
 
-template <typename PointSource, typename PointTarget>
+template <typename PointSource, typename PointTarget, typename Scalar>
 void
-NormalDistributionsTransform<PointSource, PointTarget>::updateHessian(
+NormalDistributionsTransform<PointSource, PointTarget, Scalar>::updateHessian(
     Eigen::Matrix<double, 6, 6>& hessian,
     const Eigen::Vector3d& x_trans,
     const Eigen::Matrix3d& c_inv) const
@@ -486,9 +487,9 @@ NormalDistributionsTransform<PointSource, PointTarget>::updateHessian(
   }
 }
 
-template <typename PointSource, typename PointTarget>
+template <typename PointSource, typename PointTarget, typename Scalar>
 bool
-NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT(
+NormalDistributionsTransform<PointSource, PointTarget, Scalar>::updateIntervalMT(
     double& a_l,
     double& f_l,
     double& g_l,
@@ -531,9 +532,9 @@ NormalDistributionsTransform<PointSource, PointTarget>::updateIntervalMT(
   return true;
 }
 
-template <typename PointSource, typename PointTarget>
+template <typename PointSource, typename PointTarget, typename Scalar>
 double
-NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelectionMT(
+NormalDistributionsTransform<PointSource, PointTarget, Scalar>::trialValueSelectionMT(
     double a_l,
     double f_l,
     double g_l,
@@ -644,9 +645,9 @@ NormalDistributionsTransform<PointSource, PointTarget>::trialValueSelectionMT(
   }
 }
 
-template <typename PointSource, typename PointTarget>
+template <typename PointSource, typename PointTarget, typename Scalar>
 double
-NormalDistributionsTransform<PointSource, PointTarget>::computeStepLengthMT(
+NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeStepLengthMT(
     const Eigen::Matrix<double, 6, 1>& x,
     Eigen::Matrix<double, 6, 1>& step_dir,
     double step_init,

--- a/registration/include/pcl/registration/ndt.h
+++ b/registration/include/pcl/registration/ndt.h
@@ -61,16 +61,17 @@ namespace pcl {
  * \note Math refactored by Todor Stoyanov.
  * \author Brian Okorn (Space and Naval Warfare Systems Center Pacific)
  */
-template <typename PointSource, typename PointTarget>
-class NormalDistributionsTransform : public Registration<PointSource, PointTarget> {
+template <typename PointSource, typename PointTarget, typename Scalar = float>
+class NormalDistributionsTransform
+: public Registration<PointSource, PointTarget, Scalar> {
 protected:
   using PointCloudSource =
-      typename Registration<PointSource, PointTarget>::PointCloudSource;
+      typename Registration<PointSource, PointTarget, Scalar>::PointCloudSource;
   using PointCloudSourcePtr = typename PointCloudSource::Ptr;
   using PointCloudSourceConstPtr = typename PointCloudSource::ConstPtr;
 
   using PointCloudTarget =
-      typename Registration<PointSource, PointTarget>::PointCloudTarget;
+      typename Registration<PointSource, PointTarget, Scalar>::PointCloudTarget;
   using PointCloudTargetPtr = typename PointCloudTarget::Ptr;
   using PointCloudTargetConstPtr = typename PointCloudTarget::ConstPtr;
 
@@ -88,9 +89,13 @@ protected:
   using TargetGridLeafConstPtr = typename TargetGrid::LeafConstPtr;
 
 public:
-  using Ptr = shared_ptr<NormalDistributionsTransform<PointSource, PointTarget>>;
+  using Ptr =
+      shared_ptr<NormalDistributionsTransform<PointSource, PointTarget, Scalar>>;
   using ConstPtr =
-      shared_ptr<const NormalDistributionsTransform<PointSource, PointTarget>>;
+      shared_ptr<const NormalDistributionsTransform<PointSource, PointTarget, Scalar>>;
+  using Vector3 = Eigen::Matrix<Scalar, 3, 1>;
+  using Matrix4 = typename Registration<PointSource, PointTarget, Scalar>::Matrix4;
+  using Affine3 = typename Eigen::Transform<Scalar, 3, Eigen::Affine>;
 
   /** \brief Constructor.  Sets \ref outlier_ratio_ to 0.35, \ref step_size_ to
    * 0.05 and \ref resolution_ to 1.0
@@ -107,7 +112,7 @@ public:
   inline void
   setInputTarget(const PointCloudTargetConstPtr& cloud) override
   {
-    Registration<PointSource, PointTarget>::setInputTarget(cloud);
+    Registration<PointSource, PointTarget, Scalar>::setInputTarget(cloud);
     init();
   }
 
@@ -208,12 +213,12 @@ public:
    * vector
    */
   static void
-  convertTransform(const Eigen::Matrix<double, 6, 1>& x, Eigen::Affine3f& trans)
+  convertTransform(const Eigen::Matrix<double, 6, 1>& x, Affine3& trans)
   {
-    trans = Eigen::Translation<float, 3>(x.head<3>().cast<float>()) *
-            Eigen::AngleAxis<float>(float(x(3)), Eigen::Vector3f::UnitX()) *
-            Eigen::AngleAxis<float>(float(x(4)), Eigen::Vector3f::UnitY()) *
-            Eigen::AngleAxis<float>(float(x(5)), Eigen::Vector3f::UnitZ());
+    trans = Eigen::Translation<Scalar, 3>(x.head<3>().cast<Scalar>()) *
+            Eigen::AngleAxis<Scalar>(Scalar(x(3)), Vector3::UnitX()) *
+            Eigen::AngleAxis<Scalar>(Scalar(x(4)), Vector3::UnitY()) *
+            Eigen::AngleAxis<Scalar>(Scalar(x(5)), Vector3::UnitZ());
   }
 
   /** \brief Convert 6 element transformation vector to transformation matrix.
@@ -222,31 +227,32 @@ public:
    * transformation vector
    */
   static void
-  convertTransform(const Eigen::Matrix<double, 6, 1>& x, Eigen::Matrix4f& trans)
+  convertTransform(const Eigen::Matrix<double, 6, 1>& x, Matrix4& trans)
   {
-    Eigen::Affine3f _affine;
+    Affine3 _affine;
     convertTransform(x, _affine);
     trans = _affine.matrix();
   }
 
 protected:
-  using Registration<PointSource, PointTarget>::reg_name_;
-  using Registration<PointSource, PointTarget>::getClassName;
-  using Registration<PointSource, PointTarget>::input_;
-  using Registration<PointSource, PointTarget>::indices_;
-  using Registration<PointSource, PointTarget>::target_;
-  using Registration<PointSource, PointTarget>::nr_iterations_;
-  using Registration<PointSource, PointTarget>::max_iterations_;
-  using Registration<PointSource, PointTarget>::previous_transformation_;
-  using Registration<PointSource, PointTarget>::final_transformation_;
-  using Registration<PointSource, PointTarget>::transformation_;
-  using Registration<PointSource, PointTarget>::transformation_epsilon_;
-  using Registration<PointSource, PointTarget>::transformation_rotation_epsilon_;
-  using Registration<PointSource, PointTarget>::converged_;
-  using Registration<PointSource, PointTarget>::corr_dist_threshold_;
-  using Registration<PointSource, PointTarget>::inlier_threshold_;
+  using Registration<PointSource, PointTarget, Scalar>::reg_name_;
+  using Registration<PointSource, PointTarget, Scalar>::getClassName;
+  using Registration<PointSource, PointTarget, Scalar>::input_;
+  using Registration<PointSource, PointTarget, Scalar>::indices_;
+  using Registration<PointSource, PointTarget, Scalar>::target_;
+  using Registration<PointSource, PointTarget, Scalar>::nr_iterations_;
+  using Registration<PointSource, PointTarget, Scalar>::max_iterations_;
+  using Registration<PointSource, PointTarget, Scalar>::previous_transformation_;
+  using Registration<PointSource, PointTarget, Scalar>::final_transformation_;
+  using Registration<PointSource, PointTarget, Scalar>::transformation_;
+  using Registration<PointSource, PointTarget, Scalar>::transformation_epsilon_;
+  using Registration<PointSource, PointTarget, Scalar>::
+      transformation_rotation_epsilon_;
+  using Registration<PointSource, PointTarget, Scalar>::converged_;
+  using Registration<PointSource, PointTarget, Scalar>::corr_dist_threshold_;
+  using Registration<PointSource, PointTarget, Scalar>::inlier_threshold_;
 
-  using Registration<PointSource, PointTarget>::update_visualizer_;
+  using Registration<PointSource, PointTarget, Scalar>::update_visualizer_;
 
   /** \brief Estimate the transformation and returns the transformed source
    * (input) as output.
@@ -255,7 +261,7 @@ protected:
   virtual void
   computeTransformation(PointCloudSource& output)
   {
-    computeTransformation(output, Eigen::Matrix4f::Identity());
+    computeTransformation(output, Matrix4::Identity());
   }
 
   /** \brief Estimate the transformation and returns the transformed source
@@ -264,8 +270,7 @@ protected:
    * \param[in] guess the initial gross estimation of the transformation
    */
   void
-  computeTransformation(PointCloudSource& output,
-                        const Eigen::Matrix4f& guess) override;
+  computeTransformation(PointCloudSource& output, const Matrix4& guess) override;
 
   /** \brief Initiate covariance voxel structure. */
   void inline init()

--- a/registration/include/pcl/registration/ndt.h
+++ b/registration/include/pcl/registration/ndt.h
@@ -93,7 +93,7 @@ public:
       shared_ptr<NormalDistributionsTransform<PointSource, PointTarget, Scalar>>;
   using ConstPtr =
       shared_ptr<const NormalDistributionsTransform<PointSource, PointTarget, Scalar>>;
-  using Vector3 = Eigen::Matrix<Scalar, 3, 1>;
+  using Vector3 = typename Eigen::Matrix<Scalar, 3, 1>;
   using Matrix4 = typename Registration<PointSource, PointTarget, Scalar>::Matrix4;
   using Affine3 = typename Eigen::Transform<Scalar, 3, Eigen::Affine>;
 


### PR DESCRIPTION
`NormalDistributionsTransform` inherits from `Registration<PointSource, PointTarget, typename Scalar = float>`, so originally it's using float precision, this PR adds double precision support.