### PR TITLE
Fix HarrisKeypoint3D::refineCorners

### DIFF
--- a/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
@@ -503,13 +503,12 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::refineCorners (PointCloudOu
 {
   Eigen::Matrix3f nnT;
   Eigen::Matrix3f NNT;
-  Eigen::Matrix3f NNTInv;
   Eigen::Vector3f NNTp;
   const unsigned max_iterations = 10;
 #pragma omp parallel for \
   default(none) \
   shared(corners) \
-  firstprivate(nnT, NNT, NNTInv, NNTp) \
+  firstprivate(nnT, NNT, NNTp) \
   num_threads(threads_)
   for (int cIdx = 0; cIdx < static_cast<int> (corners.size ()); ++cIdx)
   {
@@ -533,8 +532,9 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::refineCorners (PointCloudOu
         NNT += nnT;
         NNTp += nnT * (*surface_)[index].getVector3fMap ();
       }
-      if (invert3x3SymMatrix (NNT, NNTInv) != 0)
-        corners[cIdx].getVector3fMap () = NNTInv * NNTp;
+      const Eigen::LDLT<Eigen::Matrix3f> ldlt(NNT);
+      if (ldlt.rcond() > 1e-4)
+        corners[cIdx].getVector3fMap () = ldlt.solve(NNTp);
 
       const auto diff = (corners[cIdx].getVector3fMap () - corner.getVector3fMap()).squaredNorm ();
       if (diff <= 1e-6) {


### PR DESCRIPTION
Fixes https://github.com/PointCloudLibrary/pcl/issues/3503
Solving a system of linear equations by computing a matrix inverse is not a good idea, both in terms of speed and accuracy. Eigen's LDLT decomposition is fast and precise (NNT is positive definite so we can use LDLT). Also, the condition number (rcond) is a better check for instability than the determinant (returned by invert3x3SymMatrix)