### PR TITLE
Relax error tolerance in pca test

### DIFF
--- a/test/common/test_pca.cpp
+++ b/test/common/test_pca.cpp
@@ -53,7 +53,7 @@ TEST(PCA, projection)
   {
     pca.project (point, projected);
     pca.reconstruct (projected, reconstructed);
-    EXPECT_NEAR_VECTORS (reconstructed.getVector3fMap (), point.getVector3fMap (), 2.5e-4);
+    EXPECT_NEAR_VECTORS (reconstructed.getVector3fMap (), point.getVector3fMap (), 5e-4);
   }
 }
 
@@ -87,7 +87,7 @@ TEST(PCA, cloud_projection)
     for(std::size_t i = 0; i < cloud.size(); i++)
       EXPECT_NEAR_VECTORS (cloud[i].getVector3fMap (),
                            cloud_reconstructed[i].getVector3fMap (),
-                           2.5e-4);
+                           5e-4);
   }
   catch (pcl::InitFailedException &/*e*/)
   {


### PR DESCRIPTION
Necessary e.g. for aarch64/arm64.
5e-4 is still quite small, considering the biggest point coordinate is 2999.
@jspricke @StefanBruens for your information