### PR TITLE
Update minimum required Eigen version to 3.3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -313,7 +313,7 @@ endif()
 find_package(Threads REQUIRED)
 
 # Eigen (required)
-find_package(Eigen 3.1 REQUIRED)
+find_package(Eigen 3.3 REQUIRED)
 include_directories(SYSTEM ${EIGEN_INCLUDE_DIRS})
 
 # FLANN (required)

--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -118,7 +118,7 @@ macro(find_eigen)
   elseif(NOT EIGEN_ROOT)
     get_filename_component(EIGEN_ROOT "@EIGEN_INCLUDE_DIRS@" ABSOLUTE)
   endif()
-  find_package(Eigen 3.1)
+  find_package(Eigen 3.3)
 endmacro()
 
 #remove this as soon as qhull is shipped with FindQhull.cmake


### PR DESCRIPTION
PCL uses Eigen::Index, which is available since Eigen 3.3 (https://eigen.tuxfamily.org/index.php?title=3.3#Index_typedef)
Eigen 3.3 was released in Nov 2016