### PR TITLE
[octree] fix definition of ConstIterator and add OctreeBaseIteratorsPrePostTest for them

### DIFF
--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -103,10 +103,16 @@ public:
   friend class OctreeFixedDepthIterator<OctreeT>;
   friend class OctreeLeafNodeDepthFirstIterator<OctreeT>;
   friend class OctreeLeafNodeBreadthFirstIterator<OctreeT>;
+  friend class OctreeIteratorBase<const OctreeT>;
+  friend class OctreeDepthFirstIterator<const OctreeT>;
+  friend class OctreeBreadthFirstIterator<const OctreeT>;
+  friend class OctreeFixedDepthIterator<const OctreeT>;
+  friend class OctreeLeafNodeDepthFirstIterator<const OctreeT>;
+  friend class OctreeLeafNodeBreadthFirstIterator<const OctreeT>;
 
   // Octree default iterators
   using Iterator = OctreeDepthFirstIterator<OctreeT>;
-  using ConstIterator = const OctreeDepthFirstIterator<OctreeT>;
+  using ConstIterator = OctreeDepthFirstIterator<const OctreeT>;
 
   Iterator
   begin(uindex_t max_depth_arg = 0u)
@@ -114,10 +120,22 @@ public:
     return Iterator(this, max_depth_arg ? max_depth_arg : this->octree_depth_);
   };
 
+  ConstIterator
+  begin(uindex_t max_depth_arg = 0u) const
+  {
+    return ConstIterator(this, max_depth_arg ? max_depth_arg : this->octree_depth_);
+  };
+
   const Iterator
   end()
   {
     return Iterator(this, 0, nullptr);
+  };
+
+  const ConstIterator
+  end() const
+  {
+    return ConstIterator(this, 0, nullptr);
   };
 
   // Octree leaf node iterators
@@ -130,12 +148,19 @@ public:
   // The currently valide names
   using LeafNodeDepthFirstIterator = OctreeLeafNodeDepthFirstIterator<OctreeT>;
   using ConstLeafNodeDepthFirstIterator =
-      const OctreeLeafNodeDepthFirstIterator<OctreeT>;
+      OctreeLeafNodeDepthFirstIterator<const OctreeT>;
 
   LeafNodeDepthFirstIterator
   leaf_depth_begin(uindex_t max_depth_arg = 0u)
   {
     return LeafNodeDepthFirstIterator(
+        this, max_depth_arg ? max_depth_arg : this->octree_depth_);
+  };
+
+  ConstLeafNodeDepthFirstIterator
+  leaf_depth_begin(uindex_t max_depth_arg = 0u) const
+  {
+    return ConstLeafNodeDepthFirstIterator(
         this, max_depth_arg ? max_depth_arg : this->octree_depth_);
   };
 
@@ -145,9 +170,15 @@ public:
     return LeafNodeDepthFirstIterator(this, 0, nullptr);
   };
 
+  const ConstLeafNodeDepthFirstIterator
+  leaf_depth_end() const
+  {
+    return ConstLeafNodeDepthFirstIterator(this, 0, nullptr);
+  };
+
   // Octree depth-first iterators
   using DepthFirstIterator = OctreeDepthFirstIterator<OctreeT>;
-  using ConstDepthFirstIterator = const OctreeDepthFirstIterator<OctreeT>;
+  using ConstDepthFirstIterator = OctreeDepthFirstIterator<const OctreeT>;
 
   DepthFirstIterator
   depth_begin(uindex_t max_depth_arg = 0u)
@@ -156,15 +187,28 @@ public:
                               max_depth_arg ? max_depth_arg : this->octree_depth_);
   };
 
+  ConstDepthFirstIterator
+  depth_begin(uindex_t max_depth_arg = 0u) const
+  {
+    return ConstDepthFirstIterator(this,
+                                   max_depth_arg ? max_depth_arg : this->octree_depth_);
+  };
+
   const DepthFirstIterator
   depth_end()
   {
     return DepthFirstIterator(this, 0, nullptr);
   };
 
+  const ConstDepthFirstIterator
+  depth_end() const
+  {
+    return ConstDepthFirstIterator(this, 0, nullptr);
+  };
+
   // Octree breadth-first iterators
   using BreadthFirstIterator = OctreeBreadthFirstIterator<OctreeT>;
-  using ConstBreadthFirstIterator = const OctreeBreadthFirstIterator<OctreeT>;
+  using ConstBreadthFirstIterator = OctreeBreadthFirstIterator<const OctreeT>;
 
   BreadthFirstIterator
   breadth_begin(uindex_t max_depth_arg = 0u)
@@ -173,20 +217,39 @@ public:
                                 max_depth_arg ? max_depth_arg : this->octree_depth_);
   };
 
+  ConstBreadthFirstIterator
+  breadth_begin(uindex_t max_depth_arg = 0u) const
+  {
+    return ConstBreadthFirstIterator(
+        this, max_depth_arg ? max_depth_arg : this->octree_depth_);
+  };
+
   const BreadthFirstIterator
   breadth_end()
   {
     return BreadthFirstIterator(this, 0, nullptr);
   };
 
+  const ConstBreadthFirstIterator
+  breadth_end() const
+  {
+    return ConstBreadthFirstIterator(this, 0, nullptr);
+  };
+
   // Octree breadth iterators at a given depth
   using FixedDepthIterator = OctreeFixedDepthIterator<OctreeT>;
-  using ConstFixedDepthIterator = const OctreeFixedDepthIterator<OctreeT>;
+  using ConstFixedDepthIterator = OctreeFixedDepthIterator<const OctreeT>;
 
   FixedDepthIterator
   fixed_depth_begin(uindex_t fixed_depth_arg = 0u)
   {
     return FixedDepthIterator(this, fixed_depth_arg);
+  };
+
+  ConstFixedDepthIterator
+  fixed_depth_begin(uindex_t fixed_depth_arg = 0u) const
+  {
+    return ConstFixedDepthIterator(this, fixed_depth_arg);
   };
 
   const FixedDepthIterator
@@ -195,10 +258,16 @@ public:
     return FixedDepthIterator(this, 0, nullptr);
   };
 
+  const ConstFixedDepthIterator
+  fixed_depth_end() const
+  {
+    return ConstFixedDepthIterator(this, 0, nullptr);
+  };
+
   // Octree leaf node iterators
   using LeafNodeBreadthFirstIterator = OctreeLeafNodeBreadthFirstIterator<OctreeT>;
   using ConstLeafNodeBreadthFirstIterator =
-      const OctreeLeafNodeBreadthFirstIterator<OctreeT>;
+      OctreeLeafNodeBreadthFirstIterator<const OctreeT>;
 
   LeafNodeBreadthFirstIterator
   leaf_breadth_begin(uindex_t max_depth_arg = 0u)
@@ -207,10 +276,23 @@ public:
         this, max_depth_arg ? max_depth_arg : this->octree_depth_);
   };
 
+  ConstLeafNodeBreadthFirstIterator
+  leaf_breadth_begin(uindex_t max_depth_arg = 0u) const
+  {
+    return ConstLeafNodeBreadthFirstIterator(
+        this, max_depth_arg ? max_depth_arg : this->octree_depth_);
+  };
+
   const LeafNodeBreadthFirstIterator
   leaf_breadth_end()
   {
     return LeafNodeBreadthFirstIterator(this, 0, nullptr);
+  };
+
+  const ConstLeafNodeBreadthFirstIterator
+  leaf_breadth_end() const
+  {
+    return ConstLeafNodeBreadthFirstIterator(this, 0, nullptr);
   };
 
   /** \brief Empty constructor. */

--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -126,6 +126,12 @@ public:
     return ConstIterator(this, max_depth_arg ? max_depth_arg : this->octree_depth_);
   };
 
+  ConstIterator
+  cbegin(uindex_t max_depth_arg = 0u) const
+  {
+    return ConstIterator(this, max_depth_arg ? max_depth_arg : this->octree_depth_);
+  };
+
   const Iterator
   end()
   {
@@ -134,6 +140,12 @@ public:
 
   const ConstIterator
   end() const
+  {
+    return ConstIterator(this, 0, nullptr);
+  };
+
+  const ConstIterator
+  cend() const
   {
     return ConstIterator(this, 0, nullptr);
   };

--- a/test/octree/test_octree_iterator.cpp
+++ b/test/octree/test_octree_iterator.cpp
@@ -205,6 +205,7 @@ struct OctreeBaseBeginEndIteratorsTest : public testing::Test
 
   // Members
   OctreeT oct_a_, oct_b_;
+  const OctreeT const_oct_a_, const_oct_b_;
 };
 
 TEST_F (OctreeBaseBeginEndIteratorsTest, Begin)
@@ -1102,10 +1103,10 @@ TEST_F (OctreeBaseIteratorsPrePostTest, ConstDefaultIterator)
   // Default initialization
   ConstIteratorT it_a_pre;
   ConstIteratorT it_a_post;
-  ConstIteratorT it_a_end = oct_a_.end ();
+  ConstIteratorT it_a_end = const_oct_a_.end ();
 
-  // Iterate over every node of the octree oct_a_.
-  for (it_a_pre = oct_a_.begin (), it_a_post = oct_a_.begin ();
+  // Iterate over every node of the octree const_oct_a_.
+  for (it_a_pre = const_oct_a_.begin (), it_a_post = const_oct_a_.begin ();
        ((it_a_pre != it_a_end) && (it_a_post != it_a_end)); )
   {
     EXPECT_EQ (it_a_pre, it_a_post++);
@@ -1124,10 +1125,10 @@ TEST_F (OctreeBaseIteratorsPrePostTest, ConstLeafNodeDepthFirstIterator)
   // Default initialization
   ConstIteratorT it_a_pre;
   ConstIteratorT it_a_post;
-  ConstIteratorT it_a_end = oct_a_.leaf_depth_end ();
+  ConstIteratorT it_a_end = const_oct_a_.leaf_depth_end ();
 
-  // Iterate over every node of the octree oct_a_.
-  for (it_a_pre = oct_a_.leaf_depth_begin (), it_a_post = oct_a_.leaf_depth_begin ();
+  // Iterate over every node of the octree const_oct_a_.
+  for (it_a_pre = const_oct_a_.leaf_depth_begin (), it_a_post = const_oct_a_.leaf_depth_begin ();
        ((it_a_pre != it_a_end) && (it_a_post != it_a_end)); )
   {
     EXPECT_EQ (it_a_pre, it_a_post++);
@@ -1146,10 +1147,10 @@ TEST_F (OctreeBaseIteratorsPrePostTest, ConstDepthFirstIterator)
   // Default initialization
   ConstIteratorT it_a_pre;
   ConstIteratorT it_a_post;
-  ConstIteratorT it_a_end = oct_a_.depth_end ();
+  ConstIteratorT it_a_end = const_oct_a_.depth_end ();
 
-  // Iterate over every node of the octree oct_a_.
-  for (it_a_pre = oct_a_.depth_begin (), it_a_post = oct_a_.depth_begin ();
+  // Iterate over every node of the octree const_oct_a_.
+  for (it_a_pre = const_oct_a_.depth_begin (), it_a_post = const_oct_a_.depth_begin ();
        ((it_a_pre != it_a_end) && (it_a_post != it_a_end)); )
   {
     EXPECT_EQ (it_a_pre, it_a_post++);
@@ -1168,10 +1169,10 @@ TEST_F (OctreeBaseIteratorsPrePostTest, ConstBreadthFirstIterator)
   // Default initialization
   ConstIteratorT it_a_pre;
   ConstIteratorT it_a_post;
-  ConstIteratorT it_a_end = oct_a_.breadth_end ();
+  ConstIteratorT it_a_end = const_oct_a_.breadth_end ();
 
-  // Iterate over every node of the octree oct_a_.
-  for (it_a_pre = oct_a_.breadth_begin (), it_a_post = oct_a_.breadth_begin ();
+  // Iterate over every node of the octree const_oct_a_.
+  for (it_a_pre = const_oct_a_.breadth_begin (), it_a_post = const_oct_a_.breadth_begin ();
        ((it_a_pre != it_a_end) && (it_a_post != it_a_end)); )
   {
     EXPECT_EQ (it_a_pre, it_a_post++);
@@ -1190,16 +1191,16 @@ TEST_F (OctreeBaseIteratorsPrePostTest, ConstFixedDepthIterator)
   // Default initialization
   ConstIteratorT it_a_pre;
   ConstIteratorT it_a_post;
-  ConstIteratorT it_a_end = oct_a_.fixed_depth_end ();
+  ConstIteratorT it_a_end = const_oct_a_.fixed_depth_end ();
 
-  for (unsigned int depth = 0; depth <= oct_a_.getTreeDepth (); ++depth)
+  for (unsigned int depth = 0; depth <= const_oct_a_.getTreeDepth (); ++depth)
   {
-    auto it_a_pre = oct_a_.fixed_depth_begin (depth);
-    auto it_a_post = oct_a_.fixed_depth_begin (depth);
+    auto it_a_pre = const_oct_a_.fixed_depth_begin (depth);
+    auto it_a_post = const_oct_a_.fixed_depth_begin (depth);
 
 
-    // Iterate over every node at a given depth of the octree oct_a_.
-    for (it_a_pre = oct_a_.fixed_depth_begin (depth), it_a_post = oct_a_.fixed_depth_begin (depth);
+    // Iterate over every node at a given depth of the octree const_oct_a_.
+    for (it_a_pre = const_oct_a_.fixed_depth_begin (depth), it_a_post = const_oct_a_.fixed_depth_begin (depth);
          ((it_a_pre != it_a_end) && (it_a_post != it_a_end)); )
     {
       EXPECT_EQ (it_a_pre, it_a_post++);
@@ -1219,10 +1220,10 @@ TEST_F (OctreeBaseIteratorsPrePostTest, ConstLeafNodeBreadthFirstIterator)
   // Default initialization
   ConstIteratorT it_a_pre;
   ConstIteratorT it_a_post;
-  ConstIteratorT it_a_end = oct_a_.leaf_breadth_end ();
+  ConstIteratorT it_a_end = const_oct_a_.leaf_breadth_end ();
 
-  // Iterate over every node of the octree oct_a_.
-  for (it_a_pre = oct_a_.leaf_breadth_begin (), it_a_post = oct_a_.leaf_breadth_begin ();
+  // Iterate over every node of the octree const_oct_a_.
+  for (it_a_pre = const_oct_a_.leaf_breadth_begin (), it_a_post = const_oct_a_.leaf_breadth_begin ();
        ((it_a_pre != it_a_end) && (it_a_post != it_a_end)); )
   {
     EXPECT_EQ (it_a_pre, it_a_post++);

--- a/test/octree/test_octree_iterator.cpp
+++ b/test/octree/test_octree_iterator.cpp
@@ -1094,6 +1094,145 @@ TEST_F (OctreeBaseIteratorsPrePostTest, LeafNodeBreadthFirstIterator)
   EXPECT_EQ (it_a_post, it_a_end);
 }
 
+TEST_F (OctreeBaseIteratorsPrePostTest, ConstDefaultIterator)
+{
+  // Useful types
+  using ConstIteratorT = OctreeT::ConstIterator;
+
+  // Default initialization
+  ConstIteratorT it_a_pre;
+  ConstIteratorT it_a_post;
+  ConstIteratorT it_a_end = oct_a_.end ();
+
+  // Iterate over every node of the octree oct_a_.
+  for (it_a_pre = oct_a_.begin (), it_a_post = oct_a_.begin ();
+       ((it_a_pre != it_a_end) && (it_a_post != it_a_end)); )
+  {
+    EXPECT_EQ (it_a_pre, it_a_post++);
+    EXPECT_EQ (++it_a_pre, it_a_post);
+  }
+
+  EXPECT_EQ (it_a_pre, it_a_end);
+  EXPECT_EQ (it_a_post, it_a_end);
+}
+
+TEST_F (OctreeBaseIteratorsPrePostTest, ConstLeafNodeDepthFirstIterator)
+{
+  // Useful types
+  using ConstIteratorT = OctreeT::ConstLeafNodeDepthFirstIterator;
+
+  // Default initialization
+  ConstIteratorT it_a_pre;
+  ConstIteratorT it_a_post;
+  ConstIteratorT it_a_end = oct_a_.leaf_depth_end ();
+
+  // Iterate over every node of the octree oct_a_.
+  for (it_a_pre = oct_a_.leaf_depth_begin (), it_a_post = oct_a_.leaf_depth_begin ();
+       ((it_a_pre != it_a_end) && (it_a_post != it_a_end)); )
+  {
+    EXPECT_EQ (it_a_pre, it_a_post++);
+    EXPECT_EQ (++it_a_pre, it_a_post);
+  }
+
+  EXPECT_EQ (it_a_pre, it_a_end);
+  EXPECT_EQ (it_a_post, it_a_end);
+}
+
+TEST_F (OctreeBaseIteratorsPrePostTest, ConstDepthFirstIterator)
+{
+  // Useful types
+  using ConstIteratorT = OctreeT::ConstDepthFirstIterator;
+
+  // Default initialization
+  ConstIteratorT it_a_pre;
+  ConstIteratorT it_a_post;
+  ConstIteratorT it_a_end = oct_a_.depth_end ();
+
+  // Iterate over every node of the octree oct_a_.
+  for (it_a_pre = oct_a_.depth_begin (), it_a_post = oct_a_.depth_begin ();
+       ((it_a_pre != it_a_end) && (it_a_post != it_a_end)); )
+  {
+    EXPECT_EQ (it_a_pre, it_a_post++);
+    EXPECT_EQ (++it_a_pre, it_a_post);
+  }
+
+  EXPECT_EQ (it_a_pre, it_a_end);
+  EXPECT_EQ (it_a_post, it_a_end);
+}
+
+TEST_F (OctreeBaseIteratorsPrePostTest, ConstBreadthFirstIterator)
+{
+  // Useful types
+  using ConstIteratorT = OctreeT::ConstBreadthFirstIterator;
+
+  // Default initialization
+  ConstIteratorT it_a_pre;
+  ConstIteratorT it_a_post;
+  ConstIteratorT it_a_end = oct_a_.breadth_end ();
+
+  // Iterate over every node of the octree oct_a_.
+  for (it_a_pre = oct_a_.breadth_begin (), it_a_post = oct_a_.breadth_begin ();
+       ((it_a_pre != it_a_end) && (it_a_post != it_a_end)); )
+  {
+    EXPECT_EQ (it_a_pre, it_a_post++);
+    EXPECT_EQ (++it_a_pre, it_a_post);
+  }
+
+  EXPECT_EQ (it_a_pre, it_a_end);
+  EXPECT_EQ (it_a_post, it_a_end);
+}
+
+TEST_F (OctreeBaseIteratorsPrePostTest, ConstFixedDepthIterator)
+{
+  // Useful types
+  using ConstIteratorT = OctreeT::ConstFixedDepthIterator;
+
+  // Default initialization
+  ConstIteratorT it_a_pre;
+  ConstIteratorT it_a_post;
+  ConstIteratorT it_a_end = oct_a_.fixed_depth_end ();
+
+  for (unsigned int depth = 0; depth <= oct_a_.getTreeDepth (); ++depth)
+  {
+    auto it_a_pre = oct_a_.fixed_depth_begin (depth);
+    auto it_a_post = oct_a_.fixed_depth_begin (depth);
+
+
+    // Iterate over every node at a given depth of the octree oct_a_.
+    for (it_a_pre = oct_a_.fixed_depth_begin (depth), it_a_post = oct_a_.fixed_depth_begin (depth);
+         ((it_a_pre != it_a_end) && (it_a_post != it_a_end)); )
+    {
+      EXPECT_EQ (it_a_pre, it_a_post++);
+      EXPECT_EQ (++it_a_pre, it_a_post);
+    }
+
+    EXPECT_EQ (it_a_pre, it_a_end);
+    EXPECT_EQ (it_a_post, it_a_end);
+  }
+}
+
+TEST_F (OctreeBaseIteratorsPrePostTest, ConstLeafNodeBreadthFirstIterator)
+{
+  // Useful types
+  using ConstIteratorT = OctreeT::ConstLeafNodeBreadthFirstIterator;
+
+  // Default initialization
+  ConstIteratorT it_a_pre;
+  ConstIteratorT it_a_post;
+  ConstIteratorT it_a_end = oct_a_.leaf_breadth_end ();
+
+  // Iterate over every node of the octree oct_a_.
+  for (it_a_pre = oct_a_.leaf_breadth_begin (), it_a_post = oct_a_.leaf_breadth_begin ();
+       ((it_a_pre != it_a_end) && (it_a_post != it_a_end)); )
+  {
+    EXPECT_EQ (it_a_pre, it_a_post++);
+    EXPECT_EQ (++it_a_pre, it_a_post);
+  }
+
+  EXPECT_EQ (it_a_pre, it_a_end);
+  EXPECT_EQ (it_a_post, it_a_end);
+}
+
 ////////////////////////////////////////////////////////
 //     OctreePointCloudAdjacency Begin/End Iterator Construction
 ////////////////////////////////////////////////////////


### PR DESCRIPTION
Original `using ConstIterator = const OctreeDepthFirstIterator<OctreeT>;` indicates that `ConstIterator` can't be incremented, `OctreeDepthFirstIterator<const OctreeT>` seems more reasonable. From the added test, it can be seen that original definition of `ConstIterator` is not compilable.