### PR TITLE
Remove remaining checks for already unsupported CMake versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,13 +283,11 @@ endif()
 if(OpenMP_FOUND)
   string(APPEND CMAKE_C_FLAGS " ${OpenMP_C_FLAGS}")
   string(APPEND CMAKE_CXX_FLAGS " ${OpenMP_CXX_FLAGS}")
-  if(${CMAKE_VERSION} VERSION_LESS "3.7")
-    message(STATUS "Found OpenMP")
-  else()
-    # We could use OpenMP_CXX_VERSION starting from CMake 3.9, but this value is only available on first run of CMake (see https://gitlab.kitware.com/cmake/cmake/issues/19150),
-    # so we use always OpenMP_CXX_SPEC_DATE, which is available since CMake 3.7.
-    message(STATUS "Found OpenMP, spec date ${OpenMP_CXX_SPEC_DATE}")
-  endif()
+
+  # We could use OpenMP_CXX_VERSION starting from CMake 3.9, but this value is only available on first run of CMake (see https://gitlab.kitware.com/cmake/cmake/issues/19150),
+  # so we use always OpenMP_CXX_SPEC_DATE, which is available since CMake 3.7.
+  message(STATUS "Found OpenMP, spec date ${OpenMP_CXX_SPEC_DATE}")
+
   if(MSVC)
     if(MSVC_VERSION EQUAL 1900)
       set(OPENMP_DLL VCOMP140)

--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -616,16 +616,7 @@ foreach(component ${PCL_TO_FIND_COMPONENTS})
       string(REGEX REPLACE "^-D" "" def3 "${def2}")
       list(APPEND definitions ${def3})
     endforeach()
-    if(CMAKE_VERSION VERSION_LESS 3.3)
-      set_target_properties(${pcl_component}
-        PROPERTIES
-          INTERFACE_COMPILE_DEFINITIONS "${definitions}"
-          INTERFACE_COMPILE_OPTIONS "${PCL_COMPILE_OPTIONS}"
-          INTERFACE_COMPILE_FEATURES "@PCL_CXX_COMPILE_FEATURES@"
-          INTERFACE_INCLUDE_DIRECTORIES "${PCL_${COMPONENT}_INCLUDE_DIRS};${PCL_CONF_INCLUDE_DIR}"
-          INTERFACE_LINK_LIBRARIES "${PCL_${COMPONENT}_LINK_LIBRARIES}"
-      )
-    elseif(CMAKE_VERSION VERSION_LESS 3.11)
+    if(CMAKE_VERSION VERSION_LESS 3.11)
       set_target_properties(${pcl_component}
         PROPERTIES
           INTERFACE_COMPILE_DEFINITIONS "${definitions}"


### PR DESCRIPTION
Note: In `PCLConfig.cmake.in` the call `cmake_policy(VERSION 3.10)` already enforces if at least 3.10 is used (locally just tested by replacing this line by 3.25 as I'm already using 3.24 - I hope the same behavior already exists in older versions ;-) )