### PR TITLE
Fix typo in DefaultConvergenceCriteria Empty constructor documentation

### DIFF
--- a/registration/include/pcl/registration/default_convergence_criteria.h
+++ b/registration/include/pcl/registration/default_convergence_criteria.h
@@ -81,7 +81,7 @@ public:
 
   /** \brief Empty constructor.
    * Sets:
-   *  * the maximum number of iterations to 1000
+   *  * the maximum number of iterations to 100
    *  * the rotation threshold to 0.256 degrees (0.99999)
    *  * the translation threshold to 0.0003 meters (3e-4^2)
    *  * the MSE relative / absolute thresholds to 0.001% and 1e-12


### PR DESCRIPTION
The documentation reported that the default maximum number of iterations is 1000, but actually it is 100.