### PR TITLE
Remove Ubuntu 21.10 from Docker build, as it is end of life

### DIFF
--- a/.ci/azure-pipelines/env.yml
+++ b/.ci/azure-pipelines/env.yml
@@ -56,6 +56,11 @@ jobs:
         UBUNTU_VERSION: 22.04
         VTK_VERSION: 9
         TAG: 22.04
+      Ubuntu 22.10:
+        UBUNTU_VERSION: 22.10
+        USE_LATEST_CMAKE: true
+        VTK_VERSION: 9
+        TAG: 22.10
   steps:
   - script: |
       dockerBuildArgs="" ; \

--- a/.ci/azure-pipelines/env.yml
+++ b/.ci/azure-pipelines/env.yml
@@ -51,12 +51,7 @@ jobs:
         UBUNTU_VERSION: 20.04
         VTK_VERSION: 7
         TAG: 20.04
-      Ubuntu 21.10:
-        UBUNTU_VERSION: 21.10
-        USE_LATEST_CMAKE: true
-        VTK_VERSION: 9
-        TAG: 21.10
-        # Test the latest LTS version of Ubuntu
+      # Test the latest LTS version of Ubuntu
       Ubuntu 22.04:
         UBUNTU_VERSION: 22.04
         VTK_VERSION: 9

--- a/.dev/docker/env/Dockerfile
+++ b/.dev/docker/env/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update \
       build-essential \
       clang \
       clang-tidy \
+      libbenchmark-dev \
       libblas-dev \
       libboost-date-time-dev \
       libboost-filesystem-dev \
@@ -61,18 +62,6 @@ RUN apt-get update \
        apt-get -V install -y nvidia-cuda-toolkit g++-6 ; \
      else \
        apt-get -V install -y nvidia-cuda-toolkit-gcc ; \
-     fi \
- && if [ "$(lsb_release -sr)" = "21.10" ]; then \
-       wget -qO- https://github.com/google/benchmark/archive/refs/tags/v1.6.1.tar.gz | tar xz \
-       && cd benchmark-1.6.1 \
-       && mkdir build \
-       && cd build \
-       && cmake .. -DCMAKE_BUILD_TYPE=Release -DBENCHMARK_ENABLE_GTEST_TESTS=OFF -DBENCHMARK_ENABLE_TESTING=OFF \
-       && make -j$(nproc) install \
-       && cd ../.. \
-       && rm -rf benchmark-1.6.1 ; \
-     else \
-       apt-get -V install -y libbenchmark-dev ; \
      fi \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Just saw that a recent docker build failed with:
```
E: The repository 'http://archive.ubuntu.com/ubuntu impish Release' does not have a Release file.
```

Reason: Ubuntu 21.10 is EOL since [July 14, 2022](https://wiki.ubuntu.com/Releases), therefore removed it.