### PR TITLE
Ran clang-tidy on apps* optional modules

### DIFF
--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudEditorWidget.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudEditorWidget.h
@@ -69,7 +69,7 @@ class CloudEditorWidget : public QGLWidget
     CloudEditorWidget (QWidget *parent = nullptr);
 
     /// @brief Destructor
-    ~CloudEditorWidget ();
+    ~CloudEditorWidget () override;
 
     /// @brief Attempts to load the point cloud designated by the passed file
     /// name.

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudTransformTool.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudTransformTool.h
@@ -55,7 +55,7 @@ class CloudTransformTool : public ToolInterface
     CloudTransformTool (CloudPtr cloud_ptr);
 
     /// @brief Destructor
-    ~CloudTransformTool ();
+    ~CloudTransformTool () override;
 
     /// @brief Initialize the current transform with mouse screen coordinates
     /// and key modifiers.

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/command.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/command.h
@@ -50,8 +50,7 @@ class Command
   public:
     /// @brief Destructor
     virtual ~Command ()
-    {
-    }
+    = default;
 
   protected:
     /// Allows command queues to be the only objects which are able to execute

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/commandQueue.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/commandQueue.h
@@ -65,8 +65,7 @@ class CommandQueue
 
     /// @brief Destructor
     ~CommandQueue ()
-    {
-    }
+    = default;
 
     /// @brief Executes a command. If the command has an undo function, then
     /// adds the command to the queue.

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cutCommand.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cutCommand.h
@@ -69,7 +69,7 @@ class CutCommand : public Command
     operator= (const CutCommand&) = delete;
 
     /// @brief Destructor
-    ~CutCommand ();
+    ~CutCommand () override;
 
   protected:
     /// @brief Moves the selected points to the copy buffer and removes them

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/denoiseParameterForm.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/denoiseParameterForm.h
@@ -56,7 +56,7 @@ class DenoiseParameterForm : public QDialog
     DenoiseParameterForm();
 
     /// @brief Destructor
-    ~DenoiseParameterForm ();
+    ~DenoiseParameterForm () override;
 
     /// @brief Returns the mean
     inline

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/mainWindow.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/mainWindow.h
@@ -73,7 +73,7 @@ class MainWindow : public QMainWindow
     MainWindow (int argc, char **argv);
 
     /// @brief Destructor
-    ~MainWindow ();
+    ~MainWindow () override;
 
     /// @brief Increase the value of the spinbox by 1.
     void

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/select1DTool.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/select1DTool.h
@@ -58,9 +58,8 @@ class Select1DTool : public ToolInterface
     Select1DTool (SelectionPtr selection_ptr, CloudPtr cloud_ptr);
 
     /// @brief Destructor
-    ~Select1DTool ()
-    {
-    }
+    ~Select1DTool () override
+    = default;
   
     /// @brief Does nothing for 1D selection.
     /// @sa end

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/select2DTool.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/select2DTool.h
@@ -60,7 +60,7 @@ class Select2DTool : public ToolInterface
     Select2DTool (SelectionPtr selection_ptr, CloudPtr cloud_ptr);
 
     /// @brief Destructor
-    ~Select2DTool ();
+    ~Select2DTool () override;
   
     /// @brief Initializes the selection tool with the initial mouse screen
     /// coordinates and key modifiers. The passed coordinates are used for

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/selectionTransformTool.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/selectionTransformTool.h
@@ -69,9 +69,8 @@ class SelectionTransformTool : public ToolInterface
                             CommandQueuePtr command_queue_ptr);
 
     /// @brief Destructor
-    ~SelectionTransformTool ()
-    {
-    }
+    ~SelectionTransformTool () override
+    = default;
 
     /// @brief Initialize the transform tool with mouse screen coordinates
     /// and key modifiers.

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/statistics.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/statistics.h
@@ -49,8 +49,7 @@ class Statistics
   public:
     /// @brief Destructor
     virtual ~Statistics ()
-    {
-    }
+    = default;
 
     /// @brief Returns the strings of the statistics.
     static
@@ -64,8 +63,7 @@ class Statistics
   protected:
     /// @brief The default constructor.
     Statistics ()
-    {
-    }
+    = default;
 
     /// @brief Copy Constructor
     Statistics (const Statistics&)

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/statisticsDialog.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/statisticsDialog.h
@@ -58,7 +58,7 @@ class StatisticsDialog : public QDialog
     /// @brief Default Constructor
     StatisticsDialog(QWidget *parent = nullptr);
     /// @brief Destructor
-    ~StatisticsDialog ();
+    ~StatisticsDialog () override;
     
   public Q_SLOTS:
     /// @brief update the dialog box.

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/toolInterface.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/toolInterface.h
@@ -49,8 +49,7 @@ class ToolInterface
   public:
     /// @brief Destructor.
     virtual ~ToolInterface ()
-    {
-    }
+    = default;
 
     /// @brief set the initial state of the tool from the screen coordinates
     /// of the mouse as well as the value of the modifier.
@@ -102,8 +101,7 @@ class ToolInterface
   protected:
     /// @brief Default constructor
     ToolInterface ()
-    {
-    }
+    = default;
 
   private:
     /// @brief Copy constructor - tools are non-copyable

--- a/apps/point_cloud_editor/src/cloudEditorWidget.cpp
+++ b/apps/point_cloud_editor/src/cloudEditorWidget.cpp
@@ -85,8 +85,7 @@ CloudEditorWidget::CloudEditorWidget (QWidget *parent)
 }
 
 CloudEditorWidget::~CloudEditorWidget ()
-{
-}
+= default;
 
 void
 CloudEditorWidget::loadFile(const std::string &filename)

--- a/apps/point_cloud_editor/src/cloudTransformTool.cpp
+++ b/apps/point_cloud_editor/src/cloudTransformTool.cpp
@@ -53,8 +53,7 @@ CloudTransformTool::CloudTransformTool (CloudPtr cloud_ptr)
 }
 
 CloudTransformTool::~CloudTransformTool ()
-{
-}
+= default;
 
 void
 CloudTransformTool::start (int x, int y, BitMask, BitMask)

--- a/apps/point_cloud_editor/src/cutCommand.cpp
+++ b/apps/point_cloud_editor/src/cutCommand.cpp
@@ -51,8 +51,7 @@ CutCommand::CutCommand (CopyBufferPtr copy_buffer_ptr,
 }
 
 CutCommand::~CutCommand ()
-{
-}
+= default;
 
 void
 CutCommand::execute ()

--- a/apps/point_cloud_editor/src/mainWindow.cpp
+++ b/apps/point_cloud_editor/src/mainWindow.cpp
@@ -56,9 +56,7 @@ window_width_(WINDOW_WIDTH), window_height_(WINDOW_HEIGHT)
 }
 
 MainWindow::~MainWindow()
-{
-
-}
+= default;
 
 void
 MainWindow::about ()

--- a/apps/point_cloud_editor/src/select2DTool.cpp
+++ b/apps/point_cloud_editor/src/select2DTool.cpp
@@ -54,8 +54,7 @@ Select2DTool::Select2DTool (SelectionPtr selection_ptr, CloudPtr cloud_ptr)
 }
 
 Select2DTool::~Select2DTool ()
-{
-}
+= default;
 
 void
 Select2DTool::start (int x, int y, BitMask, BitMask)

--- a/apps/point_cloud_editor/src/trackball.cpp
+++ b/apps/point_cloud_editor/src/trackball.cpp
@@ -48,28 +48,15 @@ TrackBall::TrackBall() : quat_(1.0f), origin_x_(0), origin_y_(0), origin_z_(0)
                 (TRACKBALL_RADIUS_SCALE * static_cast<float>(WINDOW_WIDTH));
 }
 
-TrackBall::TrackBall(const TrackBall &copy) :
-  quat_(copy.quat_), origin_x_(copy.origin_x_), origin_y_(copy.origin_y_),
-  origin_z_(copy.origin_z_), radius_sqr_(copy.radius_sqr_)
-{
-  
-}
+TrackBall::TrackBall(const TrackBall &copy)  
+= default;
 
 TrackBall::~TrackBall()
-{
-    
-}
+= default;
 
 TrackBall&
 TrackBall::operator=(const TrackBall &rhs)
-{
-  quat_ = rhs.quat_;
-  origin_x_ = rhs.origin_x_;
-  origin_y_ = rhs.origin_y_;
-  origin_z_ = rhs.origin_z_;
-  radius_sqr_ = rhs.radius_sqr_;
-  return *this;
-}
+= default;
 
 void
 TrackBall::start(int s_x, int s_y)

--- a/apps/src/grabcut_2d.cpp
+++ b/apps/src/grabcut_2d.cpp
@@ -38,7 +38,7 @@ public:
   : pcl::GrabCut<pcl::PointXYZRGB>(K, lambda)
   {}
 
-  ~GrabCutHelper() {}
+  ~GrabCutHelper() override = default;
 
   void
   setInputCloud(const pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr& cloud) override;

--- a/apps/src/stereo_ground_segmentation.cpp
+++ b/apps/src/stereo_ground_segmentation.cpp
@@ -160,7 +160,7 @@ public:
     road_comparator->setAngularThreshold(pcl::deg2rad(3.0f));
   }
 
-  ~HRCSSegmentation() {}
+  ~HRCSSegmentation() = default;
 
   void
   cloud_cb_(const pcl::PointCloud<PointT>::ConstPtr& cloud)

--- a/common/include/pcl/point_representation.h
+++ b/common/include/pcl/point_representation.h
@@ -563,8 +563,8 @@ namespace pcl
         * \param[in] p the input point
         * \param[out] out the resultant output array
         */
-      virtual void
-      copyToFloatArray (const PointDefault &p, float *out) const
+      void
+      copyToFloatArray (const PointDefault &p, float *out) const override
       {
         // If point type is unknown, treat it as a struct/array of floats
         const float *ptr = (reinterpret_cast<const float*> (&p)) + start_dim_;

--- a/keypoints/include/pcl/keypoints/harris_3d.h
+++ b/keypoints/include/pcl/keypoints/harris_3d.h
@@ -94,7 +94,7 @@ namespace pcl
       }
       
       /** \brief Empty destructor */
-      ~HarrisKeypoint3D () = default;
+      ~HarrisKeypoint3D () override = default;
 
       /** \brief Provide a pointer to the input dataset
         * \param[in] cloud the const boost shared pointer to a PointCloud message

--- a/segmentation/include/pcl/segmentation/edge_aware_plane_comparator.h
+++ b/segmentation/include/pcl/segmentation/edge_aware_plane_comparator.h
@@ -92,9 +92,8 @@ namespace pcl
 
       /** \brief Destructor for PlaneCoefficientComparator. */
 
-      ~EdgeAwarePlaneComparator ()
-      {
-      }
+      ~EdgeAwarePlaneComparator () override
+      = default;
 
       /** \brief Set a distance map to use. For an example of a valid distance map see
         * IntegralImageNormalEstimation::getDistanceMap

--- a/segmentation/include/pcl/segmentation/grabcut_segmentation.h
+++ b/segmentation/include/pcl/segmentation/grabcut_segmentation.h
@@ -336,7 +336,7 @@ namespace pcl
         , initialized_ (false)
       {}
       /// Destructor
-      ~GrabCut () = default;
+      ~GrabCut () override = default;
       // /// Set input cloud
       void
       setInputCloud (const PointCloudConstPtr& cloud) override;

--- a/segmentation/include/pcl/segmentation/ground_plane_comparator.h
+++ b/segmentation/include/pcl/segmentation/ground_plane_comparator.h
@@ -97,9 +97,8 @@ namespace pcl
       
       /** \brief Destructor for GroundPlaneComparator. */
       
-      ~GroundPlaneComparator ()
-      {
-      }
+      ~GroundPlaneComparator () override
+      = default;
       /** \brief Provide the input cloud.
         * \param[in] cloud the input point cloud.
         */


### PR DESCRIPTION
Ran `clang-tidy` on additional optional modules:
```
cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_COMPILER=/usr/bin/clang-14 -DCMAKE_C_COMPILER=/usr/bin/clang-14 . \
      -DBUILD_apps_cloud_composer=ON \
      -DBUILD_apps_in_hand_scanner=ON \
      -DBUILD_apps_modeler=ON \
      -DBUILD_apps_point_cloud_editor=ON
```