### PR TITLE
Draft: Fix MacOS CI build

### DIFF
--- a/.ci/azure-pipelines/build/macos.yaml
+++ b/.ci/azure-pipelines/build/macos.yaml
@@ -28,7 +28,8 @@ steps:
         -DBUILD_apps_cloud_composer=ON \
         -DBUILD_apps_in_hand_scanner=ON \
         -DBUILD_apps_modeler=ON \
-        -DBUILD_apps_point_cloud_editor=ON
+        -DBUILD_apps_point_cloud_editor=ON \
+        --trace-expand
     displayName: 'CMake Configuration'
   - script: |
       cd $BUILD_DIR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -450,3 +450,5 @@ MAKE_DEP_GRAPH()
 ### ---[ Finish up
 PCL_WRITE_STATUS_REPORT()
 PCL_RESET_MAPS()
+
+message(FATAL_ERROR "Aborted to save CI time")


### PR DESCRIPTION
The macOS job failed since via Brew Boost 1.79 is shipped instead of 1.78, but another component requires Boost 1.78.