### PR TITLE
Fixes pcl::io::ply::ply_parser::parse_scalar_property<float>

### DIFF
--- a/io/include/pcl/io/ply/ply_parser.h
+++ b/io/include/pcl/io/ply/ply_parser.h
@@ -557,7 +557,9 @@ inline bool pcl::io::ply::ply_parser::parse_scalar_property (format_type format,
     }
     catch (boost::bad_lexical_cast &)
     {
-      value = std::numeric_limits<scalar_type>::quiet_NaN ();
+      if (error_callback_)
+        error_callback_ (line_number_, "parse error");
+      return (false);
     }
 
     if (!istream.eof ())


### PR DESCRIPTION
Fixes pcl::io::ply::ply_parser::parse_scalar_property<float>:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=41152 and
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=35640

`memcpy` in `PLYReader::vertexScalarPropertyCallback` writes to `&cloud_->data[vertex_count_ * cloud_->point_step + vertex_offset_before_]`. The `cloud_->data` size is 5, while `vertex_count_ == 1`, `cloud_->point_step == 6` and `vertex_offset_before_ == 0`
The fix is to bail out earlier in `pcl::io::ply::ply_parser::parse_scalar_property` where it fails to parse the value.