### PR TITLE
rename variable `b_no_children`

### DIFF
--- a/octree/include/pcl/octree/impl/octree_base.hpp
+++ b/octree/include/pcl/octree/impl/octree_base.hpp
@@ -385,8 +385,8 @@ OctreeBase<LeafContainerT, BranchContainerT>::deleteLeafRecursive(
 {
   // index to branch child
   unsigned char child_idx;
-  // indicates if branch is empty and can be safely removed
-  bool b_no_children;
+  // indicates if branch has children, if so, it can't be removed
+  bool b_has_children;
 
   // find branch child from key
   child_idx = key_arg.getChildIdxWithDepthMask(depth_mask_arg);
@@ -401,9 +401,9 @@ OctreeBase<LeafContainerT, BranchContainerT>::deleteLeafRecursive(
       child_branch = static_cast<BranchNode*>(child_node);
 
       // recursively explore the indexed child branch
-      b_no_children = deleteLeafRecursive(key_arg, depth_mask_arg / 2, child_branch);
+      b_has_children = deleteLeafRecursive(key_arg, depth_mask_arg / 2, child_branch);
 
-      if (!b_no_children) {
+      if (!b_has_children) {
         // child branch does not own any sub-child nodes anymore -> delete child branch
         deleteBranchChild(*branch_arg, child_idx);
         branch_count_--;
@@ -421,12 +421,12 @@ OctreeBase<LeafContainerT, BranchContainerT>::deleteLeafRecursive(
   }
 
   // check if current branch still owns children
-  b_no_children = false;
-  for (child_idx = 0; (!b_no_children) && (child_idx < 8); child_idx++) {
-    b_no_children = branch_arg->hasChild(child_idx);
+  b_has_children = false;
+  for (child_idx = 0; (!b_has_children) && (child_idx < 8); child_idx++) {
+    b_has_children = branch_arg->hasChild(child_idx);
   }
-  // return true if current branch can be deleted
-  return (b_no_children);
+  // return false if current branch can be deleted
+  return (b_has_children);
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -604,8 +604,8 @@ protected:
    *  \param depth_mask_arg: depth mask used for octree key analysis and branch depth
    * indicator
    * \param branch_arg: current branch node
-   * \return "true" if branch does not contain any childs; "false" otherwise. This
-   * indicates if current branch can be deleted, too.
+   * \return "true" if current branch contains child(ren); "false" otherwise. If it's
+   * true, current branch cannot be deleted.
    **/
   bool
   deleteLeafRecursive(const OctreeKey& key_arg,


### PR DESCRIPTION
The variable name `b_no_children` seems misleading, this PR renames it.