### PR TITLE
Fix clang-tidy issues arisen since #4629

### DIFF
--- a/common/include/pcl/common/fft/kiss_fft.h
+++ b/common/include/pcl/common/fft/kiss_fft.h
@@ -1,11 +1,11 @@
 #pragma once
 
-#include <stdlib.h>
-#include <stdio.h>
-#include <math.h>
-#include <string.h>
-
 #include <pcl/pcl_exports.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,12 +49,12 @@ extern "C" {
 # endif
 #endif
 
-typedef struct {
+typedef struct {	// NOLINT
     kiss_fft_scalar r;
     kiss_fft_scalar i;
 }kiss_fft_cpx;
 
-typedef struct kiss_fft_state* kiss_fft_cfg;
+typedef struct kiss_fft_state* kiss_fft_cfg;	// NOLINT
 
 /* 
  *  kiss_fft_alloc

--- a/common/include/pcl/common/fft/kiss_fft.h
+++ b/common/include/pcl/common/fft/kiss_fft.h
@@ -2,10 +2,10 @@
 
 #include <pcl/pcl_exports.h>
 
-#include <cmath>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
+#include <math.h>   // NOLINT
+#include <stdio.h>  // NOLINT
+#include <stdlib.h> // NOLINT
+#include <string.h> // NOLINT
 
 #ifdef __cplusplus
 extern "C" {

--- a/common/include/pcl/common/fft/kiss_fftr.h
+++ b/common/include/pcl/common/fft/kiss_fftr.h
@@ -14,7 +14,7 @@ extern "C" {
  
  */
 
-typedef struct kiss_fftr_state *kiss_fftr_cfg;
+typedef struct kiss_fftr_state *kiss_fftr_cfg;	// NOLINT
 
 
 kiss_fftr_cfg PCL_EXPORTS kiss_fftr_alloc(int nfft,int inverse_fft,void * mem, size_t * lenmem);

--- a/features/include/pcl/features/don.h
+++ b/features/include/pcl/features/don.h
@@ -86,10 +86,7 @@ namespace pcl
         feature_name_ = "DifferenceOfNormalsEstimation";
       }
 
-      ~DifferenceOfNormalsEstimation () override
-      {
-        //
-      }
+      ~DifferenceOfNormalsEstimation () override = default;
 
       /**
        * Set the normals calculated using a smaller search radius (scale) for the DoN operator.

--- a/io/include/pcl/io/dinast_grabber.h
+++ b/io/include/pcl/io/dinast_grabber.h
@@ -68,7 +68,7 @@ namespace pcl
       DinastGrabber (const int device_position=1);
 
       /** \brief Destructor. It never throws. */
-      ~DinastGrabber () noexcept;
+      ~DinastGrabber () noexcept override;
 
       /** \brief Check if the grabber is running
         * \return true if grabber is running / streaming. False otherwise.

--- a/io/include/pcl/io/image.h
+++ b/io/include/pcl/io/image.h
@@ -82,8 +82,7 @@ namespace pcl
         /**
         * @brief virtual Destructor that never throws an exception.
         */
-        inline virtual ~Image ()
-        {}
+        inline virtual ~Image () = default;
 
         /**
         * @param[in] input_width width of input image

--- a/io/include/pcl/io/image_ir.h
+++ b/io/include/pcl/io/image_ir.h
@@ -63,8 +63,7 @@ namespace pcl
         IRImage (FrameWrapper::Ptr ir_metadata);
         IRImage (FrameWrapper::Ptr ir_metadata, Timestamp time);
 
-        ~IRImage () noexcept
-        {}
+        ~IRImage () noexcept = default;
 
         void
         fillRaw (unsigned width, unsigned height, unsigned short* ir_buffer, unsigned line_step = 0) const;

--- a/io/include/pcl/io/image_rgb24.h
+++ b/io/include/pcl/io/image_rgb24.h
@@ -55,7 +55,7 @@ namespace pcl
 
         ImageRGB24 (FrameWrapper::Ptr image_metadata);
         ImageRGB24 (FrameWrapper::Ptr image_metadata, Timestamp timestamp);
-        ~ImageRGB24 () noexcept;
+        ~ImageRGB24 () override noexcept;
 
         inline Encoding
         getEncoding () const override

--- a/io/include/pcl/io/image_rgb24.h
+++ b/io/include/pcl/io/image_rgb24.h
@@ -55,7 +55,7 @@ namespace pcl
 
         ImageRGB24 (FrameWrapper::Ptr image_metadata);
         ImageRGB24 (FrameWrapper::Ptr image_metadata, Timestamp timestamp);
-        ~ImageRGB24 () override noexcept;
+        ~ImageRGB24 () noexcept override;
 
         inline Encoding
         getEncoding () const override

--- a/io/include/pcl/io/image_yuv422.h
+++ b/io/include/pcl/io/image_yuv422.h
@@ -55,7 +55,7 @@ namespace pcl
         ImageYUV422 (FrameWrapper::Ptr image_metadata);
         ImageYUV422 (FrameWrapper::Ptr image_metadata, Timestamp timestamp);
 
-        ~ImageYUV422 () noexcept;
+        ~ImageYUV422 () noexcept override;
 
         inline Encoding
         getEncoding () const override

--- a/io/include/pcl/io/openni2_grabber.h
+++ b/io/include/pcl/io/openni2_grabber.h
@@ -145,7 +145,7 @@ namespace pcl
           const Mode& image_mode = OpenNI_Default_Mode);
 
         /** \brief virtual Destructor inherited from the Grabber interface. It never throws. */
-        ~OpenNI2Grabber () noexcept;
+        ~OpenNI2Grabber () noexcept override;
 
         /** \brief Start the data acquisition. */
         void

--- a/io/include/pcl/io/real_sense_2_grabber.h
+++ b/io/include/pcl/io/real_sense_2_grabber.h
@@ -66,7 +66,7 @@ namespace pcl
     RealSense2Grabber ( const std::string& file_name_or_serial_number = "", const bool repeat_playback = true );
 
     /** \brief virtual Destructor inherited from the Grabber interface. It never throws. */
-    ~RealSense2Grabber ();
+    ~RealSense2Grabber () override;
 
     /** \brief Set the device options
     * \param[in] width resolution
@@ -104,10 +104,10 @@ namespace pcl
     getName () const override { return std::string ( "RealSense2Grabber" ); }
 
     //define callback signature typedefs
-    typedef void (signal_librealsense_PointXYZ) ( const pcl::PointCloud<pcl::PointXYZ>::ConstPtr& );
-    typedef void (signal_librealsense_PointXYZI) ( const pcl::PointCloud<pcl::PointXYZI>::ConstPtr& );
-    typedef void (signal_librealsense_PointXYZRGB) ( const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr& );
-    typedef void (signal_librealsense_PointXYZRGBA) ( const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr& );
+    using signal_librealsense_PointXYZ = void()( const pcl::PointCloud<pcl::PointXYZ>::ConstPtr& );
+    using signal_librealsense_PointXYZI = void()( const pcl::PointCloud<pcl::PointXYZI>::ConstPtr& );
+    using signal_librealsense_PointXYZRGB = void()( const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr& );
+    using signal_librealsense_PointXYZRGBA = void()( const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr& );
 
   protected:
 

--- a/io/include/pcl/io/real_sense_2_grabber.h
+++ b/io/include/pcl/io/real_sense_2_grabber.h
@@ -104,10 +104,10 @@ namespace pcl
     getName () const override { return std::string ( "RealSense2Grabber" ); }
 
     //define callback signature typedefs
-    using signal_librealsense_PointXYZ = void()( const pcl::PointCloud<pcl::PointXYZ>::ConstPtr& );
-    using signal_librealsense_PointXYZI = void()( const pcl::PointCloud<pcl::PointXYZI>::ConstPtr& );
-    using signal_librealsense_PointXYZRGB = void()( const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr& );
-    using signal_librealsense_PointXYZRGBA = void()( const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr& );
+    using signal_librealsense_PointXYZ = void( const pcl::PointCloud<pcl::PointXYZ>::ConstPtr& );
+    using signal_librealsense_PointXYZI = void( const pcl::PointCloud<pcl::PointXYZI>::ConstPtr& );
+    using signal_librealsense_PointXYZRGB = void( const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr& );
+    using signal_librealsense_PointXYZRGBA = void( const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr& );
 
   protected:
 

--- a/io/include/pcl/io/tim_grabber.h
+++ b/io/include/pcl/io/tim_grabber.h
@@ -75,7 +75,7 @@ class PCL_EXPORTS TimGrabber : public Grabber
 
     TimGrabber ();
     TimGrabber (const boost::asio::ip::address& ipAddress, const std::uint16_t port);
-    ~TimGrabber () noexcept;
+    ~TimGrabber () noexcept override;
 
     void
     start () override;

--- a/io/src/image_depth.cpp
+++ b/io/src/image_depth.cpp
@@ -65,9 +65,7 @@ pcl::io::DepthImage::DepthImage (FrameWrapper::Ptr depth_metadata, float baselin
 {}
 
 
-pcl::io::DepthImage::~DepthImage ()
-{}
-
+pcl::io::DepthImage::~DepthImage () = default;
 
 const unsigned short*
 pcl::io::DepthImage::getData ()

--- a/io/src/image_rgb24.cpp
+++ b/io/src/image_rgb24.cpp
@@ -55,8 +55,7 @@ pcl::io::ImageRGB24::ImageRGB24 (FrameWrapper::Ptr image_metadata, Timestamp tim
 {}
 
 
-pcl::io::ImageRGB24::~ImageRGB24 () noexcept
-{}
+pcl::io::ImageRGB24::~ImageRGB24 () noexcept = default;
 
 bool
 pcl::io::ImageRGB24::isResizingSupported (unsigned input_width, unsigned input_height, unsigned output_width, unsigned output_height) const

--- a/io/src/openni2/openni2_device_manager.cpp
+++ b/io/src/openni2/openni2_device_manager.cpp
@@ -82,7 +82,7 @@ namespace pcl
             }
           }
 
-          ~OpenNI2DeviceListener ()
+          ~OpenNI2DeviceListener () override
           {
             openni::OpenNI::removeDeviceConnectedListener (this);
             openni::OpenNI::removeDeviceDisconnectedListener (this);
@@ -191,9 +191,7 @@ pcl::io::openni2::OpenNI2DeviceManager::OpenNI2DeviceManager ()
   device_listener_.reset(new OpenNI2DeviceListener);
 }
 
-pcl::io::openni2::OpenNI2DeviceManager::~OpenNI2DeviceManager ()
-{
-}
+pcl::io::openni2::OpenNI2DeviceManager::~OpenNI2DeviceManager () = default;
 
 std::shared_ptr<std::vector<OpenNI2DeviceInfo>>
 pcl::io::openni2::OpenNI2DeviceManager::getConnectedDeviceInfos () const

--- a/io/src/openni2/openni2_timer_filter.cpp
+++ b/io/src/openni2/openni2_timer_filter.cpp
@@ -44,8 +44,7 @@ namespace pcl
         filter_len_(filter_len)
       {}
 
-      OpenNI2TimerFilter::~OpenNI2TimerFilter ()
-      {}
+      OpenNI2TimerFilter::~OpenNI2TimerFilter () = default;
 
       void OpenNI2TimerFilter::addSample (double sample)
       {

--- a/io/tools/openni_pcd_recorder.cpp
+++ b/io/tools/openni_pcd_recorder.cpp
@@ -103,6 +103,8 @@ class PCDBuffer
 {
   public:
     PCDBuffer () = default;
+    PCDBuffer (const PCDBuffer&) = delete; // Disabled copy constructor
+    PCDBuffer& operator = (const PCDBuffer&) = delete; // Disabled assignment operator
 
     bool 
     pushBack (typename PointCloud<PointT>::ConstPtr); // thread-save wrapper for push_back() method of ciruclar_buffer
@@ -145,9 +147,6 @@ class PCDBuffer
     }
 
   private:
-    PCDBuffer (const PCDBuffer&) = delete; // Disabled copy constructor
-    PCDBuffer& operator = (const PCDBuffer&) = delete; // Disabled assignment operator
-
     std::mutex bmutex_;
     std::condition_variable buff_empty_;
     boost::circular_buffer<typename PointCloud<PointT>::ConstPtr> buffer_;

--- a/outofcore/include/pcl/outofcore/cJSON.h
+++ b/outofcore/include/pcl/outofcore/cJSON.h
@@ -44,7 +44,7 @@ extern "C"
 #define cJSON_IsReference 256
 
 /* The cJSON structure: */
-typedef struct cJSON {
+typedef struct cJSON {	// NOLINT
 	struct cJSON *next,*prev;	/* next/prev allow you to walk array/object chains. Alternatively, use GetArraySize/GetArrayItem/GetObjectItem */
 	struct cJSON *child;		/* An array or object item will have a child pointer pointing to a chain of the items in the array/object. */
 
@@ -57,7 +57,7 @@ typedef struct cJSON {
 	char *string;				/* The item's name string, if this item is the child of, or is in the list of subitems of an object. */
 } cJSON;
 
-typedef struct cJSON_Hooks {
+typedef struct cJSON_Hooks {	// NOLINT
       void *(*malloc_fn)(std::size_t sz);
       void (*free_fn)(void *ptr);
 } cJSON_Hooks;

--- a/outofcore/include/pcl/outofcore/visualization/scene.h
+++ b/outofcore/include/pcl/outofcore/visualization/scene.h
@@ -14,12 +14,13 @@ private:
 
   static Scene *instance_;
 
+
+public:
+
   Scene ();
   Scene (const Scene& op) = delete;
   Scene&
   operator= (const Scene& op) = delete;
-
-public:
 
   // Singleton
   static Scene*

--- a/people/include/pcl/people/impl/ground_based_people_detection_app.hpp
+++ b/people/include/pcl/people/impl/ground_based_people_detection_app.hpp
@@ -416,8 +416,5 @@ pcl::people::GroundBasedPeopleDetectionApp<PointT>::compute (std::vector<pcl::pe
 }
 
 template <typename PointT>
-pcl::people::GroundBasedPeopleDetectionApp<PointT>::~GroundBasedPeopleDetectionApp ()
-{
-  // TODO Auto-generated destructor stub
-}
+pcl::people::GroundBasedPeopleDetectionApp<PointT>::~GroundBasedPeopleDetectionApp () = default;
 #endif /* PCL_PEOPLE_GROUND_BASED_PEOPLE_DETECTION_APP_HPP_ */

--- a/people/include/pcl/people/impl/head_based_subcluster.hpp
+++ b/people/include/pcl/people/impl/head_based_subcluster.hpp
@@ -331,8 +331,5 @@ pcl::people::HeadBasedSubclustering<PointT>::subcluster (std::vector<pcl::people
 }
 
 template <typename PointT>
-pcl::people::HeadBasedSubclustering<PointT>::~HeadBasedSubclustering ()
-{
-  // TODO Auto-generated destructor stub
-}
+pcl::people::HeadBasedSubclustering<PointT>::~HeadBasedSubclustering () = default;
 #endif /* PCL_PEOPLE_HEAD_BASED_SUBCLUSTER_HPP_ */

--- a/people/include/pcl/people/impl/height_map_2d.hpp
+++ b/people/include/pcl/people/impl/height_map_2d.hpp
@@ -304,8 +304,5 @@ pcl::people::HeightMap2D<PointT>::getMaximaCloudIndicesFiltered ()
 }
 
 template <typename PointT>
-pcl::people::HeightMap2D<PointT>::~HeightMap2D ()
-{
-  // TODO Auto-generated destructor stub
-}
+pcl::people::HeightMap2D<PointT>::~HeightMap2D () = default;
 #endif /* PCL_PEOPLE_HEIGHT_MAP_2D_HPP_ */

--- a/people/include/pcl/people/impl/person_cluster.hpp
+++ b/people/include/pcl/people/impl/person_cluster.hpp
@@ -417,8 +417,5 @@ void pcl::people::PersonCluster<PointT>::drawTBoundingBox (pcl::visualization::P
 }
 
 template <typename PointT>
-pcl::people::PersonCluster<PointT>::~PersonCluster ()
-{
-  // Auto-generated destructor stub
-}
+pcl::people::PersonCluster<PointT>::~PersonCluster () = default;
 #endif /* PCL_PEOPLE_PERSON_CLUSTER_HPP_ */

--- a/recognition/include/pcl/recognition/3rdparty/metslib/observer.hh
+++ b/recognition/include/pcl/recognition/3rdparty/metslib/observer.hh
@@ -58,11 +58,11 @@ namespace mets {
   public:
     /// @brief Ctor.
     update_observer(observed_subject* who) : who_m(who) {}
+    update_observer() = delete;
     /// @brief Subscript operator to update an observer.
     void 
     operator()(observer<observed_subject>* o) { o->update(who_m); }
   private:
-    update_observer() = delete;
     observed_subject* who_m;
   };
   

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -507,7 +507,7 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeTransformatio
     }
     nr_iterations_++;
 
-    if (update_visualizer_ != 0) {
+    if (update_visualizer_ != nullptr) {
       PointCloudSourcePtr input_transformed(new PointCloudSource);
       pcl::transformPointCloud(output, *input_transformed, transformation_);
       update_visualizer_(*input_transformed, source_indices, *target_, target_indices);

--- a/registration/include/pcl/registration/impl/icp.hpp
+++ b/registration/include/pcl/registration/impl/icp.hpp
@@ -226,7 +226,7 @@ IterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformation(
     ++nr_iterations_;
 
     // Update the vizualization of icp convergence
-    if (update_visualizer_ != 0) {
+    if (update_visualizer_ != nullptr) {
       pcl::Indices source_indices_good, target_indices_good;
       for (const Correspondence& corr : *correspondences_) {
         source_indices_good.emplace_back(corr.index_query);

--- a/segmentation/include/pcl/segmentation/sac_segmentation.h
+++ b/segmentation/include/pcl/segmentation/sac_segmentation.h
@@ -102,7 +102,7 @@ namespace pcl
       }
 
       /** \brief Empty destructor. */
-      ~SACSegmentation () override { /*srv_.reset ();*/ };
+      ~SACSegmentation () override = default;
 
       /** \brief The type of model to use (user given parameter).
         * \param[in] model the model type (check \a model_types.h)

--- a/surface/include/pcl/surface/grid_projection.h
+++ b/surface/include/pcl/surface/grid_projection.h
@@ -96,7 +96,7 @@ namespace pcl
         Eigen::Vector3f vect_at_grid_pt;
       };
 
-      typedef std::unordered_map<int, Leaf, std::hash<int>, std::equal_to<>, Eigen::aligned_allocator<std::pair<const int, Leaf>>> HashMap;
+      using HashMap = std::unordered_map<int, Leaf, std::hash<int>, std::equal_to<>, Eigen::aligned_allocator<std::pair<const int, Leaf>>>;
 
       /** \brief Constructor. */ 
       GridProjection ();

--- a/tools/openni_image.cpp
+++ b/tools/openni_image.cpp
@@ -166,6 +166,8 @@ class Buffer
 {
 	public:
     Buffer () = default;
+    Buffer (const Buffer&) = delete;            // Disabled copy constructor
+    Buffer& operator =(const Buffer&) = delete; // Disabled assignment operator
 
     bool 
     pushBack (Frame::ConstPtr frame)
@@ -245,9 +247,6 @@ class Buffer
     }
 
 	private:
-		Buffer (const Buffer&) = delete;            // Disabled copy constructor
-		Buffer& operator =(const Buffer&) = delete; // Disabled assignment operator
-		
     std::mutex bmutex_;
 		std::condition_variable buff_empty_;
 		boost::circular_buffer<Frame::ConstPtr> buffer_;

--- a/visualization/include/pcl/visualization/vtk/vtkFixedXRenderWindowInteractor.h
+++ b/visualization/include/pcl/visualization/vtk/vtkFixedXRenderWindowInteractor.h
@@ -43,6 +43,9 @@ class vtkXRenderWindowInteractorInternals;
 class VTKRENDERINGUI_EXPORT vtkXRenderWindowInteractor : public vtkRenderWindowInteractor
 {
 public:
+  vtkXRenderWindowInteractor(const vtkXRenderWindowInteractor&) = delete;
+  void operator=(const vtkXRenderWindowInteractor&) = delete;
+
   static vtkXRenderWindowInteractor* New();
   vtkTypeMacro(vtkXRenderWindowInteractor, vtkRenderWindowInteractor);
   void PrintSelf(ostream& os, vtkIndent indent) override;
@@ -150,9 +153,6 @@ protected:
    */
   void Finalize();
 
-private:
-  vtkXRenderWindowInteractor(const vtkXRenderWindowInteractor&) = delete;
-  void operator=(const vtkXRenderWindowInteractor&) = delete;
 };
 } // namespace pcl
 

--- a/visualization/src/vtk/vtkFixedXRenderWindowInteractor.cxx
+++ b/visualization/src/vtk/vtkFixedXRenderWindowInteractor.cxx
@@ -145,7 +145,7 @@ private:
 std::set<vtkXRenderWindowInteractor*> vtkXRenderWindowInteractorInternals::Instances;
 
 // for some reason the X11 def of KeySym is getting messed up
-typedef XID vtkKeySym;
+using vtkKeySym = XID;
 
 //------------------------------------------------------------------------------
 vtkXRenderWindowInteractor::vtkXRenderWindowInteractor()


### PR DESCRIPTION
The GitHub `clang-tidy` workflow introduced in #4636 is flagging a different set of issues than those resolved previously.

This PR is attempting to reconcile issues flagged by `clang-tidy-14` in both CI and in a local repo.