### PR TITLE
Document segmentation dependency "features"

### DIFF
--- a/segmentation/segmentation.doxy
+++ b/segmentation/segmentation.doxy
@@ -13,5 +13,6 @@
   - \ref sample_consensus "sample_consensus"
   - \ref kdtree "kdtree"
   - \ref octree "octree"
+  - \ref features "features"
 
 */


### PR DESCRIPTION
Manually disabling features during build will implicitly disable
segmentation as well. In automated build environments this will almost
silently not install "segmentation" therefore causing confusing behavior
if not documented.

Fixes #5357