### PR TITLE
Small fixes on UseCompilerCache

### DIFF
--- a/cmake/Modules/UseCompilerCache.cmake
+++ b/cmake/Modules/UseCompilerCache.cmake
@@ -74,7 +74,7 @@ function(UseCompilerCache)
     endif()
   endforeach()
 
-  if(NOT QUIET)
+  if(NOT ARGS_QUIET)
     message(STATUS "Using Compiler Cache (${CCACHE_PROGRAM}) v${version} in the C/C++ toolchain")
   endif()
 
@@ -105,12 +105,7 @@ function(UseCompilerCache)
                   "${CMAKE_BINARY_DIR}/launch-c"
                   "${CMAKE_BINARY_DIR}/launch-cxx")
 
-  # Cuda support only added in CMake 3.10
-  set(cuda_supported FALSE)
-  if (NOT (CMAKE_VERSION VERSION_LESS 3.10) AND CMAKE_CUDA_COMPILER)
-    set(cuda_supported TRUE)
-  endif()
-  if(${cuda_supported})
+  if(CMAKE_CUDA_COMPILER)
     pcl_ccache_compat_file_gen("launch-cuda" ${CCACHE_PROGRAM} ${CMAKE_CUDA_COMPILER})
     execute_process(COMMAND chmod a+rx
                     "${CMAKE_BINARY_DIR}/launch-cuda")
@@ -127,7 +122,7 @@ function(UseCompilerCache)
     message(STATUS "Compiler cache via launch files to support Unix Makefiles and Ninja")
     set(CMAKE_C_COMPILER_LAUNCHER    "${CMAKE_BINARY_DIR}/launch-c" PARENT_SCOPE)
     set(CMAKE_CXX_COMPILER_LAUNCHER  "${CMAKE_BINARY_DIR}/launch-cxx" PARENT_SCOPE)
-    if (${cuda_supported})
+    if (CMAKE_CUDA_COMPILER)
         set(CMAKE_CUDA_COMPILER_LAUNCHER "${CMAKE_BINARY_DIR}/launch-cuda" PARENT_SCOPE)
     endif()
   endif()


### PR DESCRIPTION
- Fix wrong check for argument `QUIET`
- Remove check for CMake version as 3.10 is currently already the minimum version