### PR TITLE
Fix wrong implemented CUDA function `RGB& operator-(RGB &rhs)`

### DIFF
--- a/cuda/common/include/pcl/cuda/common/point_type_rgb.h
+++ b/cuda/common/include/pcl/cuda/common/point_type_rgb.h
@@ -69,13 +69,11 @@ namespace cuda
       return (r == rhs.r && g == rhs.g && b == rhs.b && alpha == rhs.alpha);
     }
 
-    inline __host__ __device__ RGB& operator - (RGB &rhs)
+    inline __host__ __device__ RGB operator - (RGB &rhs)
     {
-      r = -r;
-      g = -g;
-      b = -b;
-      alpha = -alpha;
-      return (*this);
+      RGB res = *this;
+      res -= rhs;
+      return (res);
     }
 
     inline __host__ __device__ RGB& operator += (const RGB &rhs)


### PR DESCRIPTION
Fix wrong implemented CUDA function `RGB& operator-(RGB &rhs)` as this inverted the stored value instead of subtracting the passed value. ~~As there is no `operator+` defined and the implementation is completely wrong I believe no one is using it, so we could skip the deprecation circle here.~~

Just found this due to a warning `unused parameter 'rhs'`.