### PR TITLE
Fixes Crash in pcl::PLYReader::amendProperty

### DIFF
--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -123,9 +123,9 @@ pcl::PLYReader::amendProperty (const std::string& old_name, const std::string& n
       break;
   if (finder == cloud_->fields.rend ())
   {
-      assert (false);
-      PCL_ERROR("[pcl::PLYReader::amendProperty] old_name was not found in cloud_->fields!\n",
+      PCL_ERROR("[pcl::PLYReader::amendProperty] old_name '%s' was not found in cloud_->fields!\n",
           old_name.c_str());
+      assert (false);
       return;
   }
   finder->name = new_name;

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -124,6 +124,8 @@ pcl::PLYReader::amendProperty (const std::string& old_name, const std::string& n
   if (finder == cloud_->fields.rend ())
   {
       assert (false);
+      PCL_ERROR("[pcl::PLYReader::amendProperty] old_name was not found in cloud_->fields!\n",
+          old_name.c_str());
       return;
   }
   finder->name = new_name;

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -121,7 +121,11 @@ pcl::PLYReader::amendProperty (const std::string& old_name, const std::string& n
   for (; finder != cloud_->fields.rend (); ++finder)
     if (finder->name == old_name)
       break;
-  assert (finder != cloud_->fields.rend ());
+  if (finder == cloud_->fields.rend ())
+  {
+      assert (false);
+      return;
+  }
   finder->name = new_name;
   if (new_datatype > 0 && new_datatype != finder->datatype)
     finder->datatype = new_datatype;


### PR DESCRIPTION
Fixes Crash in pcl::PLYReader::amendProperty:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=42111 and
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=32184

In a `pcl::PLYReader::amendProperty` call `cloud_->fields` is empty and the `finder` iterator is invalid. It leads to invalid memory read in Release.