### PR TITLE
Add modernize-use-auto to clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,3 +1,3 @@
 ---
-Checks: '-*,modernize-deprecated-headers,modernize-redundant-void-arg,modernize-replace-random-shuffle,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-nullptr,modernize-use-override,modernize-use-using'
-WarningsAsErrors: '-*,modernize-deprecated-headers,modernize-redundant-void-arg,modernize-replace-random-shuffle,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-nullptr,modernize-use-override,modernize-use-using'
+Checks: '-*,modernize-use-auto,modernize-deprecated-headers,modernize-redundant-void-arg,modernize-replace-random-shuffle,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-nullptr,modernize-use-override,modernize-use-using'
+WarningsAsErrors: '-*,modernize-use-auto,modernize-deprecated-headers,modernize-redundant-void-arg,modernize-replace-random-shuffle,modernize-use-equals-default,modernize-use-equals-delete,modernize-use-nullptr,modernize-use-override,modernize-use-using'

--- a/2d/include/pcl/2d/impl/kernel.hpp
+++ b/2d/include/pcl/2d/impl/kernel.hpp
@@ -132,7 +132,7 @@ kernel<PointT>::loGKernel(pcl::PointCloud<PointT>& kernel)
     for (int j = 0; j < kernel_size_; j++) {
       int iks = (i - kernel_size_ / 2);
       int jks = (j - kernel_size_ / 2);
-      float temp = float(double(iks * iks + jks * jks) / sigma_sqr);
+      auto temp = float(double(iks * iks + jks * jks) / sigma_sqr);
       kernel(j, i).intensity = (1.0f - temp) * std::exp(-temp);
       sum += kernel(j, i).intensity;
     }

--- a/common/include/pcl/common/impl/spring.hpp
+++ b/common/include/pcl/common/impl/spring.hpp
@@ -124,7 +124,7 @@ duplicateColumns (const PointCloud<PointT>& input, PointCloud<PointT>& output,
   for (std::size_t j = 0; j < old_height; ++j)
     for(std::size_t i = 0; i < amount; ++i)
     {
-      typename PointCloud<PointT>::iterator start = output.begin () + (j * new_width);
+      auto start = output.begin () + (j * new_width);
       output.insert (start, *start);
       start = output.begin () + (j * new_width) + old_width + i;
       output.insert (start, *start);
@@ -182,7 +182,7 @@ mirrorColumns (const PointCloud<PointT>& input, PointCloud<PointT>& output,
   for (std::size_t j = 0; j < old_height; ++j)
     for(std::size_t i = 0; i < amount; ++i)
     {
-      typename PointCloud<PointT>::iterator start = output.begin () + (j * new_width);
+      auto start = output.begin () + (j * new_width);
       output.insert (start, *(start + 2*i));
       start = output.begin () + (j * new_width) + old_width + 2*i;
       output.insert (start+1, *(start - 2*i));
@@ -254,7 +254,7 @@ deleteCols (const PointCloud<PointT>& input, PointCloud<PointT>& output,
   std::uint32_t new_width = old_width - 2 * amount;
   for(std::size_t j = 0; j < old_height; j++)
   {
-    typename PointCloud<PointT>::iterator start = output.begin () + j * new_width;
+    auto start = output.begin () + j * new_width;
     output.erase (start, start + amount);
     start = output.begin () + (j+1) * new_width;
     output.erase (start, start + amount);

--- a/common/include/pcl/point_representation.h
+++ b/common/include/pcl/point_representation.h
@@ -107,7 +107,7 @@ namespace pcl
 
         if (trivial_)
         {
-          const float* temp = reinterpret_cast<const float*>(&p);
+          const auto* temp = reinterpret_cast<const float*>(&p);
 
           for (int i = 0; i < nr_dimensions_; ++i)
           {
@@ -120,7 +120,7 @@ namespace pcl
         }
         else
         {
-          float *temp = new float[nr_dimensions_];
+          auto *temp = new float[nr_dimensions_];
           copyToFloatArray (p, temp);
 
           for (int i = 0; i < nr_dimensions_; ++i)
@@ -143,7 +143,7 @@ namespace pcl
       template <typename OutputType> void
       vectorize (const PointT &p, OutputType &out) const
       {
-        float *temp = new float[nr_dimensions_];
+        auto *temp = new float[nr_dimensions_];
         copyToFloatArray (p, temp);
         if (alpha_.empty ())
         {
@@ -208,7 +208,7 @@ namespace pcl
       copyToFloatArray (const PointDefault &p, float * out) const override
       {
         // If point type is unknown, treat it as a struct/array of floats
-        const float* ptr = reinterpret_cast<const float*> (&p);
+        const auto* ptr = reinterpret_cast<const float*> (&p);
         std::copy_n(ptr, nr_dimensions_, out);
       }
   };
@@ -274,7 +274,7 @@ namespace pcl
           const std::uint8_t * data_ptr = reinterpret_cast<const std::uint8_t *> (&p1) +
             pcl::traits::offset<PointDefault, Key>::value;
           int nr_dims = NrDims;
-          const FieldT * array = reinterpret_cast<const FieldT *> (data_ptr);
+          const auto * array = reinterpret_cast<const FieldT *> (data_ptr);
           for (int i = 0; i < nr_dims; ++i)
           {
             p2[f_idx++] = array[i];

--- a/common/include/pcl/point_types_conversion.h
+++ b/common/include/pcl/point_types_conversion.h
@@ -120,7 +120,7 @@ namespace pcl
       return;
     }
 
-    const float diff = static_cast <float> (max - min);
+    const auto diff = static_cast <float> (max - min);
     out.s = diff / static_cast <float> (max);
 
     if (min == max) // diff == 0 -> division by zero
@@ -209,7 +209,7 @@ namespace pcl
       return;
     }
 
-    const float diff = static_cast <float> (max - min);
+    const auto diff = static_cast <float> (max - min);
     out.s = diff / static_cast <float> (max);
 
     if (min == max) // diff == 0 -> division by zero

--- a/common/include/pcl/range_image/impl/range_image.hpp
+++ b/common/include/pcl/range_image/impl/range_image.hpp
@@ -632,7 +632,7 @@ RangeImage::getImpactAngle (const PointWithRange& point1, const PointWithRange& 
   
   float r1 = (std::min) (point1.range, point2.range),
         r2 = (std::max) (point1.range, point2.range);
-  float impact_angle = static_cast<float> (0.5f * M_PI);
+  auto impact_angle = static_cast<float> (0.5f * M_PI);
   
   if (std::isinf (r2)) 
   {

--- a/common/src/feature_histogram.cpp
+++ b/common/src/feature_histogram.cpp
@@ -100,7 +100,7 @@ pcl::FeatureHistogram::addValue (float value)
     ++number_of_elements_;
 
     // Increase the bin.
-    std::size_t bin_number = static_cast<std::size_t> ((value - threshold_min_) / step_);
+    auto bin_number = static_cast<std::size_t> ((value - threshold_min_) / step_);
     ++histogram_[bin_number];
   }
 }

--- a/common/src/parse.cpp
+++ b/common/src/parse.cpp
@@ -544,7 +544,7 @@ pcl::console::parse_multiple_arguments (int argc, const char * const * argv, con
     // Search for the string
     if ((strcmp (argv[i], str) == 0) && (++i < argc))
     {
-      float val = static_cast<float> (atof (argv[i]));
+      auto val = static_cast<float> (atof (argv[i]));
       values.push_back (val);
     }
   }

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -279,7 +279,7 @@ float*
 RangeImage::getRangesArray () const 
 {
   int arraySize = width * height;
-  float* ranges = new float[arraySize];
+  auto* ranges = new float[arraySize];
   for (int i=0; i<arraySize; ++i)
     ranges[i] = points[i].range;
   return ranges;
@@ -465,7 +465,7 @@ RangeImage::getInterpolatedSurfaceProjection (const Eigen::Affine3f& pose, int p
   Eigen::Affine3f inverse_pose = pose.inverse (Eigen::Isometry);
   
   int no_of_pixels = pixel_size*pixel_size;
-  float* surface_patch = new float[no_of_pixels];
+  auto* surface_patch = new float[no_of_pixels];
   SET_ARRAY (surface_patch, -std::numeric_limits<float>::infinity (), no_of_pixels);
   
   Eigen::Vector3f position = inverse_pose.translation ();
@@ -754,7 +754,7 @@ RangeImage::getImpactAngleImageBasedOnLocalNormals (int radius) const
 {
   MEASURE_FUNCTION_TIME;
   int size = width*height;
-  float* impact_angle_image = new float[size];
+  auto* impact_angle_image = new float[size];
   for (int y=0; y<int (height); ++y)
   {
     for (int x=0; x<int (width); ++x)

--- a/examples/features/example_difference_of_normals.cpp
+++ b/examples/features/example_difference_of_normals.cpp
@@ -92,14 +92,14 @@ int main (int argc, char *argv[])
 
     // Create downsampled point cloud for DoN NN search with small scale
     small_cloud_downsampled = PointCloud<PointT>::Ptr(new pcl::PointCloud<PointT>);
-    float smalldownsample = static_cast<float> (scale1 / decimation);
+    auto smalldownsample = static_cast<float> (scale1 / decimation);
     sor.setLeafSize (smalldownsample, smalldownsample, smalldownsample);
     sor.filter (*small_cloud_downsampled);
     std::cout << "Using leaf size of " << smalldownsample << " for small scale, " << small_cloud_downsampled->size() << " points" << std::endl;
 
     // Create downsampled point cloud for DoN NN search with large scale
     large_cloud_downsampled = PointCloud<PointT>::Ptr(new pcl::PointCloud<PointT>);
-    const float largedownsample = float (scale2/decimation);
+    const auto largedownsample = float (scale2/decimation);
     sor.setLeafSize (largedownsample, largedownsample, largedownsample);
     sor.filter (*large_cloud_downsampled);
     std::cout << "Using leaf size of " << largedownsample << " for large scale, " << large_cloud_downsampled->size() << " points" << std::endl;

--- a/examples/segmentation/example_cpc_segmentation.cpp
+++ b/examples/segmentation/example_cpc_segmentation.cpp
@@ -455,7 +455,7 @@ CPCSegmentation Parameters: \n\
 
     // Create a polydata to store everything in
     vtkSmartPointer<vtkPolyData> polyData = vtkSmartPointer<vtkPolyData>::New ();
-    for (VertexIterator itr = vertex_iterator_range.first; itr != vertex_iterator_range.second; ++itr)
+    for (auto itr = vertex_iterator_range.first; itr != vertex_iterator_range.second; ++itr)
     {
       const std::uint32_t sv_label = sv_adjacency_list[*itr];
       std::pair<AdjacencyIterator, AdjacencyIterator> neighbors = boost::adjacent_vertices (*itr, sv_adjacency_list);

--- a/examples/segmentation/example_lccp_segmentation.cpp
+++ b/examples/segmentation/example_lccp_segmentation.cpp
@@ -379,7 +379,7 @@ LCCPSegmentation Parameters: \n\
     
     // Create a polydata to store everything in
     vtkSmartPointer<vtkPolyData> polyData = vtkSmartPointer<vtkPolyData>::New ();
-    for (VertexIterator itr = vertex_iterator_range.first; itr != vertex_iterator_range.second; ++itr)
+    for (auto itr = vertex_iterator_range.first; itr != vertex_iterator_range.second; ++itr)
     {
       const std::uint32_t sv_label = sv_adjacency_list[*itr];
       std::pair<AdjacencyIterator, AdjacencyIterator> neighbors = boost::adjacent_vertices (*itr, sv_adjacency_list);

--- a/features/include/pcl/features/impl/brisk_2d.hpp
+++ b/features/include/pcl/features/impl/brisk_2d.hpp
@@ -153,7 +153,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::generateKernel (
             pattern_iterator->sigma = static_cast<float> (sigma_scale * scale_list_[scale] * (double (radius_list[ring])) * sin (M_PI / double (number_list[ring])));
 
           // adapt the sizeList if necessary
-          const unsigned int size = static_cast<unsigned int> (std::ceil (((scale_list_[scale] * radius_list[ring]) + pattern_iterator->sigma)) + 1);
+          const auto size = static_cast<unsigned int> (std::ceil (((scale_list_[scale] * radius_list[ring]) + pattern_iterator->sigma)) + 1);
 
           if (size_list_[scale] < size)
             size_list_[scale] = size;
@@ -453,8 +453,8 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
   }
 
   // image size
-  const index_t width = static_cast<index_t>(input_cloud_->width);
-  const index_t height = static_cast<index_t>(input_cloud_->height);
+  const auto width = static_cast<index_t>(input_cloud_->width);
+  const auto height = static_cast<index_t>(input_cloud_->height);
 
   // destination for intensity data; will be forwarded to BRISK
   std::vector<unsigned char> image_data (width*height);
@@ -470,8 +470,8 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
   // initialize constants
   static const float lb_scalerange = std::log2 (scalerange_);
 
-  typename std::vector<KeypointT, Eigen::aligned_allocator<KeypointT> >::iterator beginning = keypoints_->points.begin ();
-  std::vector<int>::iterator beginningkscales = kscales.begin ();
+  auto beginning = keypoints_->points.begin ();
+  auto beginningkscales = kscales.begin ();
 
   static const float basic_size_06 = basic_size_ * 0.6f;
   unsigned int basicscale = 0;
@@ -636,7 +636,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
 #endif
 
     // now iterate through all the pairings
-    UINT32_ALIAS* ptr2 = reinterpret_cast<UINT32_ALIAS*> (ptr);
+    auto* ptr2 = reinterpret_cast<UINT32_ALIAS*> (ptr);
     const BriskShortPair* max = short_pairs_ + no_short_pairs_;
 
     for (BriskShortPair* iter = short_pairs_; iter < max; ++iter)

--- a/features/include/pcl/features/impl/integral_image2D.hpp
+++ b/features/include/pcl/features/impl/integral_image2D.hpp
@@ -177,7 +177,7 @@ IntegralImage2D<DataType, Dimension>::computeIntegralImages (
       {
         current_row [colIdx + 1] = previous_row [colIdx + 1] + current_row [colIdx] - previous_row [colIdx];
         count_current_row [colIdx + 1] = count_previous_row [colIdx + 1] + count_current_row [colIdx] - count_previous_row [colIdx];
-        const InputType* element = reinterpret_cast <const InputType*> (&data [valIdx]);
+        const auto* element = reinterpret_cast <const InputType*> (&data [valIdx]);
         if (std::isfinite (element->sum ()))
         {
           current_row [colIdx + 1] += element->template cast<typename IntegralImageTypeTraits<DataType>::IntegralType>();
@@ -208,7 +208,7 @@ IntegralImage2D<DataType, Dimension>::computeIntegralImages (
         so_current_row [colIdx + 1] = so_previous_row [colIdx + 1] + so_current_row [colIdx] - so_previous_row [colIdx];
         count_current_row [colIdx + 1] = count_previous_row [colIdx + 1] + count_current_row [colIdx] - count_previous_row [colIdx];
 
-        const InputType* element = reinterpret_cast <const InputType*> (&data [valIdx]);
+        const auto* element = reinterpret_cast <const InputType*> (&data [valIdx]);
         if (std::isfinite (element->sum ()))
         {
           current_row [colIdx + 1] += element->template cast<typename IntegralImageTypeTraits<DataType>::IntegralType>();

--- a/features/include/pcl/features/impl/integral_image_normal.hpp
+++ b/features/include/pcl/features/impl/integral_image_normal.hpp
@@ -109,7 +109,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::initSimple3DGradientMet
   // number of DataType entries per row (equal or bigger than element_stride number of elements per row)
   int row_stride     = element_stride * input_->width;
 
-  const float *data_ = reinterpret_cast<const float*> (&(*input_)[0]);
+  const auto *data_ = reinterpret_cast<const float*> (&(*input_)[0]);
 
   integral_image_XYZ_.setSecondOrderComputation (false);
   integral_image_XYZ_.setInput (data_, input_->width, input_->height, element_stride, row_stride);
@@ -127,7 +127,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::initCovarianceMatrixMet
   // number of DataType entries per row (equal or bigger than element_stride number of elements per row)
   int row_stride     = element_stride * input_->width;
 
-  const float *data_ = reinterpret_cast<const float*> (&(*input_)[0]);
+  const auto *data_ = reinterpret_cast<const float*> (&(*input_)[0]);
 
   integral_image_XYZ_.setSecondOrderComputation (true);
   integral_image_XYZ_.setInput (data_, input_->width, input_->height, element_stride, row_stride);
@@ -196,7 +196,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::initAverageDepthChangeM
   // number of DataType entries per row (equal or bigger than element_stride number of elements per row)
   int row_stride     = element_stride * input_->width;
 
-  const float *data_ = reinterpret_cast<const float*> (&(*input_)[0]);
+  const auto *data_ = reinterpret_cast<const float*> (&(*input_)[0]);
 
   // integral image over the z - value
   integral_image_depth_.setInput (&(data_[2]), input_->width, input_->height, element_stride, row_stride);
@@ -278,9 +278,9 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computePointNormal (
 
     normal_vector /= sqrt (normal_length);
 
-    float nx = static_cast<float> (normal_vector [0]);
-    float ny = static_cast<float> (normal_vector [1]);
-    float nz = static_cast<float> (normal_vector [2]);
+    auto nx = static_cast<float> (normal_vector [0]);
+    auto ny = static_cast<float> (normal_vector [1]);
+    auto nz = static_cast<float> (normal_vector [2]);
 
     flipNormalTowardsViewpoint ((*input_)[point_index], vpx_, vpy_, vpz_, nx, ny, nz);
 
@@ -307,10 +307,10 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computePointNormal (
       return;
     }
 
-    float mean_L_z = static_cast<float> (integral_image_depth_.getFirstOrderSum (pos_x - rect_width_2_, pos_y - rect_height_4_, rect_width_2_, rect_height_2_) / count_L_z);
-    float mean_R_z = static_cast<float> (integral_image_depth_.getFirstOrderSum (pos_x + 1            , pos_y - rect_height_4_, rect_width_2_, rect_height_2_) / count_R_z);
-    float mean_U_z = static_cast<float> (integral_image_depth_.getFirstOrderSum (pos_x - rect_width_4_, pos_y - rect_height_2_, rect_width_2_, rect_height_2_) / count_U_z);
-    float mean_D_z = static_cast<float> (integral_image_depth_.getFirstOrderSum (pos_x - rect_width_4_, pos_y + 1             , rect_width_2_, rect_height_2_) / count_D_z);
+    auto mean_L_z = static_cast<float> (integral_image_depth_.getFirstOrderSum (pos_x - rect_width_2_, pos_y - rect_height_4_, rect_width_2_, rect_height_2_) / count_L_z);
+    auto mean_R_z = static_cast<float> (integral_image_depth_.getFirstOrderSum (pos_x + 1            , pos_y - rect_height_4_, rect_width_2_, rect_height_2_) / count_R_z);
+    auto mean_U_z = static_cast<float> (integral_image_depth_.getFirstOrderSum (pos_x - rect_width_4_, pos_y - rect_height_2_, rect_width_2_, rect_height_2_) / count_U_z);
+    auto mean_D_z = static_cast<float> (integral_image_depth_.getFirstOrderSum (pos_x - rect_width_4_, pos_y + 1             , rect_width_2_, rect_height_2_) / count_D_z);
 
     PointInT pointL = (*input_)[point_index - rect_width_4_ - 1];
     PointInT pointR = (*input_)[point_index + rect_width_4_ + 1];
@@ -371,9 +371,9 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computePointNormal (
 
     normal_vector /= sqrt (normal_length);
 
-    float nx = static_cast<float> (normal_vector [0]);
-    float ny = static_cast<float> (normal_vector [1]);
-    float nz = static_cast<float> (normal_vector [2]);
+    auto nx = static_cast<float> (normal_vector [0]);
+    auto ny = static_cast<float> (normal_vector [1]);
+    auto nz = static_cast<float> (normal_vector [2]);
 
     flipNormalTowardsViewpoint ((*input_)[point_index], vpx_, vpy_, vpz_, nx, ny, nz);
     
@@ -585,9 +585,9 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computePointNormalMirro
 
     normal_vector /= sqrt (normal_length);
 
-    float nx = static_cast<float> (normal_vector [0]);
-    float ny = static_cast<float> (normal_vector [1]);
-    float nz = static_cast<float> (normal_vector [2]);
+    auto nx = static_cast<float> (normal_vector [0]);
+    auto ny = static_cast<float> (normal_vector [1]);
+    auto nz = static_cast<float> (normal_vector [2]);
 
     flipNormalTowardsViewpoint ((*input_)[point_index], vpx_, vpy_, vpz_, nx, ny, nz);
 
@@ -738,7 +738,7 @@ pcl::IntegralImageNormalEstimation<PointInT, PointOutT>::computeFeature (PointCl
   float bad_point = std::numeric_limits<float>::quiet_NaN ();
 
   // compute depth-change map
-  unsigned char * depthChangeMap = new unsigned char[input_->size ()];
+  auto * depthChangeMap = new unsigned char[input_->size ()];
   memset (depthChangeMap, 255, input_->size ());
 
   unsigned index = 0;

--- a/features/include/pcl/features/impl/moment_of_inertia_estimation.hpp
+++ b/features/include/pcl/features/impl/moment_of_inertia_estimation.hpp
@@ -232,7 +232,7 @@ pcl::MomentOfInertiaEstimation<PointT>::computeOBB ()
   obb_max_point_.y = std::numeric_limits <float>::min ();
   obb_max_point_.z = std::numeric_limits <float>::min ();
 
-  unsigned int number_of_points = static_cast <unsigned int> (indices_->size ());
+  auto number_of_points = static_cast <unsigned int> (indices_->size ());
   for (unsigned int i_point = 0; i_point < number_of_points; i_point++)
   {
     float x = ((*input_)[(*indices_)[i_point]].x - mean_value_ (0)) * major_axis_ (0) +
@@ -332,7 +332,7 @@ pcl::MomentOfInertiaEstimation<PointT>::computeMeanValue ()
   aabb_max_point_.y = -std::numeric_limits <float>::max ();
   aabb_max_point_.z = -std::numeric_limits <float>::max ();
 
-  unsigned int number_of_points = static_cast <unsigned int> (indices_->size ());
+  auto number_of_points = static_cast <unsigned int> (indices_->size ());
   for (unsigned int i_point = 0; i_point < number_of_points; i_point++)
   {
     mean_value_ (0) += (*input_)[(*indices_)[i_point]].x;
@@ -362,7 +362,7 @@ pcl::MomentOfInertiaEstimation<PointT>::computeCovarianceMatrix (Eigen::Matrix <
 {
   covariance_matrix.setZero ();
 
-  unsigned int number_of_points = static_cast <unsigned int> (indices_->size ());
+  auto number_of_points = static_cast <unsigned int> (indices_->size ());
   float factor = 1.0f / static_cast <float> ((number_of_points - 1 > 0)?(number_of_points - 1):1);
   for (unsigned int i_point = 0; i_point < number_of_points; i_point++)
   {
@@ -482,7 +482,7 @@ template <typename PointT> float
 pcl::MomentOfInertiaEstimation<PointT>::calculateMomentOfInertia (const Eigen::Vector3f& current_axis, const Eigen::Vector3f& mean_value) const
 {
   float moment_of_inertia = 0.0f;
-  unsigned int number_of_points = static_cast <unsigned int> (indices_->size ());
+  auto number_of_points = static_cast <unsigned int> (indices_->size ());
   for (unsigned int i_point = 0; i_point < number_of_points; i_point++)
   {
     Eigen::Vector3f vector;
@@ -506,7 +506,7 @@ pcl::MomentOfInertiaEstimation<PointT>::getProjectedCloud (const Eigen::Vector3f
 {
   const float D = - normal_vector.dot (point);
 
-  unsigned int number_of_points = static_cast <unsigned int> (indices_->size ());
+  auto number_of_points = static_cast <unsigned int> (indices_->size ());
   projected_cloud->points.resize (number_of_points, PointT ());
 
   for (unsigned int i_point = 0; i_point < number_of_points; i_point++)

--- a/features/include/pcl/features/impl/organized_edge_detection.hpp
+++ b/features/include/pcl/features/impl/organized_edge_detection.hpp
@@ -66,7 +66,7 @@ pcl::OrganizedEdgeBase<PointT, PointLT>::compute (pcl::PointCloud<PointLT>& labe
 template<typename PointT, typename PointLT> void
 pcl::OrganizedEdgeBase<PointT, PointLT>::assignLabelIndices (pcl::PointCloud<PointLT>& labels, std::vector<pcl::PointIndices>& label_indices) const
 {
-  const unsigned invalid_label = unsigned (0);
+  const auto invalid_label = unsigned (0);
   label_indices.resize (num_of_edgetype_);
   for (std::size_t idx = 0; idx < input_->size (); idx++)
   {

--- a/features/include/pcl/features/impl/our_cvfh.hpp
+++ b/features/include/pcl/features/impl/our_cvfh.hpp
@@ -296,10 +296,10 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::sgurf (Eigen::Vector3f & c
 
   //select the axis that could be disambiguated more easily
   float fx, fy;
-  float max_x = static_cast<float> (std::max (s_xplus, s_xminus));
-  float min_x = static_cast<float> (std::min (s_xplus, s_xminus));
-  float max_y = static_cast<float> (std::max (s_yplus, s_yminus));
-  float min_y = static_cast<float> (std::min (s_yplus, s_yminus));
+  auto max_x = static_cast<float> (std::max (s_xplus, s_xminus));
+  auto min_x = static_cast<float> (std::min (s_xplus, s_xminus));
+  auto max_y = static_cast<float> (std::max (s_yplus, s_yminus));
+  auto min_y = static_cast<float> (std::min (s_yplus, s_yminus));
 
   fx = (min_x / max_x);
   fy = (min_y / max_y);
@@ -422,7 +422,7 @@ pcl::OURCVFHEstimation<PointInT, PointNT, PointOutT>::computeRFAndShapeDistribut
       else
         hist_incr = 1.0f;
 
-      float * weights = new float[num_hists];
+      auto * weights = new float[num_hists];
       float sigma = 0.01f; //1cm
       float sigma_sq = sigma * sigma;
 

--- a/features/include/pcl/features/impl/pfh.hpp
+++ b/features/include/pcl/features/impl/pfh.hpp
@@ -99,7 +99,7 @@ pcl::PFHEstimation<PointInT, PointNT, PointOutT>::computePointPFHSignature (
         key = std::pair<int, int> (p1, p2);
 
         // Check to see if we already estimated this pair in the global hashmap
-        std::map<std::pair<int, int>, Eigen::Vector4f, std::less<>, Eigen::aligned_allocator<std::pair<const std::pair<int, int>, Eigen::Vector4f> > >::iterator fm_it = feature_map_.find (key);
+        auto fm_it = feature_map_.find (key);
         if (fm_it != feature_map_.end ())
         {
           pfh_tuple_ = fm_it->second;

--- a/features/include/pcl/features/impl/ppfrgb.hpp
+++ b/features/include/pcl/features/impl/ppfrgb.hpp
@@ -160,7 +160,7 @@ pcl::PPFRGBRegionEstimation<PointInT, PointNT, PointOutT>::computeFeature (Point
       }
     }
 
-    float normalization_factor = static_cast<float> (nn_indices.size ());
+    auto normalization_factor = static_cast<float> (nn_indices.size ());
     average_feature_nn.f1 /= normalization_factor;
     average_feature_nn.f2 /= normalization_factor;
     average_feature_nn.f3 /= normalization_factor;

--- a/features/include/pcl/features/impl/rops_estimation.hpp
+++ b/features/include/pcl/features/impl/rops_estimation.hpp
@@ -481,11 +481,11 @@ pcl::ROPSEstimation <PointInT, PointOutT>::getDistributionMatrix (const unsigned
     const float v_length = point (coord[projection][1]) - min[coord[projection][1]];
 
     const float u_ratio = u_length / u_bin_length;
-    unsigned int row = static_cast <unsigned int> (u_ratio);
+    auto row = static_cast <unsigned int> (u_ratio);
     if (row == number_of_bins_) row--;
 
     const float v_ratio = v_length / v_bin_length;
-    unsigned int col = static_cast <unsigned int> (v_ratio);
+    auto col = static_cast <unsigned int> (v_ratio);
     if (col == number_of_bins_) col--;
 
     matrix (row, col) += 1.0f;

--- a/features/include/pcl/features/impl/shot.hpp
+++ b/features/include/pcl/features/impl/shot.hpp
@@ -277,7 +277,7 @@ pcl::SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::interpolateSing
 
 
     unsigned char bit4 = ((yInFeatRef > 0) || ((yInFeatRef == 0.0) && (xInFeatRef < 0))) ? 1 : 0;
-    unsigned char bit3 = static_cast<unsigned char> (((xInFeatRef > 0) || ((xInFeatRef == 0.0) && (yInFeatRef > 0))) ? !bit4 : bit4);
+    auto bit3 = static_cast<unsigned char> (((xInFeatRef > 0) || ((xInFeatRef == 0.0) && (yInFeatRef > 0))) ? !bit4 : bit4);
 
     assert (bit3 == 0 || bit3 == 1);
 
@@ -455,7 +455,7 @@ pcl::SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::interpolateDou
       zInFeatRef  = 0;
 
     unsigned char bit4 = ((yInFeatRef > 0) || ((yInFeatRef == 0.0) && (xInFeatRef < 0))) ? 1 : 0;
-    unsigned char bit3 = static_cast<unsigned char> (((xInFeatRef > 0) || ((xInFeatRef == 0.0) && (yInFeatRef > 0))) ? !bit4 : bit4);
+    auto bit3 = static_cast<unsigned char> (((xInFeatRef > 0) || ((xInFeatRef == 0.0) && (yInFeatRef > 0))) ? !bit4 : bit4);
 
     assert (bit3 == 0 || bit3 == 1);
 

--- a/features/include/pcl/features/impl/usc.hpp
+++ b/features/include/pcl/features/impl/usc.hpp
@@ -203,7 +203,7 @@ pcl::UniqueShapeContext<PointInT, PointOutT, PointRFT>::computePointDescriptor (
     /// Local point density = number of points in a sphere of radius "point_density_radius_" around the current neighbour
     pcl::Indices neighbour_indices;
     std::vector<float> neighbour_didtances;
-    float point_density = static_cast<float> (searchForNeighbors (*surface_, nn_indices[ne], point_density_radius_, neighbour_indices, neighbour_didtances));
+    auto point_density = static_cast<float> (searchForNeighbors (*surface_, nn_indices[ne], point_density_radius_, neighbour_indices, neighbour_didtances));
     /// point_density is always bigger than 0 because FindPointsWithinRadius returns at least the point itself
     float w = (1.0f / point_density) * volume_lut_[(l*elevation_bins_*radius_bins_) +
                                                    (k*radius_bins_) +

--- a/features/include/pcl/features/impl/vfh.hpp
+++ b/features/include/pcl/features/impl/vfh.hpp
@@ -226,7 +226,7 @@ pcl::VFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
                             (*normals_)[index].normal[2], 0);
     // Normalize
     double alpha = (normal.dot (d_vp_p) + 1.0) * 0.5;
-    std::size_t fi = static_cast<std::size_t> (std::floor (alpha * hist_vp_.size ()));
+    auto fi = static_cast<std::size_t> (std::floor (alpha * hist_vp_.size ()));
     fi = std::max<std::size_t> (0u, fi);
     fi = std::min<std::size_t> (hist_vp_.size () - 1, fi);
     // Bin into the histogram

--- a/features/src/cppf.cpp
+++ b/features/src/cppf.cpp
@@ -57,7 +57,7 @@
       return;
     }
 
-    const float diff = static_cast <float> (max - min);
+    const auto diff = static_cast <float> (max - min);
     out[1] = diff / static_cast <float> (max);
 
     if (min == max) // diff == 0 -> division by zero

--- a/features/src/narf.cpp
+++ b/features/src/narf.cpp
@@ -276,7 +276,7 @@ Narf::getBlurredSurfacePatch (int new_pixel_size, int blur_radius) const
   float new_to_old_factor = float(surface_patch_pixel_size_)/float(new_pixel_size);
   int new_size = new_pixel_size*new_pixel_size;
   
-  float* integral_image = new float[new_size];
+  auto* integral_image = new float[new_size];
   float* integral_image_ptr = integral_image;
   for (int y=0; y<new_pixel_size; ++y)
   {
@@ -303,7 +303,7 @@ Narf::getBlurredSurfacePatch (int new_pixel_size, int blur_radius) const
     }
   }
   
-  float* new_surface_patch = new float[new_size];
+  auto* new_surface_patch = new float[new_size];
   float* new_surface_patch_ptr = new_surface_patch;
   for (int y=0; y<new_pixel_size; ++y)
   {
@@ -477,14 +477,14 @@ Narf::getRotations (std::vector<float>& rotations, std::vector<float>& strengths
   
   while (!scored_orientations.empty())
   {
-    std::multimap<float, float>::iterator best_remaining_orientation_it = scored_orientations.end();
+    auto best_remaining_orientation_it = scored_orientations.end();
     --best_remaining_orientation_it;
     rotations.push_back(best_remaining_orientation_it->second);
     strengths.push_back(best_remaining_orientation_it->first);
     scored_orientations.erase(best_remaining_orientation_it);
-    for (std::multimap<float, float>::iterator it = scored_orientations.begin(); it!=scored_orientations.end();)
+    for (auto it = scored_orientations.begin(); it!=scored_orientations.end();)
     {
-      std::multimap<float, float>::iterator current_it = it++;
+      auto current_it = it++;
       if (normAngle(current_it->second - rotations.back()) < min_angle_dist_between_rotations)
         scored_orientations.erase(current_it);
     }

--- a/features/src/range_image_border_extractor.cpp
+++ b/features/src/range_image_border_extractor.cpp
@@ -204,7 +204,7 @@ RangeImageBorderExtractor::extractBorderScoreImages ()
 float*
 RangeImageBorderExtractor::updatedScoresAccordingToNeighborValues (const float* border_scores) const
 {
-  float* new_scores = new float[range_image_->width*range_image_->height];
+  auto* new_scores = new float[range_image_->width*range_image_->height];
   float* new_scores_ptr = new_scores;
   for (int y=0; y < static_cast<int> (range_image_->height); ++y)
     for (int x=0; x < static_cast<int> (range_image_->width); ++x)
@@ -296,7 +296,7 @@ RangeImageBorderExtractor::getAnglesImageForBorderDirections ()
   int width  = range_image_->width,
       height = range_image_->height,
       array_size = width*height;
-  float* angles_image = new float[array_size];
+  auto* angles_image = new float[array_size];
 
   for (int y=0; y<height; ++y)
   {
@@ -333,7 +333,7 @@ RangeImageBorderExtractor::getAnglesImageForSurfaceChangeDirections ()
   int width  = range_image_->width,
       height = range_image_->height,
       array_size = width*height;
-  float* angles_image = new float[array_size];
+  auto* angles_image = new float[array_size];
 
   for (int y=0; y<height; ++y)
   {
@@ -493,7 +493,7 @@ RangeImageBorderExtractor::calculateBorderDirections ()
     }
   }
 
-  Eigen::Vector3f** average_border_directions = new Eigen::Vector3f*[size];
+  auto** average_border_directions = new Eigen::Vector3f*[size];
   int radius = parameters_.pixel_radius_border_direction;
   int minimum_weight = radius+1;
   float min_cos_angle=std::cos(deg2rad(120.0f));
@@ -614,8 +614,8 @@ RangeImageBorderExtractor::blurSurfaceChanges ()
 
   const RangeImage& range_image = *range_image_;
 
-  Eigen::Vector3f* blurred_directions = new Eigen::Vector3f[range_image.width*range_image.height];
-  float* blurred_scores = new float[range_image.width*range_image.height];
+  auto* blurred_directions = new Eigen::Vector3f[range_image.width*range_image.height];
+  auto* blurred_scores = new float[range_image.width*range_image.height];
   for (int y=0; y<int(range_image.height); ++y)
   {
     for (int x=0; x<int(range_image.width); ++x)

--- a/filters/include/pcl/filters/impl/approximate_voxel_grid.hpp
+++ b/filters/include/pcl/filters/impl/approximate_voxel_grid.hpp
@@ -94,7 +94,7 @@ pcl::ApproximateVoxelGrid<PointT>::applyFilter (PointCloud &output)
     int ix = static_cast<int> (std::floor (point.x * inverse_leaf_size_[0]));
     int iy = static_cast<int> (std::floor (point.y * inverse_leaf_size_[1]));
     int iz = static_cast<int> (std::floor (point.z * inverse_leaf_size_[2]));
-    unsigned int hash = static_cast<unsigned int> ((ix * 7171 + iy * 3079 + iz * 4231) & (histsize_ - 1));
+    auto hash = static_cast<unsigned int> ((ix * 7171 + iy * 3079 + iz * 4231) & (histsize_ - 1));
     he *hhe = &history_[hash];
     if (hhe->count && ((ix != hhe->ix) || (iy != hhe->iy) || (iz != hhe->iz))) 
     {

--- a/filters/include/pcl/filters/impl/conditional_removal.hpp
+++ b/filters/include/pcl/filters/impl/conditional_removal.hpp
@@ -193,7 +193,7 @@ template <typename PointT> bool
 pcl::PackedRGBComparison<PointT>::evaluate (const PointT &point) const
 {
   // extract the component value
-  const std::uint8_t* pt_data = reinterpret_cast<const std::uint8_t*> (&point);
+  const auto* pt_data = reinterpret_cast<const std::uint8_t*> (&point);
   std::uint8_t my_val = *(pt_data + component_offset_);
 
   // now do the comparison
@@ -298,8 +298,8 @@ pcl::PackedHSIComparison<PointT>::evaluate (const PointT &point) const
   static std::uint8_t i_ = 0;
 
   // We know that rgb data is 32 bit aligned (verified in the ctor) so...
-  const std::uint8_t* pt_data = reinterpret_cast<const std::uint8_t*> (&point);
-  const std::uint32_t* rgb_data = reinterpret_cast<const std::uint32_t*> (pt_data + rgb_offset_);
+  const auto* pt_data = reinterpret_cast<const std::uint8_t*> (&point);
+  const auto* rgb_data = reinterpret_cast<const std::uint32_t*> (pt_data + rgb_offset_);
   std::uint32_t new_rgb_val = *rgb_data;
 
   if (rgb_val_ != new_rgb_val) 
@@ -523,7 +523,7 @@ pcl::PointDataAtOffset<PointT>::compare (const PointT& p, const double& val)
   // if p(data) == val return 0
   // if p(data) < val return -1 
   
-  const std::uint8_t* pt_data = reinterpret_cast<const std::uint8_t*> (&p);
+  const auto* pt_data = reinterpret_cast<const std::uint8_t*> (&p);
 
   switch (datatype_) 
   {

--- a/filters/include/pcl/filters/impl/extract_indices.hpp
+++ b/filters/include/pcl/filters/impl/extract_indices.hpp
@@ -58,7 +58,7 @@ pcl::ExtractIndices<PointT>::filterDirectly (PointCloudPtr &cloud)
   pcl::for_each_type<FieldList> (pcl::detail::FieldAdder<PointT> (fields));
   for (const auto& rii : (*removed_indices_)) // rii = removed indices iterator
   {
-    uindex_t pt_index = (uindex_t) rii;
+    auto pt_index = (uindex_t) rii;
     if (pt_index >= input_->size ())
     {
       PCL_ERROR ("[pcl::%s::filterDirectly] The index exceeds the size of the input. Do nothing.\n",
@@ -66,7 +66,7 @@ pcl::ExtractIndices<PointT>::filterDirectly (PointCloudPtr &cloud)
       *cloud = *input_;
       return;
     }
-    std::uint8_t* pt_data = reinterpret_cast<std::uint8_t*> (&(*cloud)[pt_index]);
+    auto* pt_data = reinterpret_cast<std::uint8_t*> (&(*cloud)[pt_index]);
     for (const auto &field : fields)
       memcpy (pt_data + field.offset, &user_filter_value_, sizeof (float));
   }
@@ -91,7 +91,7 @@ pcl::ExtractIndices<PointT>::applyFilter (PointCloud &output)
     pcl::for_each_type<FieldList> (pcl::detail::FieldAdder<PointT> (fields));
     for (const auto ri : *removed_indices_)  // ri = removed index
     {
-      std::size_t pt_index = (std::size_t)ri;
+      auto pt_index = (std::size_t)ri;
       if (pt_index >= input_->size ())
       {
         PCL_ERROR ("[pcl::%s::applyFilter] The index exceeds the size of the input. Do nothing.\n",
@@ -99,7 +99,7 @@ pcl::ExtractIndices<PointT>::applyFilter (PointCloud &output)
         output = *input_;
         return;
       }
-      std::uint8_t* pt_data = reinterpret_cast<std::uint8_t*> (&output[pt_index]);
+      auto* pt_data = reinterpret_cast<std::uint8_t*> (&output[pt_index]);
       for (const auto &field : fields)
         memcpy (pt_data + field.offset, &user_filter_value_, sizeof (float));
     }

--- a/filters/include/pcl/filters/impl/fast_bilateral.hpp
+++ b/filters/include/pcl/filters/impl/fast_bilateral.hpp
@@ -138,7 +138,7 @@ FastBilateralFilter<PointT>::applyFilter (PointCloud &output)
 
   if (early_division_)
   {
-    for (std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> >::iterator d = data.begin (); d != data.end (); ++d)
+    for (auto d = data.begin (); d != data.end (); ++d)
       *d /= ((*d)[0] != 0) ? (*d)[1] : 1;
 
     for (std::size_t x = 0; x < input_->width; x++)

--- a/filters/include/pcl/filters/impl/fast_bilateral_omp.hpp
+++ b/filters/include/pcl/filters/impl/fast_bilateral_omp.hpp
@@ -116,15 +116,15 @@ pcl::FastBilateralFilterOMP<PointT>::applyFilter (PointCloud &output)
 #endif
   for (long int i = 0; i < static_cast<long int> (small_width * small_height); ++i)
   {
-    std::size_t small_x = static_cast<std::size_t> (i % small_width);
-    std::size_t small_y = static_cast<std::size_t> (i / small_width);
-    std::size_t start_x = static_cast<std::size_t>( 
+    auto small_x = static_cast<std::size_t> (i % small_width);
+    auto small_y = static_cast<std::size_t> (i / small_width);
+    auto start_x = static_cast<std::size_t>( 
         std::max ((static_cast<float> (small_x) - static_cast<float> (padding_xy) - 0.5f) * sigma_s_ + 1, 0.f));
-    std::size_t end_x = static_cast<std::size_t>( 
+    auto end_x = static_cast<std::size_t>( 
       std::max ((static_cast<float> (small_x) - static_cast<float> (padding_xy) + 0.5f) * sigma_s_ + 1, 0.f));
-    std::size_t start_y = static_cast<std::size_t>( 
+    auto start_y = static_cast<std::size_t>( 
       std::max ((static_cast<float> (small_y) - static_cast<float> (padding_xy) - 0.5f) * sigma_s_ + 1, 0.f));
-    std::size_t end_y = static_cast<std::size_t>( 
+    auto end_y = static_cast<std::size_t>( 
       std::max ((static_cast<float> (small_y) - static_cast<float> (padding_xy) + 0.5f) * sigma_s_ + 1, 0.f));
     for (std::size_t x = start_x; x < end_x && x < input_->width; ++x)
     {
@@ -165,8 +165,8 @@ pcl::FastBilateralFilterOMP<PointT>::applyFilter (PointCloud &output)
 #endif
       for(long int i = 0; i < static_cast<long int> ((small_width - 2)*(small_height - 2)); ++i)
       {
-        std::size_t x = static_cast<std::size_t> (i % (small_width - 2) + 1);
-        std::size_t y = static_cast<std::size_t> (i / (small_width - 2) + 1);
+        auto x = static_cast<std::size_t> (i % (small_width - 2) + 1);
+        auto y = static_cast<std::size_t> (i / (small_width - 2) + 1);
         const long int off = offset[dim];
         Eigen::Vector2f* d_ptr = &(current_data->operator() (x,y,1));
         Eigen::Vector2f* b_ptr = &(current_buffer->operator() (x,y,1));
@@ -182,7 +182,7 @@ pcl::FastBilateralFilterOMP<PointT>::applyFilter (PointCloud &output)
 
   if (early_division_)
   {
-    for (std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> >::iterator d = data.begin (); d != data.end (); ++d)
+    for (auto d = data.begin (); d != data.end (); ++d)
       *d /= ((*d)[0] != 0) ? (*d)[1] : 1;
 
 #pragma omp parallel for \
@@ -191,8 +191,8 @@ pcl::FastBilateralFilterOMP<PointT>::applyFilter (PointCloud &output)
   num_threads(threads_)
     for (long int i = 0; i < static_cast<long int> (input_->size ()); ++i)
     {
-      std::size_t x = static_cast<std::size_t> (i % input_->width);
-      std::size_t y = static_cast<std::size_t> (i / input_->width);
+      auto x = static_cast<std::size_t> (i % input_->width);
+      auto y = static_cast<std::size_t> (i / input_->width);
       const float z = output (x,y).z - base_min;
       const Eigen::Vector2f D = data.trilinear_interpolation (static_cast<float> (x) / sigma_s_ + padding_xy,
                                                               static_cast<float> (y) / sigma_s_ + padding_xy,
@@ -208,8 +208,8 @@ pcl::FastBilateralFilterOMP<PointT>::applyFilter (PointCloud &output)
   num_threads(threads_)
     for (long i = 0; i < static_cast<long int> (input_->size ()); ++i)
     {
-      std::size_t x = static_cast<std::size_t> (i % input_->width);
-      std::size_t y = static_cast<std::size_t> (i / input_->width);
+      auto x = static_cast<std::size_t> (i % input_->width);
+      auto y = static_cast<std::size_t> (i / input_->width);
       const float z = output (x,y).z - base_min;
       const Eigen::Vector2f D = data.trilinear_interpolation (static_cast<float> (x) / sigma_s_ + padding_xy,
                                                               static_cast<float> (y) / sigma_s_ + padding_xy,

--- a/filters/include/pcl/filters/impl/frustum_culling.hpp
+++ b/filters/include/pcl/filters/impl/frustum_culling.hpp
@@ -58,23 +58,23 @@ pcl::FrustumCulling<PointT>::applyFilter (Indices &indices)
   Eigen::Vector3f T = camera_pose_.block<3, 1> (0, 3);       // The (X, Y, Z) position of the camera w.r.t origin
 
 
-  float vfov_rad = float (vfov_ * M_PI / 180);  // degrees to radians
-  float hfov_rad = float (hfov_ * M_PI / 180);  // degrees to radians
+  auto vfov_rad = float (vfov_ * M_PI / 180);  // degrees to radians
+  auto hfov_rad = float (hfov_ * M_PI / 180);  // degrees to radians
 
   float roi_xmax = roi_x_ + (roi_w_ / 2);  // roi max x
   float roi_xmin = roi_x_ - (roi_w_ / 2);  // roi min x
   float roi_ymax = roi_y_ + (roi_h_ / 2);  // roi max y
   float roi_ymin = roi_y_ - (roi_h_ / 2);  // roi min y
   
-  float np_h_u = float(2 * tan(vfov_rad / 2) * np_dist_ * (roi_ymin - 0.5) * (-1));  // near plane upper height
-  float np_h_d = float(2 * tan(vfov_rad / 2) * np_dist_ * (roi_ymax - 0.5));         // near plane lower height
-  float np_w_l = float(2 * tan(hfov_rad / 2) * np_dist_ * (roi_xmin - 0.5) * (-1));  // near plane left width
-  float np_w_r = float(2 * tan(hfov_rad / 2) * np_dist_ * (roi_xmax - 0.5));         // near plane right width
+  auto np_h_u = float(2 * tan(vfov_rad / 2) * np_dist_ * (roi_ymin - 0.5) * (-1));  // near plane upper height
+  auto np_h_d = float(2 * tan(vfov_rad / 2) * np_dist_ * (roi_ymax - 0.5));         // near plane lower height
+  auto np_w_l = float(2 * tan(hfov_rad / 2) * np_dist_ * (roi_xmin - 0.5) * (-1));  // near plane left width
+  auto np_w_r = float(2 * tan(hfov_rad / 2) * np_dist_ * (roi_xmax - 0.5));         // near plane right width
 
-  float fp_h_u = float(2 * tan(vfov_rad / 2) * fp_dist_ * (roi_ymin - 0.5) * (-1));  // far plane upper height
-  float fp_h_d = float(2 * tan(vfov_rad / 2) * fp_dist_ * (roi_ymax - 0.5));         // far plane lower height
-  float fp_w_l = float(2 * tan(hfov_rad / 2) * fp_dist_ * (roi_xmin - 0.5) * (-1));  // far plane left width
-  float fp_w_r = float(2 * tan(hfov_rad / 2) * fp_dist_ * (roi_xmax - 0.5));         // far plane right width
+  auto fp_h_u = float(2 * tan(vfov_rad / 2) * fp_dist_ * (roi_ymin - 0.5) * (-1));  // far plane upper height
+  auto fp_h_d = float(2 * tan(vfov_rad / 2) * fp_dist_ * (roi_ymax - 0.5));         // far plane lower height
+  auto fp_w_l = float(2 * tan(hfov_rad / 2) * fp_dist_ * (roi_xmin - 0.5) * (-1));  // far plane left width
+  auto fp_w_r = float(2 * tan(hfov_rad / 2) * fp_dist_ * (roi_xmax - 0.5));         // far plane right width
 
   Eigen::Vector3f fp_c (T + view * fp_dist_);                           // far plane center
   Eigen::Vector3f fp_tl (fp_c + (up * fp_h_u) - (right * fp_w_l));  // Top left corner of the far plane

--- a/filters/include/pcl/filters/impl/model_outlier_removal.hpp
+++ b/filters/include/pcl/filters/impl/model_outlier_removal.hpp
@@ -155,7 +155,7 @@ pcl::ModelOutlierRemoval<PointT>::applyFilterIndices (Indices &indices)
 
   using SACModelFromNormals = SampleConsensusModelFromNormals<PointT, pcl::Normal>;
   // Returns NULL if cast isn't possible
-  SACModelFromNormals *model_from_normals = dynamic_cast<SACModelFromNormals *> (& (*model_));
+  auto *model_from_normals = dynamic_cast<SACModelFromNormals *> (& (*model_));
 
   if (model_from_normals)
   {

--- a/filters/include/pcl/filters/impl/normal_space.hpp
+++ b/filters/include/pcl/filters/impl/normal_space.hpp
@@ -80,9 +80,9 @@ pcl::NormalSpaceSampling<PointT, NormalT>::isEntireBinSampled (boost::dynamic_bi
 template<typename PointT, typename NormalT> unsigned int 
 pcl::NormalSpaceSampling<PointT, NormalT>::findBin (const float *normal)
 {
-  const unsigned ix = static_cast<unsigned> (std::round (0.5f * (binsx_ - 1.f) * (normal[0] + 1.f)));
-  const unsigned iy = static_cast<unsigned> (std::round (0.5f * (binsy_ - 1.f) * (normal[1] + 1.f)));
-  const unsigned iz = static_cast<unsigned> (std::round (0.5f * (binsz_ - 1.f) * (normal[2] + 1.f)));
+  const auto ix = static_cast<unsigned> (std::round (0.5f * (binsx_ - 1.f) * (normal[0] + 1.f)));
+  const auto iy = static_cast<unsigned> (std::round (0.5f * (binsy_ - 1.f) * (normal[1] + 1.f)));
+  const auto iz = static_cast<unsigned> (std::round (0.5f * (binsz_ - 1.f) * (normal[2] + 1.f)));
   return ix * (binsy_*binsz_) + iy * binsz_ + iz;
 }
 
@@ -126,7 +126,7 @@ pcl::NormalSpaceSampling<PointT, NormalT>::applyFilter (Indices &indices)
     random_access[i].resize (normals_hg[i].size ());
 
     std::size_t j = 0;
-    for (std::list<int>::iterator itr = normals_hg[i].begin (); itr != normals_hg[i].end (); ++itr, ++j)
+    for (auto itr = normals_hg[i].begin (); itr != normals_hg[i].end (); ++itr, ++j)
       random_access[i][j] = itr;
   }
   std::vector<std::size_t> start_index (normals_hg.size ());
@@ -148,7 +148,7 @@ pcl::NormalSpaceSampling<PointT, NormalT>::applyFilter (Indices &indices)
     // Iterating through every bin and picking one point at random, until the required number of points are sampled.
     for (std::size_t j = 0; j < normals_hg.size (); j++)
     {
-      unsigned int M = static_cast<unsigned int> (normals_hg[j].size ());
+      auto M = static_cast<unsigned int> (normals_hg[j].size ());
       if (M == 0 || bin_empty_flag.test (j)) // bin_empty_flag(i) is set if all points in that bin are sampled..
         continue;
 

--- a/filters/include/pcl/filters/impl/passthrough.hpp
+++ b/filters/include/pcl/filters/impl/passthrough.hpp
@@ -96,7 +96,7 @@ pcl::PassThrough<PointT>::applyFilterIndices (Indices &indices)
       }
 
       // Get the field's value
-      const std::uint8_t* pt_data = reinterpret_cast<const std::uint8_t*> (&(*input_)[ii]);
+      const auto* pt_data = reinterpret_cast<const std::uint8_t*> (&(*input_)[ii]);
       float field_value = 0;
       memcpy (&field_value, pt_data + fields[distance_idx].offset, sizeof (float));
 

--- a/filters/include/pcl/filters/impl/voxel_grid.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid.hpp
@@ -67,7 +67,7 @@ pcl::getMinMax3D (const typename pcl::PointCloud<PointT>::ConstPtr &cloud,
     for (const auto& point: *cloud)
     {
       // Get the distance value
-      const std::uint8_t* pt_data = reinterpret_cast<const std::uint8_t*> (&point);
+      const auto* pt_data = reinterpret_cast<const std::uint8_t*> (&point);
       memcpy (&distance_value, pt_data + fields[distance_idx].offset, sizeof (float));
 
       if (limit_negative)
@@ -93,7 +93,7 @@ pcl::getMinMax3D (const typename pcl::PointCloud<PointT>::ConstPtr &cloud,
     for (const auto& point: *cloud)
     {
       // Get the distance value
-      const std::uint8_t* pt_data = reinterpret_cast<const std::uint8_t*> (&point);
+      const auto* pt_data = reinterpret_cast<const std::uint8_t*> (&point);
       memcpy (&distance_value, pt_data + fields[distance_idx].offset, sizeof (float));
 
       if (limit_negative)
@@ -144,7 +144,7 @@ pcl::getMinMax3D (const typename pcl::PointCloud<PointT>::ConstPtr &cloud,
     for (const auto &index : indices)
     {
       // Get the distance value
-      const std::uint8_t* pt_data = reinterpret_cast<const std::uint8_t*> (&(*cloud)[index]);
+      const auto* pt_data = reinterpret_cast<const std::uint8_t*> (&(*cloud)[index]);
       memcpy (&distance_value, pt_data + fields[distance_idx].offset, sizeof (float));
 
       if (limit_negative)
@@ -170,7 +170,7 @@ pcl::getMinMax3D (const typename pcl::PointCloud<PointT>::ConstPtr &cloud,
     for (const auto &index : indices)
     {
       // Get the distance value
-      const std::uint8_t* pt_data = reinterpret_cast<const std::uint8_t*> (&(*cloud)[index]);
+      const auto* pt_data = reinterpret_cast<const std::uint8_t*> (&(*cloud)[index]);
       memcpy (&distance_value, pt_data + fields[distance_idx].offset, sizeof (float));
 
       if (limit_negative)
@@ -286,7 +286,7 @@ pcl::VoxelGrid<PointT>::applyFilter (PointCloud &output)
           continue;
 
       // Get the distance value
-      const std::uint8_t* pt_data = reinterpret_cast<const std::uint8_t*> (&(*input_)[index]);
+      const auto* pt_data = reinterpret_cast<const std::uint8_t*> (&(*input_)[index]);
       float distance_value = 0;
       memcpy (&distance_value, pt_data + fields[distance_idx].offset, sizeof (float));
 

--- a/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
@@ -140,7 +140,7 @@ pcl::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
           continue;
 
       // Get the distance value
-      const std::uint8_t* pt_data = reinterpret_cast<const std::uint8_t*> (&point);
+      const auto* pt_data = reinterpret_cast<const std::uint8_t*> (&point);
       float distance_value = 0;
       memcpy (&distance_value, pt_data + fields[distance_idx].offset, sizeof (float));
 
@@ -275,7 +275,7 @@ pcl::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
   // Eigen values less than a threshold of max eigen value are inflated to a set fraction of the max eigen value.
   double min_covar_eigvalue;
 
-  for (typename std::map<std::size_t, Leaf>::iterator it = leaves_.begin (); it != leaves_.end (); ++it)
+  for (auto it = leaves_.begin (); it != leaves_.end (); ++it)
   {
 
     // Normalize the centroid
@@ -461,7 +461,7 @@ pcl::VoxelGridCovariance<PointT>::getDisplayCloud (pcl::PointCloud<PointXYZ>& ce
       [this] (auto& l) { return (l.second.nr_points >= min_points_per_voxel_); }));
 
   // Generate points for each occupied voxel with sufficient points.
-  for (typename std::map<std::size_t, Leaf>::iterator it = leaves_.begin (); it != leaves_.end (); ++it)
+  for (auto it = leaves_.begin (); it != leaves_.end (); ++it)
   {
     Leaf& leaf = it->second;
 

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -298,7 +298,7 @@ namespace pcl
       inline LeafConstPtr
       getLeaf (int index)
       {
-        typename std::map<std::size_t, Leaf>::iterator leaf_iter = leaves_.find (index);
+        auto leaf_iter = leaves_.find (index);
         if (leaf_iter != leaves_.end ())
         {
           LeafConstPtr ret (&(leaf_iter->second));
@@ -323,7 +323,7 @@ namespace pcl
         int idx = ijk0 * divb_mul_[0] + ijk1 * divb_mul_[1] + ijk2 * divb_mul_[2];
 
         // Find leaf associated with index
-        typename std::map<std::size_t, Leaf>::iterator leaf_iter = leaves_.find (idx);
+        auto leaf_iter = leaves_.find (idx);
         if (leaf_iter != leaves_.end ())
         {
           // If such a leaf exists return the pointer to the leaf structure
@@ -349,7 +349,7 @@ namespace pcl
         int idx = ijk0 * divb_mul_[0] + ijk1 * divb_mul_[1] + ijk2 * divb_mul_[2];
 
         // Find leaf associated with index
-        typename std::map<std::size_t, Leaf>::iterator leaf_iter = leaves_.find (idx);
+        auto leaf_iter = leaves_.find (idx);
         if (leaf_iter != leaves_.end ())
         {
           // If such a leaf exists return the pointer to the leaf structure

--- a/filters/src/crop_box.cpp
+++ b/filters/src/crop_box.cpp
@@ -71,7 +71,7 @@ pcl::CropBox<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
     const static float user_filter_value = user_filter_value_;
     for (const auto ri : *removed_indices_) // ri = removed index
     {
-      std::uint8_t* pt_data = reinterpret_cast<std::uint8_t*> (&output.data[ri * output.point_step]);
+      auto* pt_data = reinterpret_cast<std::uint8_t*> (&output.data[ri * output.point_step]);
       for (const auto &offset : offsets)
       {
         memcpy (pt_data + offset, &user_filter_value, sizeof (float));

--- a/filters/src/passthrough.cpp
+++ b/filters/src/passthrough.cpp
@@ -355,7 +355,7 @@ pcl::PassThrough<pcl::PCLPointCloud2>::applyFilter (Indices &indices)
       }
 
       // Get the field's value
-      const std::uint8_t* pt_data = reinterpret_cast<const std::uint8_t*> (&input_->data[ii * input_->point_step]);
+      const auto* pt_data = reinterpret_cast<const std::uint8_t*> (&input_->data[ii * input_->point_step]);
       float field_value = 0;
       memcpy (&field_value, pt_data + input_->fields[distance_idx].offset, sizeof (float));
 

--- a/filters/src/random_sample.cpp
+++ b/filters/src/random_sample.cpp
@@ -72,7 +72,7 @@ pcl::RandomSample<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
     const static float user_filter_value = user_filter_value_;
     for (const auto ri : *removed_indices_) // ri = removed index
     {
-      std::uint8_t* pt_data = reinterpret_cast<std::uint8_t*> (&output.data[ri * output.point_step]);
+      auto* pt_data = reinterpret_cast<std::uint8_t*> (&output.data[ri * output.point_step]);
       for (const auto &offset : offsets)
       {
         memcpy (pt_data + offset, &user_filter_value, sizeof (float));

--- a/filters/src/voxel_grid_label.cpp
+++ b/filters/src/voxel_grid_label.cpp
@@ -136,7 +136,7 @@ pcl::VoxelGridLabel::applyFilter (PointCloud &output)
           continue;
 
       // Get the distance value
-      const std::uint8_t* pt_data = reinterpret_cast<const std::uint8_t*> (&(*input_)[cp]);
+      const auto* pt_data = reinterpret_cast<const std::uint8_t*> (&(*input_)[cp]);
       float distance_value = 0;
       memcpy (&distance_value, pt_data + fields[distance_idx].offset, sizeof (float));
 
@@ -265,7 +265,7 @@ pcl::VoxelGridLabel::applyFilter (PointCloud &output)
       {
         // store the label in a map data structure
         std::uint32_t label = (*input_)[index_vector[cp].cloud_point_index].label;
-        std::map<int, int>::iterator it = labels.find (label);
+        auto it = labels.find (label);
         if (it == labels.end ())
           labels.insert (labels.begin (), std::pair<int, int> (label, 1));
         else

--- a/geometry/include/pcl/geometry/mesh_base.h
+++ b/geometry/include/pcl/geometry/mesh_base.h
@@ -325,14 +325,14 @@ public:
     }
 
     // Adjust the indices
-    for (VertexIterator it = vertices_.begin(); it != vertices_.end(); ++it) {
+    for (auto it = vertices_.begin(); it != vertices_.end(); ++it) {
       if (it->idx_outgoing_half_edge_.isValid()) {
         it->idx_outgoing_half_edge_ =
             new_half_edge_indices[it->idx_outgoing_half_edge_.get()];
       }
     }
 
-    for (HalfEdgeIterator it = half_edges_.begin(); it != half_edges_.end(); ++it) {
+    for (auto it = half_edges_.begin(); it != half_edges_.end(); ++it) {
       it->idx_terminating_vertex_ =
           new_vertex_indices[it->idx_terminating_vertex_.get()];
       it->idx_next_half_edge_ = new_half_edge_indices[it->idx_next_half_edge_.get()];
@@ -342,7 +342,7 @@ public:
       }
     }
 
-    for (FaceIterator it = faces_.begin(); it != faces_.end(); ++it) {
+    for (auto it = faces_.begin(); it != faces_.end(); ++it) {
       it->idx_inner_half_edge_ = new_half_edge_indices[it->idx_inner_half_edge_.get()];
     }
   }
@@ -1800,12 +1800,12 @@ protected:
     Index ind_old(0), ind_new(0);
 
     typename ElementContainerT::const_iterator it_e_old = elements.begin();
-    typename ElementContainerT::iterator it_e_new = elements.begin();
+    auto it_e_new = elements.begin();
 
     typename DataContainerT::const_iterator it_d_old = data_cloud.begin();
-    typename DataContainerT::iterator it_d_new = data_cloud.begin();
+    auto it_d_new = data_cloud.begin();
 
-    typename IndexContainerT::iterator it_ind_new = new_indices.begin();
+    auto it_ind_new = new_indices.begin();
     typename IndexContainerT::const_iterator it_ind_new_end = new_indices.end();
 
     while (it_ind_new != it_ind_new_end) {

--- a/geometry/include/pcl/geometry/mesh_io.h
+++ b/geometry/include/pcl/geometry/mesh_io.h
@@ -229,14 +229,14 @@ public:
          << mesh.sizeFaces() << "\n";
 
     // Write the vertices
-    for (typename Vertices::const_iterator it = mesh.vertices_.begin();
+    for (auto it = mesh.vertices_.begin();
          it != mesh.vertices_.end();
          ++it) {
       file << it->idx_outgoing_half_edge_ << "\n";
     }
 
     // Write the half-edges
-    for (typename HalfEdges::const_iterator it = mesh.half_edges_.begin();
+    for (auto it = mesh.half_edges_.begin();
          it != mesh.half_edges_.end();
          ++it) {
       file << it->idx_terminating_vertex_ << " " << it->idx_next_half_edge_ << " "
@@ -244,7 +244,7 @@ public:
     }
 
     // Write the faces
-    for (typename Faces::const_iterator it = mesh.faces_.begin();
+    for (auto it = mesh.faces_.begin();
          it != mesh.faces_.end();
          ++it) {
       file << it->idx_inner_half_edge_ << "\n";

--- a/io/include/pcl/compression/color_coding.h
+++ b/io/include/pcl/compression/color_coding.h
@@ -173,7 +173,7 @@ public:
 
     }
 
-    const uindex_t len = static_cast<uindex_t> (indexVector_arg.size());
+    const auto len = static_cast<uindex_t> (indexVector_arg.size());
     // calculated average color information
     if (len > 1)
     {
@@ -222,7 +222,7 @@ public:
 
     }
 
-    const uindex_t len = static_cast<uindex_t> (indexVector_arg.size());
+    const auto len = static_cast<uindex_t> (indexVector_arg.size());
     if (len > 1)
     {
       unsigned char diffRed;
@@ -339,7 +339,7 @@ public:
     assert (beginIdx_arg <= endIdx_arg);
 
     // amount of points to be decoded
-    unsigned int pointCount = static_cast<unsigned int> (endIdx_arg - beginIdx_arg);
+    auto pointCount = static_cast<unsigned int> (endIdx_arg - beginIdx_arg);
 
     // iterate over points
     for (std::size_t i = 0; i < pointCount; i++)

--- a/io/include/pcl/compression/impl/entropy_range_coder.hpp
+++ b/io/include/pcl/compression/impl/entropy_range_coder.hpp
@@ -60,7 +60,7 @@ pcl::AdaptiveRangeCoder::encodeCharVectorToStream (const std::vector<char>& inpu
   const DWord bottom = static_cast<DWord> (1) << 16;
   const DWord maxRange = static_cast<DWord> (1) << 16;
 
-  unsigned int input_size = static_cast<unsigned> (inputByteVector_arg.size ());
+  auto input_size = static_cast<unsigned> (inputByteVector_arg.size ());
 
   // init output vector
   outputCharVector_.clear ();
@@ -69,7 +69,7 @@ pcl::AdaptiveRangeCoder::encodeCharVectorToStream (const std::vector<char>& inpu
   unsigned int readPos = 0;
 
   DWord low = 0;
-  DWord range = static_cast<DWord> (-1);
+  auto range = static_cast<DWord> (-1);
 
   // initialize cumulative frequency table
   for (unsigned int i = 0; i < 257; i++)
@@ -138,7 +138,7 @@ pcl::AdaptiveRangeCoder::decodeStreamToCharVector (std::istream& inputByteStream
   const DWord bottom = static_cast<DWord> (1) << 16;
   const DWord maxRange = static_cast<DWord> (1) << 16;
 
-  unsigned int output_size = static_cast<unsigned> (outputByteVector_arg.size ());
+  auto output_size = static_cast<unsigned> (outputByteVector_arg.size ());
 
   unsigned long streamByteCount = 0;
 
@@ -146,7 +146,7 @@ pcl::AdaptiveRangeCoder::decodeStreamToCharVector (std::istream& inputByteStream
 
   DWord code = 0;
   DWord low = 0;
-  DWord range = static_cast<DWord> (-1);
+  auto range = static_cast<DWord> (-1);
 
   // init decoding
   for (unsigned int i = 0; i < 4; i++)
@@ -228,7 +228,7 @@ pcl::StaticRangeCoder::encodeIntVectorToStream (std::vector<unsigned int>& input
   const std::uint64_t bottom = static_cast<std::uint64_t> (1) << 48;
   const std::uint64_t maxRange = static_cast<std::uint64_t> (1) << 48;
 
-  unsigned long input_size = static_cast<unsigned long> (inputIntVector_arg.size ());
+  auto input_size = static_cast<unsigned long> (inputIntVector_arg.size ());
 
   // init output vector
   outputCharVector_.clear ();
@@ -291,7 +291,7 @@ pcl::StaticRangeCoder::encodeIntVectorToStream (std::vector<unsigned int>& input
   }
 
   // calculate amount of bytes per frequency table entry
-  std::uint8_t frequencyTableByteSize = static_cast<std::uint8_t> (std::ceil (
+  auto frequencyTableByteSize = static_cast<std::uint8_t> (std::ceil (
       std::log2 (static_cast<double> (cFreqTable_[static_cast<std::size_t> (frequencyTableSize - 1)] + 1)) / 8.0));
 
   // write size of frequency table to output stream
@@ -309,7 +309,7 @@ pcl::StaticRangeCoder::encodeIntVectorToStream (std::vector<unsigned int>& input
 
   readPos = 0;
   std::uint64_t low = 0;
-  std::uint64_t range = static_cast<std::uint64_t> (-1);
+  auto range = static_cast<std::uint64_t> (-1);
 
   // start encoding
   while (readPos < input_size)
@@ -389,7 +389,7 @@ pcl::StaticRangeCoder::decodeStreamToIntVector (std::istream& inputByteStream_ar
   // initialize range & code
   std::uint64_t code = 0;
   std::uint64_t low = 0;
-  std::uint64_t range = static_cast<std::uint64_t> (-1);
+  auto range = static_cast<std::uint64_t> (-1);
 
   // init code vector
   for (unsigned int i = 0; i < 8; i++)
@@ -467,7 +467,7 @@ pcl::StaticRangeCoder::encodeCharVectorToStream (const std::vector<char>& inputB
   unsigned int readPos = 0;
   while (readPos < input_size)
   {
-    std::uint8_t symbol = static_cast<std::uint8_t> (inputByteVector_arg[readPos++]);
+    auto symbol = static_cast<std::uint8_t> (inputByteVector_arg[readPos++]);
     FreqHist[symbol + 1]++;
   }
 

--- a/io/include/pcl/compression/impl/octree_pointcloud_compression.hpp
+++ b/io/include/pcl/compression/impl/octree_pointcloud_compression.hpp
@@ -55,7 +55,7 @@ namespace pcl
         const PointCloudConstPtr &cloud_arg,
         std::ostream& compressed_tree_data_out_arg)
     {
-      unsigned char recent_tree_depth =
+      auto recent_tree_depth =
           static_cast<unsigned char> (this->getTreeDepth ());
 
       // initialize octree

--- a/io/include/pcl/compression/impl/organized_pointcloud_compression.hpp
+++ b/io/include/pcl/compression/impl/organized_pointcloud_compression.hpp
@@ -225,7 +225,7 @@ namespace pcl
            // grayscale conversion
            for (std::size_t i = 0; i < size; ++i)
            {
-             std::uint8_t grayvalue = static_cast<std::uint8_t>(0.2989 * static_cast<float>(colorImage_arg[i*3+0]) +
+             auto grayvalue = static_cast<std::uint8_t>(0.2989 * static_cast<float>(colorImage_arg[i*3+0]) +
                                                       0.5870 * static_cast<float>(colorImage_arg[i*3+1]) +
                                                       0.1140 * static_cast<float>(colorImage_arg[i*3+2]));
              monoImage.push_back(grayvalue);

--- a/io/include/pcl/compression/organized_pointcloud_conversion.h
+++ b/io/include/pcl/compression/organized_pointcloud_conversion.h
@@ -113,7 +113,7 @@ struct OrganizedConversion<PointT, false>
       if (pcl::isFinite (point))
       {
         // Inverse depth quantization
-        std::uint16_t disparity = static_cast<std::uint16_t> ( focalLength_arg / (disparityScale_arg * point.z) + disparityShift_arg / disparityScale_arg);
+        auto disparity = static_cast<std::uint16_t> ( focalLength_arg / (disparityScale_arg * point.z) + disparityShift_arg / disparityScale_arg);
         disparityData_arg.push_back (disparity);
       }
       else
@@ -303,7 +303,7 @@ struct OrganizedConversion<PointT, true>
         if (convertToMono)
         {
           // Encode point color
-          std::uint8_t grayvalue = static_cast<std::uint8_t>(0.2989 * point.r
+          auto grayvalue = static_cast<std::uint8_t>(0.2989 * point.r
                                                     + 0.5870 * point.g
                                                     + 0.1140 * point.b);
 
@@ -317,7 +317,7 @@ struct OrganizedConversion<PointT, true>
         }
 
         // Inverse depth quantization
-        std::uint16_t disparity = static_cast<std::uint16_t> (focalLength_arg / (disparityScale_arg * point.z) + disparityShift_arg / disparityScale_arg);
+        auto disparity = static_cast<std::uint16_t> (focalLength_arg / (disparityScale_arg * point.z) + disparityShift_arg / disparityScale_arg);
 
         // Encode disparity
         disparityData_arg.push_back (disparity);

--- a/io/include/pcl/io/impl/ascii_io.hpp
+++ b/io/include/pcl/io/impl/ascii_io.hpp
@@ -50,7 +50,7 @@ ASCIIReader::setInputFields ()
 
   // Remove empty fields and adjust offset
   int offset =0;
-  for (std::vector<pcl::PCLPointField>::iterator field_iter = fields_.begin ();
+  for (auto field_iter = fields_.begin ();
        field_iter != fields_.end (); ++field_iter)
   {
     if (field_iter->name == "_") 

--- a/io/include/pcl/io/impl/lzf_image_io.hpp
+++ b/io/include/pcl/io/impl/lzf_image_io.hpp
@@ -236,9 +236,9 @@ LZFRGB24ImageReader::read (
   cloud.resize (getWidth () * getHeight ());
 
   int rgb_idx = 0;
-  unsigned char *color_r = reinterpret_cast<unsigned char*> (&uncompressed_data[0]);
-  unsigned char *color_g = reinterpret_cast<unsigned char*> (&uncompressed_data[getWidth () * getHeight ()]);
-  unsigned char *color_b = reinterpret_cast<unsigned char*> (&uncompressed_data[2 * getWidth () * getHeight ()]);
+  auto *color_r = reinterpret_cast<unsigned char*> (&uncompressed_data[0]);
+  auto *color_g = reinterpret_cast<unsigned char*> (&uncompressed_data[getWidth () * getHeight ()]);
+  auto *color_b = reinterpret_cast<unsigned char*> (&uncompressed_data[2 * getWidth () * getHeight ()]);
 
   for (std::size_t i = 0; i < cloud.size (); ++i, ++rgb_idx)
   {
@@ -284,9 +284,9 @@ LZFRGB24ImageReader::readOMP (
   cloud.height = getHeight ();
   cloud.resize (getWidth () * getHeight ());
 
-  unsigned char *color_r = reinterpret_cast<unsigned char*> (&uncompressed_data[0]);
-  unsigned char *color_g = reinterpret_cast<unsigned char*> (&uncompressed_data[getWidth () * getHeight ()]);
-  unsigned char *color_b = reinterpret_cast<unsigned char*> (&uncompressed_data[2 * getWidth () * getHeight ()]);
+  auto *color_r = reinterpret_cast<unsigned char*> (&uncompressed_data[0]);
+  auto *color_g = reinterpret_cast<unsigned char*> (&uncompressed_data[getWidth () * getHeight ()]);
+  auto *color_b = reinterpret_cast<unsigned char*> (&uncompressed_data[2 * getWidth () * getHeight ()]);
 
 #ifdef _OPENMP
 #pragma omp parallel for                   \
@@ -341,9 +341,9 @@ LZFYUV422ImageReader::read (
   cloud.resize (getWidth () * getHeight ());
 
   int wh2 = getWidth () * getHeight () / 2;
-  unsigned char *color_u = reinterpret_cast<unsigned char*> (&uncompressed_data[0]);
-  unsigned char *color_y = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2]);
-  unsigned char *color_v = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2 + getWidth () * getHeight ()]);
+  auto *color_u = reinterpret_cast<unsigned char*> (&uncompressed_data[0]);
+  auto *color_y = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2]);
+  auto *color_v = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2 + getWidth () * getHeight ()]);
 
   int y_idx = 0;
   for (int i = 0; i < wh2; ++i, y_idx += 2)
@@ -399,9 +399,9 @@ LZFYUV422ImageReader::readOMP (
   cloud.resize (getWidth () * getHeight ());
 
   int wh2 = getWidth () * getHeight () / 2;
-  unsigned char *color_u = reinterpret_cast<unsigned char*> (&uncompressed_data[0]);
-  unsigned char *color_y = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2]);
-  unsigned char *color_v = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2 + getWidth () * getHeight ()]);
+  auto *color_u = reinterpret_cast<unsigned char*> (&uncompressed_data[0]);
+  auto *color_y = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2]);
+  auto *color_v = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2 + getWidth () * getHeight ()]);
 
 #ifdef _OPENMP
 #pragma omp parallel for                        \

--- a/io/include/pcl/io/impl/point_cloud_image_extractors.hpp
+++ b/io/include/pcl/io/impl/point_cloud_image_extractors.hpp
@@ -153,7 +153,7 @@ pcl::io::PointCloudImageExtractorFromLabelField<PointT>::extractImpl (const Poin
       img.height = cloud.height;
       img.step = img.width * sizeof (unsigned short);
       img.data.resize (img.step * img.height);
-      unsigned short* data = reinterpret_cast<unsigned short*>(&img.data[0]);
+      auto* data = reinterpret_cast<unsigned short*>(&img.data[0]);
       for (std::size_t i = 0; i < cloud.size (); ++i)
       {
         std::uint32_t val;
@@ -254,7 +254,7 @@ pcl::io::PointCloudImageExtractorWithScaling<PointT>::extractImpl (const PointCl
   img.height = cloud.height;
   img.step = img.width * sizeof (unsigned short);
   img.data.resize (img.step * img.height);
-  unsigned short* data = reinterpret_cast<unsigned short*>(&img.data[0]);
+  auto* data = reinterpret_cast<unsigned short*>(&img.data[0]);
 
   float scaling_factor = scaling_factor_;
   float data_min = 0.0f;

--- a/io/src/dinast_grabber.cpp
+++ b/io/src/dinast_grabber.cpp
@@ -317,8 +317,8 @@ pcl::DinastGrabber::getXYZIPointCloud ()
       double pixel = image_[x + image_width_ * y];
 
       // Correcting distortion, data empirically got in a calibration test
-      double xc = static_cast<double> (x - image_width_ / 2);
-      double yc = static_cast<double> (y - image_height_ / 2);
+      auto xc = static_cast<double> (x - image_width_ / 2);
+      auto yc = static_cast<double> (y - image_height_ / 2);
       double r1 = sqrt (xc * xc + yc * yc);
       double r2 = r1 * r1;
       double r3 = r1 * r2;

--- a/io/src/hdl_grabber.cpp
+++ b/io/src/hdl_grabber.cpp
@@ -472,7 +472,7 @@ pcl::HDLGrabber::enqueueHDLPacket (const std::uint8_t *data,
 {
   if (bytesReceived == 1206)
   {
-    std::uint8_t *dup = static_cast<std::uint8_t *> (malloc (bytesReceived * sizeof(std::uint8_t)));
+    auto *dup = static_cast<std::uint8_t *> (malloc (bytesReceived * sizeof(std::uint8_t)));
     memcpy (dup, data, bytesReceived * sizeof (std::uint8_t));
 
     hdl_data_.enqueue (dup);

--- a/io/src/libpng_wrapper.cpp
+++ b/io/src/libpng_wrapper.cpp
@@ -55,7 +55,7 @@ namespace
   void 
   user_read_data (png_structp png_ptr, png_bytep data, png_size_t length)
   {
-    std::uint8_t** input_pointer = reinterpret_cast<std::uint8_t**>(png_get_io_ptr (png_ptr));
+    auto** input_pointer = reinterpret_cast<std::uint8_t**>(png_get_io_ptr (png_ptr));
 
     memcpy (data, *input_pointer, sizeof (std::uint8_t) * length);
     (*input_pointer) += length;
@@ -65,7 +65,7 @@ namespace
   void 
   user_write_data (png_structp png_ptr,  png_bytep data, png_size_t length)
   {
-    std::vector<std::uint8_t>* pngVec = reinterpret_cast<std::vector<std::uint8_t>*>(png_get_io_ptr (png_ptr));
+    auto* pngVec = reinterpret_cast<std::vector<std::uint8_t>*>(png_get_io_ptr (png_ptr));
     std::copy (data, data + length, std::back_inserter (*pngVec));
   }
 

--- a/io/src/lzf.cpp
+++ b/io/src/lzf.cpp
@@ -91,8 +91,8 @@ pcl::lzfCompress (const void *const in_data, unsigned int in_len,
                   void *out_data, unsigned int out_len)
 {
   LZF_STATE htab;
-  const unsigned char *ip = static_cast<const unsigned char *> (in_data);
-        unsigned char *op = static_cast<unsigned char *> (out_data);
+  const auto *ip = static_cast<const unsigned char *> (in_data);
+        auto *op = static_cast<unsigned char *> (out_data);
   const unsigned char *in_end  = ip + in_len;
         unsigned char *out_end = op + out_len;
 
@@ -280,8 +280,8 @@ unsigned int
 pcl::lzfDecompress (const void *const in_data,  unsigned int in_len,
                     void             *out_data, unsigned int out_len)
 {
-  unsigned char const *ip = static_cast<const unsigned char *> (in_data);
-  unsigned char       *op = static_cast<unsigned char *> (out_data);
+  auto const *ip = static_cast<const unsigned char *> (in_data);
+  auto       *op = static_cast<unsigned char *> (out_data);
   unsigned char const *const in_end  = ip + in_len;
   unsigned char       *const out_end = op + out_len;
 

--- a/io/src/lzf_image_io.cpp
+++ b/io/src/lzf_image_io.cpp
@@ -116,7 +116,7 @@ pcl::io::LZFImageWriter::compress (const char* input,
                                    char *output)
 {
   static const int header_size = LZF_HEADER_SIZE;
-  float finput_size = static_cast<float> (uncompressed_size);
+  auto finput_size = static_cast<float> (uncompressed_size);
   unsigned int compressed_size = pcl::lzfCompress (input,
                                                    uncompressed_size,
                                                    &output[header_size],

--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -135,7 +135,7 @@ pcl::MTLReader::fillRGBfromRGB (const std::vector<std::string>& split_line,
 std::vector<pcl::TexMaterial>::const_iterator
 pcl::MTLReader::getMaterial (const std::string& material_name) const
 {
-  std::vector<pcl::TexMaterial>::const_iterator mat_it = materials_.begin ();
+  auto mat_it = materials_.begin ();
   for (; mat_it != materials_.end (); ++mat_it)
     if (mat_it->tex_name == material_name)
       break;
@@ -562,7 +562,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
         {
           for (int i = 1, f = 0; i < 4; ++i, ++f)
           {
-            float value = boost::lexical_cast<float> (st[i]);
+            auto value = boost::lexical_cast<float> (st[i]);
             memcpy (&cloud.data[point_idx * cloud.point_step + cloud.fields[f].offset],
                 &value,
                 sizeof (float));
@@ -591,7 +591,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
         {
           for (int i = 1, f = normal_x_field; i < 4; ++i, ++f)
           {
-            float value = boost::lexical_cast<float> (st[i]);
+            auto value = boost::lexical_cast<float> (st[i]);
             memcpy (&cloud.data[normal_idx * cloud.point_step + cloud.fields[f].offset],
                 &value,
                 sizeof (float));
@@ -700,7 +700,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
         {
           for (int i = 1, f = 0; i < 4; ++i, ++f)
           {
-            float value = boost::lexical_cast<float> (st[i]);
+            auto value = boost::lexical_cast<float> (st[i]);
             memcpy (&mesh.cloud.data[v_idx * mesh.cloud.point_step + mesh.cloud.fields[f].offset],
                 &value,
                 sizeof (float));
@@ -721,7 +721,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
         {
           for (int i = 1, f = normal_x_field; i < 4; ++i, ++f)
           {
-            float value = boost::lexical_cast<float> (st[i]);
+            auto value = boost::lexical_cast<float> (st[i]);
             memcpy (&mesh.cloud.data[vn_idx * mesh.cloud.point_step + mesh.cloud.fields[f].offset],
                 &value,
                 sizeof (float));
@@ -895,7 +895,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PolygonMesh &mesh,
         {
           for (int i = 1, f = 0; i < 4; ++i, ++f)
           {
-            float value = boost::lexical_cast<float> (st[i]);
+            auto value = boost::lexical_cast<float> (st[i]);
             memcpy (&mesh.cloud.data[v_idx * mesh.cloud.point_step + mesh.cloud.fields[f].offset],
                 &value,
                 sizeof (float));
@@ -917,7 +917,7 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PolygonMesh &mesh,
         {
           for (int i = 1, f = normal_x_field; i < 4; ++i, ++f)
           {
-            float value = boost::lexical_cast<float> (st[i]);
+            auto value = boost::lexical_cast<float> (st[i]);
             memcpy (&mesh.cloud.data[vn_idx * mesh.cloud.point_step + mesh.cloud.fields[f].offset],
                 &value,
                 sizeof (float));
@@ -986,10 +986,10 @@ pcl::io::saveOBJFile (const std::string &file_name,
   /* Write 3D information */
   // number of points
   unsigned nr_points  = tex_mesh.cloud.width * tex_mesh.cloud.height;
-  unsigned point_size = static_cast<unsigned> (tex_mesh.cloud.data.size () / nr_points);
+  auto point_size = static_cast<unsigned> (tex_mesh.cloud.data.size () / nr_points);
 
   // mesh size
-  unsigned nr_meshes = static_cast<unsigned> (tex_mesh.tex_polygons.size ());
+  auto nr_meshes = static_cast<unsigned> (tex_mesh.tex_polygons.size ());
   // number of faces for header
   unsigned nr_faces = 0;
   for (unsigned m = 0; m < nr_meshes; ++m)
@@ -1169,9 +1169,9 @@ pcl::io::saveOBJFile (const std::string &file_name,
   // number of points
   int nr_points  = mesh.cloud.width * mesh.cloud.height;
   // point size
-  unsigned point_size = static_cast<unsigned> (mesh.cloud.data.size () / nr_points);
+  auto point_size = static_cast<unsigned> (mesh.cloud.data.size () / nr_points);
   // number of faces for header
-  unsigned nr_faces = static_cast<unsigned> (mesh.polygons.size ());
+  auto nr_faces = static_cast<unsigned> (mesh.polygons.size ());
   // Do we have vertices normals?
   int normal_index = getFieldIndex (mesh.cloud, "normal_x");
 

--- a/io/src/openni_camera/openni_device.cpp
+++ b/io/src/openni_camera/openni_device.cpp
@@ -395,7 +395,7 @@ void openni_wrapper::OpenNIDevice::InitShiftToDepthConversion ()
 
     for (std::uint32_t nIndex = 1; nIndex < shift_conversion_parameters_.device_max_shift_; nIndex++)
     {
-      std::int32_t nShiftValue = (std::int32_t)nIndex;
+      auto nShiftValue = (std::int32_t)nIndex;
 
       double dFixedRefX = (double) (nShiftValue - nConstShift) /
                           (double) shift_conversion_parameters_.param_coeff_;
@@ -697,8 +697,8 @@ openni_wrapper::OpenNIDevice::isDepthRegistered () const throw ()
 {
   if (hasDepthStream () && hasImageStream() )
   {
-    xn::DepthGenerator& depth_generator = const_cast<xn::DepthGenerator&>(depth_generator_);
-    xn::ImageGenerator& image_generator = const_cast<xn::ImageGenerator&>(image_generator_);
+    auto& depth_generator = const_cast<xn::DepthGenerator&>(depth_generator_);
+    auto& image_generator = const_cast<xn::ImageGenerator&>(image_generator_);
 
     std::lock_guard<std::mutex> image_lock (image_mutex_);
     std::lock_guard<std::mutex> depth_lock (depth_mutex_);
@@ -713,7 +713,7 @@ openni_wrapper::OpenNIDevice::isDepthRegistrationSupported () const throw ()
 {
   std::lock_guard<std::mutex> image_lock (image_mutex_);
   std::lock_guard<std::mutex> depth_lock (depth_mutex_);
-  xn::ImageGenerator& image_generator = const_cast<xn::ImageGenerator&> (image_generator_);
+  auto& image_generator = const_cast<xn::ImageGenerator&> (image_generator_);
   return (depth_generator_.IsValid() && image_generator_.IsValid() && depth_generator_.GetAlternativeViewPointCap().IsViewPointSupported(image_generator));
 }
 
@@ -761,8 +761,8 @@ openni_wrapper::OpenNIDevice::isSynchronized () const throw ()
   {
     std::lock_guard<std::mutex> image_lock (image_mutex_);
     std::lock_guard<std::mutex> depth_lock (depth_mutex_);
-    xn::DepthGenerator& depth_generator = const_cast<xn::DepthGenerator&>(depth_generator_);
-    xn::ImageGenerator& image_generator = const_cast<xn::ImageGenerator&>(image_generator_);
+    auto& depth_generator = const_cast<xn::DepthGenerator&>(depth_generator_);
+    auto& image_generator = const_cast<xn::ImageGenerator&>(image_generator_);
     return (depth_generator.GetFrameSyncCap ().CanFrameSyncWith (image_generator) && depth_generator.GetFrameSyncCap ().IsFrameSyncedWith (image_generator));
   }
   return (false);
@@ -784,7 +784,7 @@ openni_wrapper::OpenNIDevice::isDepthCropped () const
   {
     std::lock_guard<std::mutex> depth_lock (depth_mutex_);
     XnCropping cropping;
-    xn::DepthGenerator& depth_generator = const_cast<xn::DepthGenerator&>(depth_generator_);
+    auto& depth_generator = const_cast<xn::DepthGenerator&>(depth_generator_);
     XnStatus status = depth_generator.GetCroppingCap ().GetCropping (cropping);
     if (status != XN_STATUS_OK)
       THROW_OPENNI_EXCEPTION ("could not read cropping information for depth stream. Reason: %s", xnGetStatusString (status));
@@ -909,7 +909,7 @@ openni_wrapper::OpenNIDevice::IRDataThreadFunction ()
 void __stdcall 
 openni_wrapper::OpenNIDevice::NewDepthDataAvailable (xn::ProductionNode&, void* cookie) noexcept
 {
-  OpenNIDevice* device = reinterpret_cast<OpenNIDevice*>(cookie);
+  auto* device = reinterpret_cast<OpenNIDevice*>(cookie);
   device->depth_condition_.notify_all ();
 }
 
@@ -917,7 +917,7 @@ openni_wrapper::OpenNIDevice::NewDepthDataAvailable (xn::ProductionNode&, void* 
 void __stdcall 
 openni_wrapper::OpenNIDevice::NewImageDataAvailable (xn::ProductionNode&, void* cookie) noexcept
 {
-  OpenNIDevice* device = reinterpret_cast<OpenNIDevice*>(cookie);
+  auto* device = reinterpret_cast<OpenNIDevice*>(cookie);
   device->image_condition_.notify_all ();
 }
 
@@ -925,7 +925,7 @@ openni_wrapper::OpenNIDevice::NewImageDataAvailable (xn::ProductionNode&, void* 
 void __stdcall 
 openni_wrapper::OpenNIDevice::NewIRDataAvailable (xn::ProductionNode&, void* cookie) noexcept
 {
-  OpenNIDevice* device = reinterpret_cast<OpenNIDevice*>(cookie);
+  auto* device = reinterpret_cast<OpenNIDevice*>(cookie);
   device->ir_condition_.notify_all ();
 }
 
@@ -1056,7 +1056,7 @@ openni_wrapper::OpenNIDevice::getAddress () const throw ()
 const char* 
 openni_wrapper::OpenNIDevice::getVendorName () const throw ()
 {
-  XnProductionNodeDescription& description = const_cast<XnProductionNodeDescription&>(device_node_info_.GetDescription ());
+  auto& description = const_cast<XnProductionNodeDescription&>(device_node_info_.GetDescription ());
   return (description.strVendor);
 }
 
@@ -1064,7 +1064,7 @@ openni_wrapper::OpenNIDevice::getVendorName () const throw ()
 const char* 
 openni_wrapper::OpenNIDevice::getProductName () const throw ()
 {
-  XnProductionNodeDescription& description = const_cast<XnProductionNodeDescription&>(device_node_info_.GetDescription ());
+  auto& description = const_cast<XnProductionNodeDescription&>(device_node_info_.GetDescription ());
   return (description.strName);
 }
 

--- a/io/src/openni_camera/openni_device_oni.cpp
+++ b/io/src/openni_camera/openni_device_oni.cpp
@@ -223,7 +223,7 @@ openni_wrapper::DeviceONI::PlayerThreadFunction ()
 void __stdcall 
 openni_wrapper::DeviceONI::NewONIDepthDataAvailable (xn::ProductionNode&, void* cookie) noexcept
 {
-  DeviceONI* device = reinterpret_cast<DeviceONI*>(cookie);
+  auto* device = reinterpret_cast<DeviceONI*>(cookie);
   if (device->depth_stream_running_)
     device->depth_condition_.notify_all ();
 }
@@ -232,7 +232,7 @@ openni_wrapper::DeviceONI::NewONIDepthDataAvailable (xn::ProductionNode&, void* 
 void __stdcall 
 openni_wrapper::DeviceONI::NewONIImageDataAvailable (xn::ProductionNode&, void* cookie) noexcept
 {
-  DeviceONI* device = reinterpret_cast<DeviceONI*> (cookie);
+  auto* device = reinterpret_cast<DeviceONI*> (cookie);
   if (device->image_stream_running_)
     device->image_condition_.notify_all ();
 }
@@ -241,7 +241,7 @@ openni_wrapper::DeviceONI::NewONIImageDataAvailable (xn::ProductionNode&, void* 
 void __stdcall 
 openni_wrapper::DeviceONI::NewONIIRDataAvailable (xn::ProductionNode&, void* cookie) noexcept
 {
-  DeviceONI* device = reinterpret_cast<DeviceONI*> (cookie);
+  auto* device = reinterpret_cast<DeviceONI*> (cookie);
   if (device->ir_stream_running_)
     device->ir_condition_.notify_all ();
 }

--- a/io/src/openni_camera/openni_driver.cpp
+++ b/io/src/openni_camera/openni_driver.cpp
@@ -291,7 +291,7 @@ openni_wrapper::OpenNIDriver::getDeviceByIndex (unsigned index) const
 openni_wrapper::OpenNIDevice::Ptr
 openni_wrapper::OpenNIDriver::getDeviceBySerialNumber (const std::string& serial_number) const
 {
-  std::map<std::string, unsigned>::const_iterator it = serial_map_.find (serial_number);
+  auto it = serial_map_.find (serial_number);
 
   if (it != serial_map_.end ())
   {
@@ -309,10 +309,10 @@ openni_wrapper::OpenNIDriver::getDeviceBySerialNumber (const std::string& serial
 openni_wrapper::OpenNIDevice::Ptr
 openni_wrapper::OpenNIDriver::getDeviceByAddress (unsigned char bus, unsigned char address) const
 {
-  std::map<unsigned char, std::map<unsigned char, unsigned> >::const_iterator busIt = bus_map_.find (bus);
+  auto busIt = bus_map_.find (bus);
   if (busIt != bus_map_.end ())
   {
-    std::map<unsigned char, unsigned>::const_iterator devIt = busIt->second.find (address);
+    auto devIt = busIt->second.find (address);
     if (devIt != busIt->second.end ())
     {
       return getDeviceByIndex (devIt->second);
@@ -350,13 +350,13 @@ openni_wrapper::OpenNIDriver::getDeviceInfos () noexcept
       continue;
 
     std::uint8_t address = libusb_get_device_address (device);
-    std::map<unsigned char, unsigned>::const_iterator addressIt = busIt->second.find (address);
+    auto addressIt = busIt->second.find (address);
     if (addressIt == busIt->second.end ())
       continue;
 
     unsigned nodeIdx = addressIt->second;
     xn::NodeInfo& current_node = device_context_[nodeIdx].device_node;
-    XnProductionNodeDescription& description = const_cast<XnProductionNodeDescription&>(current_node.GetDescription ());
+    auto& description = const_cast<XnProductionNodeDescription&>(current_node.GetDescription ());
 
     libusb_device_descriptor descriptor;
     result = libusb_get_device_descriptor (devices[devIdx], &descriptor);

--- a/io/src/openni_camera/openni_image_rgb24.cpp
+++ b/io/src/openni_camera/openni_image_rgb24.cpp
@@ -62,7 +62,7 @@ void ImageRGB24::fillRGB (unsigned width, unsigned height, unsigned char* rgb_bu
     else // line by line
     {
       unsigned char* rgb_line = rgb_buffer;
-      const unsigned char* src_line = static_cast<const unsigned char*> (image_md_->Data());
+      const auto* src_line = static_cast<const unsigned char*> (image_md_->Data());
       for (unsigned yIdx = 0; yIdx < height; ++yIdx, rgb_line += rgb_line_step, src_line += line_size)
       {
         memcpy (rgb_line, src_line, line_size);
@@ -79,7 +79,7 @@ void ImageRGB24::fillRGB (unsigned width, unsigned height, unsigned char* rgb_bu
 
     unsigned dst_skip = rgb_line_step - width * 3; // skip of padding values in bytes
 
-    XnRGB24Pixel* dst_line = reinterpret_cast<XnRGB24Pixel*> (rgb_buffer);
+    auto* dst_line = reinterpret_cast<XnRGB24Pixel*> (rgb_buffer);
     const XnRGB24Pixel* src_line = image_md_->RGB24Data();
 
     for (unsigned yIdx = 0; yIdx < height; ++yIdx, src_line += src_skip)
@@ -92,7 +92,7 @@ void ImageRGB24::fillRGB (unsigned width, unsigned height, unsigned char* rgb_bu
       if (dst_skip != 0)
       {
         // use bytes to skip rather than XnRGB24Pixel's, since line_step does not need to be multiple of 3
-        unsigned char* temp = reinterpret_cast <unsigned char*> (dst_line);
+        auto* temp = reinterpret_cast <unsigned char*> (dst_line);
         dst_line = reinterpret_cast <XnRGB24Pixel*> (temp + dst_skip);
       }
     }

--- a/io/src/openni_grabber.cpp
+++ b/io/src/openni_grabber.cpp
@@ -110,7 +110,7 @@ pcl::OpenNIGrabber::OpenNIGrabber (const std::string& device_id, const Mode& dep
     {
       imageDepthImageCallback (image, depth_image);
     });
-    openni_wrapper::DeviceKinect* kinect = dynamic_cast<openni_wrapper::DeviceKinect*> (device_.get ());
+    auto* kinect = dynamic_cast<openni_wrapper::DeviceKinect*> (device_.get ());
     if (kinect)
       kinect->setDebayeringMethod (openni_wrapper::ImageBayerGRBG::EdgeAware);
   }
@@ -849,7 +849,7 @@ pcl::OpenNIGrabber::updateModeMaps ()
 bool
 pcl::OpenNIGrabber::mapConfigMode2XnMode (int mode, XnMapOutputMode &xnmode) const
 {
-  std::map<int, XnMapOutputMode>::const_iterator it = config2xn_map_.find (mode);
+  auto it = config2xn_map_.find (mode);
   if (it != config2xn_map_.end ())
   {
     xnmode = it->second;

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -577,7 +577,7 @@ pcl::PCDReader::readBodyBinary (const unsigned char *map, pcl::PCLPointCloud2 &c
       cloud.data.resize (uncompressed_size);
     }
 
-    unsigned int data_size = static_cast<unsigned int> (cloud.data.size ());
+    auto data_size = static_cast<unsigned int> (cloud.data.size ());
     std::vector<char> buf (data_size);
     // The size of the uncompressed data better be the same as what we stored in the header
     unsigned int tmp_size = pcl::lzfDecompress (&map[data_idx + 8], compressed_size, &buf[0], data_size);
@@ -811,7 +811,7 @@ pcl::PCDReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
       return (-1);
     }
 #else
-    unsigned char *map = static_cast<unsigned char*> (::mmap (nullptr, mmap_size, PROT_READ, MAP_SHARED, fd, 0));
+    auto *map = static_cast<unsigned char*> (::mmap (nullptr, mmap_size, PROT_READ, MAP_SHARED, fd, 0));
     if (map == reinterpret_cast<unsigned char*> (-1))    // MAP_FAILED
     {
       io::raw_close (fd);

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -857,7 +857,7 @@ pcl::PLYWriter::writeASCII (const std::string &file_name,
   }
 
   unsigned int nr_points  = cloud.width * cloud.height;
-  unsigned int point_size = static_cast<unsigned int> (cloud.data.size () / nr_points);
+  auto point_size = static_cast<unsigned int> (cloud.data.size () / nr_points);
 
   // Write the header information if available
   if (use_camera)
@@ -1188,7 +1188,7 @@ pcl::PLYWriter::writeBinary (const std::string &file_name,
   }
 
   unsigned int nr_points  = cloud.width * cloud.height;
-  unsigned int point_size = static_cast<unsigned int> (cloud.data.size () / nr_points);
+  auto point_size = static_cast<unsigned int> (cloud.data.size () / nr_points);
 
   // Compute the range_grid, if necessary, and then write out the PLY header
   bool doRangeGrid = !use_camera && cloud.height > 1;
@@ -1681,7 +1681,7 @@ pcl::io::savePLYFileBinary (const std::string &file_name, const pcl::PolygonMesh
   // Write down faces
   for (const pcl::Vertices& polygon : mesh.polygons)
   {
-    unsigned char value = static_cast<unsigned char> (polygon.vertices.size ());
+    auto value = static_cast<unsigned char> (polygon.vertices.size ());
     fpout.write (reinterpret_cast<const char*> (&value), sizeof (unsigned char));
     for (const int value : polygon.vertices)
     {

--- a/io/src/robot_eye_grabber.cpp
+++ b/io/src/robot_eye_grabber.cpp
@@ -291,7 +291,7 @@ pcl::RobotEyeGrabber::socketCallback (const boost::system::error_code&, std::siz
     || sensor_address_ == sender_endpoint_.address ())
   {
     data_size_ = number_of_bytes;
-    unsigned char *dup = new unsigned char[number_of_bytes];
+    auto *dup = new unsigned char[number_of_bytes];
     memcpy (dup, receive_buffer_, number_of_bytes);
     packet_queue_.enqueue (boost::shared_array<unsigned char>(dup));
   }

--- a/io/src/vtk_io.cpp
+++ b/io/src/vtk_io.cpp
@@ -59,7 +59,7 @@ pcl::io::saveVTKFile (const std::string &file_name,
   fs.open (file_name.c_str ());
 
   unsigned int nr_points  = triangles.cloud.width * triangles.cloud.height;
-  unsigned int point_size = static_cast<unsigned int> (triangles.cloud.data.size () / nr_points);
+  auto point_size = static_cast<unsigned int> (triangles.cloud.data.size () / nr_points);
 
   // Write the header information
   fs << "# vtk DataFile Version 3.0\nvtk output\nASCII\nDATASET POLYDATA\nPOINTS " << nr_points << " float" << '\n';
@@ -153,7 +153,7 @@ pcl::io::saveVTKFile (const std::string &file_name,
   fs.open (file_name.c_str ());
 
   unsigned int nr_points  = cloud.width * cloud.height;
-  unsigned int point_size = static_cast<unsigned int> (cloud.data.size () / nr_points);
+  auto point_size = static_cast<unsigned int> (cloud.data.size () / nr_points);
 
   // Write the header information
   fs << "# vtk DataFile Version 3.0\nvtk output\nASCII\nDATASET POLYDATA\nPOINTS " << nr_points << " float" << '\n';

--- a/io/src/vtk_lib_io.cpp
+++ b/io/src/vtk_lib_io.cpp
@@ -424,7 +424,7 @@ int
 pcl::io::mesh2vtk (const pcl::PolygonMesh& mesh, vtkSmartPointer<vtkPolyData>& poly_data)
 {
   auto nr_points = mesh.cloud.width * mesh.cloud.height;
-  unsigned int nr_polygons = static_cast<unsigned int> (mesh.polygons.size ());
+  auto nr_polygons = static_cast<unsigned int> (mesh.polygons.size ());
 
   // reset vtkPolyData object
   poly_data = vtkSmartPointer<vtkPolyData>::New (); // OR poly_data->Reset();
@@ -468,7 +468,7 @@ pcl::io::mesh2vtk (const pcl::PolygonMesh& mesh, vtkSmartPointer<vtkPolyData>& p
   {
     for (unsigned int i = 0; i < nr_polygons; i++)
     {
-      unsigned int nr_points_in_polygon = static_cast<unsigned int> (mesh.polygons[i].vertices.size ());
+      auto nr_points_in_polygon = static_cast<unsigned int> (mesh.polygons[i].vertices.size ());
       vtk_mesh_polygons->InsertNextCell (nr_points_in_polygon);
       for (unsigned int j = 0; j < nr_points_in_polygon; j++)
         vtk_mesh_polygons->InsertCellPoint (mesh.polygons[i].vertices[j]);
@@ -530,13 +530,13 @@ pcl::io::saveRangeImagePlanarFilePNG (
     {
     for (int x = 0; x < dims[0]; x++)
       {
-      float* pixel = static_cast<float*>(image->GetScalarPointer(x,y,0));
+      auto* pixel = static_cast<float*>(image->GetScalarPointer(x,y,0));
       pixel[0] = range_image(y,x).range;
       }
     }
 
   // Compute the scaling
-  float oldRange = static_cast<float> (image->GetScalarRange()[1] - image->GetScalarRange()[0]);
+  auto oldRange = static_cast<float> (image->GetScalarRange()[1] - image->GetScalarRange()[0]);
   float newRange = 255; // We want the output [0,255]
 
   vtkSmartPointer<vtkImageShiftScale> shiftScaleFilter = vtkSmartPointer<vtkImageShiftScale>::New();

--- a/io/tools/hdl_grabber_example.cpp
+++ b/io/tools/hdl_grabber_example.cpp
@@ -50,8 +50,8 @@ class SimpleHDLGrabber
       if (sweep->header.seq == 0) {
         std::uint64_t stamp;
         stamp = sweep->header.stamp;
-        time_t systemTime = static_cast<time_t>(((stamp & 0xffffffff00000000l) >> 32) & 0x00000000ffffffff);
-        std::uint32_t usec = static_cast<std::uint32_t>(stamp & 0x00000000ffffffff);
+        auto systemTime = static_cast<time_t>(((stamp & 0xffffffff00000000l) >> 32) & 0x00000000ffffffff);
+        auto usec = static_cast<std::uint32_t>(stamp & 0x00000000ffffffff);
         std::cout << std::hex << stamp << "  " << ctime(&systemTime) << " usec: " << usec << std::endl;
       }
 

--- a/io/tools/openni_pcd_recorder.cpp
+++ b/io/tools/openni_pcd_recorder.cpp
@@ -229,7 +229,7 @@ class Producer
     void 
     grabAndSend ()
     {
-      OpenNIGrabber* grabber = new OpenNIGrabber ();
+      auto* grabber = new OpenNIGrabber ();
       grabber->getDevice ()->setDepthOutputFormat (depth_mode_);
 
       Grabber* interface = grabber;

--- a/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/iss_3d.hpp
@@ -347,13 +347,13 @@ pcl::ISSKeypoint3D<PointInT, PointOutT, NormalT>::detectKeypoints (PointCloudOut
   for (std::size_t i = 0; i < threads_; i++)
     omp_mem[i].setZero (3);
 #else
-  Eigen::Vector3d *omp_mem = new Eigen::Vector3d[1];
+  auto *omp_mem = new Eigen::Vector3d[1];
 
   omp_mem[0].setZero (3);
 #endif
 
-  double *prg_local_mem = new double[input_->size () * 3];
-  double **prg_mem = new double * [input_->size ()];
+  auto *prg_local_mem = new double[input_->size () * 3];
+  auto **prg_mem = new double * [input_->size ()];
 
   for (std::size_t i = 0; i < input_->size (); i++)
     prg_mem[i] = prg_local_mem + 3 * i;

--- a/keypoints/include/pcl/keypoints/impl/susan.hpp
+++ b/keypoints/include/pcl/keypoints/impl/susan.hpp
@@ -356,7 +356,7 @@ pcl::SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT>::detectKeypoints (P
         if (label_idx_ != -1)
         {
           // save the index in the cloud
-          std::uint32_t label = static_cast<std::uint32_t> (point_index);
+          auto label = static_cast<std::uint32_t> (point_index);
           memcpy (reinterpret_cast<char*> (&point_out) + out_fields_[label_idx_].offset,
                   &label, sizeof (std::uint32_t));
         }
@@ -389,7 +389,7 @@ pcl::SUSANKeypoint<PointInT, PointOutT, NormalT, IntensityT>::detectKeypoints (P
             if (label_idx_ != -1)
             {
               // save the index in the cloud
-              std::uint32_t label = static_cast<std::uint32_t> (point_index);
+              auto label = static_cast<std::uint32_t> (point_index);
               memcpy (reinterpret_cast<char*> (&point_out) + out_fields_[label_idx_].offset,
                       &label, sizeof (std::uint32_t));
             }

--- a/keypoints/src/agast_2d.cpp
+++ b/keypoints/src/agast_2d.cpp
@@ -299,7 +299,7 @@ pcl::keypoints::agast::AbstractAgastDetector::computeCornerScores (
   const std::vector<pcl::PointUV, Eigen::aligned_allocator<pcl::PointUV> > &corners_all,
   std::vector<ScoreIndex> &scores) const
 {
-  unsigned int num_corners = static_cast<unsigned int> (corners_all.size ());
+  auto num_corners = static_cast<unsigned int> (corners_all.size ());
 
   if (num_corners > scores.capacity ())
   {
@@ -329,7 +329,7 @@ pcl::keypoints::agast::AbstractAgastDetector::computeCornerScores (
   const std::vector<pcl::PointUV, Eigen::aligned_allocator<pcl::PointUV> > &corners_all,
   std::vector<ScoreIndex> &scores) const
 {
-  unsigned int num_corners = static_cast<unsigned int> (corners_all.size ());
+  auto num_corners = static_cast<unsigned int> (corners_all.size ());
 
   if (num_corners > scores.capacity ())
   {

--- a/keypoints/src/brisk_2d.cpp
+++ b/keypoints/src/brisk_2d.cpp
@@ -245,7 +245,7 @@ pcl::keypoints::brisk::ScaleSpace::getScoreAbove (
     const int r_x_1 =6 - r_x;
     const int r_y = (sixths_y % 6);
     const int r_y_1 = 6 - r_y;
-    std::uint8_t score = static_cast<std::uint8_t> (
+    auto score = static_cast<std::uint8_t> (
                     0xFF & ((r_x_1 * r_y_1 * l.getAgastScore (x_above,     y_above,     1) +
                              r_x   * r_y_1 * l.getAgastScore (x_above + 1, y_above,     1) +
                              r_x_1 * r_y   * l.getAgastScore (x_above,     y_above + 1, 1) +
@@ -263,7 +263,7 @@ pcl::keypoints::brisk::ScaleSpace::getScoreAbove (
   const int r_x_1 = 8 - r_x;
   const int r_y = (eighths_y % 8);
   const int r_y_1 = 8 - r_y;
-  std::uint8_t score = static_cast<std::uint8_t> (
+  auto score = static_cast<std::uint8_t> (
                   0xFF & ((r_x_1 * r_y_1 * l.getAgastScore (x_above,     y_above,     1) +
                            r_x   * r_y_1  * l.getAgastScore (x_above + 1, y_above,     1) +
                            r_x_1 * r_y    * l.getAgastScore (x_above ,    y_above + 1, 1) +
@@ -447,7 +447,7 @@ pcl::keypoints::brisk::ScaleSpace::isMax2D (
     delta.push_back (1);
   }
   
-  unsigned int deltasize = static_cast<unsigned int> (delta.size ());
+  auto deltasize = static_cast<unsigned int> (delta.size ());
   if (deltasize != 0)
   {
     // in this case, we have to analyze the situation more carefully:
@@ -512,7 +512,7 @@ pcl::keypoints::brisk::ScaleSpace::refine3D (
       // guess the lower intra octave...
       pcl::keypoints::brisk::Layer& l = pyramid_[0];
       int s_0_0 = l.getAgastScore_5_8 (x_layer - 1, y_layer - 1, 1);
-      unsigned char max_below_uchar = static_cast<unsigned char> (s_0_0);
+      auto max_below_uchar = static_cast<unsigned char> (s_0_0);
       int s_1_0 = l.getAgastScore_5_8 (x_layer, y_layer - 1, 1);
 
       if (s_1_0 > max_below_uchar) max_below_uchar = static_cast<unsigned char> (s_1_0);
@@ -1398,7 +1398,7 @@ pcl::keypoints::brisk::Layer::getAgastScore_5_8 (int x, int y, std::uint8_t thre
   }
 
   agast_detector_5_8_->setThreshold (threshold - 1);
-  std::uint8_t score = std::uint8_t (agast_detector_5_8_->computeCornerScore (&img_[0] + x + y * img_width_));
+  auto score = std::uint8_t (agast_detector_5_8_->computeCornerScore (&img_[0] + x + y * img_width_));
   if (score < threshold) score = 0;
   return (score);
 }
@@ -1560,7 +1560,7 @@ pcl::keypoints::brisk::Layer::halfsample (
 {
   pcl::utils::ignore(dstheight);
 #if defined(__SSSE3__) && !defined(__i386__)
-  const unsigned short leftoverCols = static_cast<unsigned short> ((srcwidth % 16) / 2); // take care with border...
+  const auto leftoverCols = static_cast<unsigned short> ((srcwidth % 16) / 2); // take care with border...
   const bool noleftover = (srcwidth % 16) == 0; // note: leftoverCols can be zero but this still false...
 
   // make sure the destination image is of the right size:
@@ -1571,9 +1571,9 @@ pcl::keypoints::brisk::Layer::halfsample (
   __m128i mask = _mm_set_epi32 (0x00FF00FF, 0x00FF00FF, 0x00FF00FF, 0x00FF00FF);
 
   // data pointers:
-  const __m128i* p1 = reinterpret_cast<const __m128i*> (&srcimg[0]);
-  const __m128i* p2 = reinterpret_cast<const __m128i*> (&srcimg[0] + srcwidth);
-  __m128i* p_dest = reinterpret_cast<__m128i*> (&dstimg[0]);
+  const auto* p1 = reinterpret_cast<const __m128i*> (&srcimg[0]);
+  const auto* p2 = reinterpret_cast<const __m128i*> (&srcimg[0] + srcwidth);
+  auto* p_dest = reinterpret_cast<__m128i*> (&dstimg[0]);
   unsigned char* p_dest_char;//=(unsigned char*)p_dest;
 
   // size:
@@ -1662,7 +1662,7 @@ pcl::keypoints::brisk::Layer::halfsample (
       // Todo: find the equivalent to may_alias
       #define UCHAR_ALIAS unsigned char //__declspec(noalias)
 #endif
-      const UCHAR_ALIAS* result = reinterpret_cast<const UCHAR_ALIAS*> (&result1);
+      const auto* result = reinterpret_cast<const UCHAR_ALIAS*> (&result1);
       for (unsigned int j = 0; j < 8; j++)
       {
         *(p_dest_char++) = static_cast<unsigned char> ((*(result + 2 * j) + *(result + 2 * j + 1)) / 2);
@@ -1683,11 +1683,11 @@ pcl::keypoints::brisk::Layer::halfsample (
     }
     else
     {
-      const unsigned char* p1_src_char = reinterpret_cast<const unsigned char*> (p1);
-      const unsigned char* p2_src_char = reinterpret_cast<const unsigned char*> (p2);
+      const auto* p1_src_char = reinterpret_cast<const unsigned char*> (p1);
+      const auto* p2_src_char = reinterpret_cast<const unsigned char*> (p2);
       for (unsigned int k = 0; k < leftoverCols; k++)
       {
-        unsigned short tmp = static_cast<unsigned short> (p1_src_char[k] + p1_src_char[k+1]+ p2_src_char[k] + p2_src_char[k+1]);
+        auto tmp = static_cast<unsigned short> (p1_src_char[k] + p1_src_char[k+1]+ p2_src_char[k] + p2_src_char[k+1]);
         *(p_dest_char++) = static_cast<unsigned char>(tmp / 4);
       }
       // done with the two rows:
@@ -1713,7 +1713,7 @@ pcl::keypoints::brisk::Layer::twothirdsample (
 {
   pcl::utils::ignore(dstheight);
 #if defined(__SSSE3__) && !defined(__i386__)
-  const unsigned short leftoverCols = static_cast<unsigned short> (((srcwidth / 3) * 3) % 15);// take care with border...
+  const auto leftoverCols = static_cast<unsigned short> (((srcwidth / 3) * 3) % 15);// take care with border...
 
   // make sure the destination image is of the right size:
   assert (std::floor (double (srcwidth) / 3.0 * 2.0) == dstwidth);

--- a/keypoints/src/narf_keypoint.cpp
+++ b/keypoints/src/narf_keypoint.cpp
@@ -266,7 +266,7 @@ NarfKeypoint::calculateCompleteInterestImage ()
         height = range_image.height,
         array_size = width*height;
 
-    float* interest_image = new float[array_size];
+    auto* interest_image = new float[array_size];
     interest_image_scale_space_[scale_idx] = interest_image;
     //for (int i=0; i<array_size; ++i)
       //interest_image[i] = -1.0f;
@@ -811,7 +811,7 @@ NarfKeypoint::calculateInterestPoints ()
         
         if (!types.empty () && types[0]==0)
         {
-          float keypoint_x = static_cast<float> (x_values[0]+keypoint_x_int),
+          auto keypoint_x = static_cast<float> (x_values[0]+keypoint_x_int),
                 keypoint_y = static_cast<float> (y_values[0]+keypoint_y_int);
           
           keypoint_x_int = static_cast<int> (pcl_lrint (keypoint_x));

--- a/ml/src/permutohedral.cpp
+++ b/ml/src/permutohedral.cpp
@@ -117,7 +117,7 @@ pcl::Permutohedral::init(const std::vector<float>& feature,
 
     // Find the closest 0-colored simplex through rounding
     float down_factor = 1.0f / static_cast<float>(d_ + 1);
-    float up_factor = static_cast<float>(d_ + 1);
+    auto up_factor = static_cast<float>(d_ + 1);
     int sum = 0;
     for (int j = 0; j <= d_; j++) {
       float rd = std::floor(0.5f + (down_factor * elevated(j)));
@@ -336,13 +336,13 @@ pcl::Permutohedral::initOLD(const std::vector<float>& feature,
   barycentricOLD_ = new float[(d_ + 1) * N_];
 
   // Allocate the local memory
-  float* scale_factor = new float[d_];
-  float* elevated = new float[d_ + 1];
-  float* rem0 = new float[d_ + 1];
-  float* barycentric = new float[d_ + 2];
+  auto* scale_factor = new float[d_];
+  auto* elevated = new float[d_ + 1];
+  auto* rem0 = new float[d_ + 1];
+  auto* barycentric = new float[d_ + 2];
   int* rank = new int[d_ + 1];
-  short* canonical = new short[(d_ + 1) * (d_ + 1)];
-  short* key = new short[d_ + 1];
+  auto* canonical = new short[(d_ + 1) * (d_ + 1)];
+  auto* key = new short[d_ + 1];
 
   // Compute the canonical simplex
   for (int i = 0; i <= d_; i++) {
@@ -379,7 +379,7 @@ pcl::Permutohedral::initOLD(const std::vector<float>& feature,
 
     // Find the closest 0-colored simplex through rounding
     float down_factor = 1.0f / static_cast<float>(d_ + 1);
-    float up_factor = static_cast<float>(d_ + 1);
+    auto up_factor = static_cast<float>(d_ + 1);
     int sum = 0;
     for (int i = 0; i <= d_; i++) {
       int rd = static_cast<int>(pcl_round(down_factor * elevated[i]));
@@ -452,8 +452,8 @@ pcl::Permutohedral::initOLD(const std::vector<float>& feature,
   delete[] blur_neighborsOLD_;
   blur_neighborsOLD_ = new Neighbors[(d_ + 1) * M_];
 
-  short* n1 = new short[d_ + 1];
-  short* n2 = new short[d_ + 1];
+  auto* n1 = new short[d_ + 1];
+  auto* n2 = new short[d_ + 1];
 
   // For each of d+1 axes,
   for (int j = 0; j <= d_; j++) {
@@ -496,8 +496,8 @@ pcl::Permutohedral::computeOLD(std::vector<float>& out,
     out_size = N_ - out_offset;
 
   // Shift all values by 1 such that -1 -> 0 (used for blurring)
-  float* values = new float[(M_ + 2) * value_size];
-  float* new_values = new float[(M_ + 2) * value_size];
+  auto* values = new float[(M_ + 2) * value_size];
+  auto* new_values = new float[(M_ + 2) * value_size];
 
   for (int i = 0; i < (M_ + 2) * value_size; i++)
     values[i] = new_values[i] = 0;

--- a/ml/src/point_xy_32f.cpp
+++ b/ml/src/point_xy_32f.cpp
@@ -43,8 +43,8 @@ pcl::PointXY32f::randomPoint(const int min_x,
                              const int min_y,
                              const int max_y)
 {
-  const float width = static_cast<float>(max_x - min_x);
-  const float height = static_cast<float>(max_y - min_y);
+  const auto width = static_cast<float>(max_x - min_x);
+  const auto height = static_cast<float>(max_y - min_y);
 
   PointXY32f point;
   point.x = width * static_cast<float>(rand()) / static_cast<float>(RAND_MAX) +

--- a/ml/src/point_xy_32i.cpp
+++ b/ml/src/point_xy_32i.cpp
@@ -43,8 +43,8 @@ pcl::PointXY32i::randomPoint(const int min_x,
                              const int min_y,
                              const int max_y)
 {
-  const float width = static_cast<float>(max_x - min_x);
-  const float height = static_cast<float>(max_y - min_y);
+  const auto width = static_cast<float>(max_x - min_x);
+  const auto height = static_cast<float>(max_y - min_y);
 
   PointXY32i point;
   point.x = static_cast<int>(width * static_cast<float>(rand()) /

--- a/ml/src/svm.cpp
+++ b/ml/src/svm.cpp
@@ -1644,8 +1644,8 @@ solve_c_svc(const svm_problem* prob,
             double Cn)
 {
   int l = prob->l;
-  double* minus_ones = new double[l];
-  schar* y = new schar[l];
+  auto* minus_ones = new double[l];
+  auto* y = new schar[l];
 
   for (int i = 0; i < l; i++) {
     alpha[i] = 0;
@@ -1695,7 +1695,7 @@ solve_nu_svc(const svm_problem* prob,
   int l = prob->l;
   double nu = param->nu;
 
-  schar* y = new schar[l];
+  auto* y = new schar[l];
 
   for (int i = 0; i < l; i++)
     if (prob->y[i] > 0)
@@ -1717,7 +1717,7 @@ solve_nu_svc(const svm_problem* prob,
       sum_neg -= alpha[i];
     }
 
-  double* zeros = new double[l];
+  auto* zeros = new double[l];
 
   for (int i = 0; i < l; i++)
     zeros[i] = 0;
@@ -1762,8 +1762,8 @@ solve_one_class(const svm_problem* prob,
                 Solver::SolutionInfo* si)
 {
   int l = prob->l;
-  double* zeros = new double[l];
-  schar* ones = new schar[l];
+  auto* zeros = new double[l];
+  auto* ones = new schar[l];
 
   int n = int(param->nu * prob->l); // # of alpha's at upper bound
 
@@ -1805,9 +1805,9 @@ solve_epsilon_svr(const svm_problem* prob,
                   Solver::SolutionInfo* si)
 {
   int l = prob->l;
-  double* alpha2 = new double[2 * l];
-  double* linear_term = new double[2 * l];
-  schar* y = new schar[2 * l];
+  auto* alpha2 = new double[2 * l];
+  auto* linear_term = new double[2 * l];
+  auto* y = new schar[2 * l];
 
   for (int i = 0; i < l; i++) {
     alpha2[i] = 0;
@@ -1854,9 +1854,9 @@ solve_nu_svr(const svm_problem* prob,
 {
   int l = prob->l;
   double C = param->C;
-  double* alpha2 = new double[2 * l];
-  double* linear_term = new double[2 * l];
-  schar* y = new schar[2 * l];
+  auto* alpha2 = new double[2 * l];
+  auto* linear_term = new double[2 * l];
+  auto* y = new schar[2 * l];
 
   double sum = C * param->nu * l / 2;
 
@@ -1908,7 +1908,7 @@ struct decision_function {
 static decision_function
 svm_train_one(const svm_problem* prob, const svm_parameter* param, double Cp, double Cn)
 {
-  double* alpha = Malloc(double, prob->l);
+  auto* alpha = Malloc(double, prob->l);
   Solver::SolutionInfo si;
 
   switch (param->svm_type) {
@@ -1989,7 +1989,7 @@ sigmoid_train(
 
   const double loTarget = 1 / (prior0 + 2.0);
 
-  double* t = Malloc(double, l);
+  auto* t = Malloc(double, l);
 
   // Initial Point and Initial Fun Value
   A = 0.0;
@@ -2113,8 +2113,8 @@ static void
 multiclass_probability(int k, double** r, double* p)
 {
   const int max_iter = max(100, k);
-  double** Q = Malloc(double*, k);
-  double* Qp = Malloc(double, k);
+  auto** Q = Malloc(double*, k);
+  auto* Qp = Malloc(double, k);
   const double eps = 0.005 / k;
 
   for (int t = 0; t < k; t++) {
@@ -2193,7 +2193,7 @@ svm_binary_svc_probability(const svm_problem* prob,
 {
   int nr_fold = 5;
   int* perm = Malloc(int, prob->l);
-  double* dec_values = Malloc(double, prob->l);
+  auto* dec_values = Malloc(double, prob->l);
 
   // random shuffle
 
@@ -2287,7 +2287,7 @@ static double
 svm_svr_probability(const svm_problem* prob, const svm_parameter* param)
 {
   int nr_fold = 5;
-  double* ymv = Malloc(double, prob->l);
+  auto* ymv = Malloc(double, prob->l);
   double mae = 0;
 
   svm_parameter newparam = *param;
@@ -2400,7 +2400,7 @@ svm_group_classes(const svm_problem* prob,
 svm_model*
 svm_train(const svm_problem* prob, const svm_parameter* param)
 {
-  svm_model* model = Malloc(svm_model, 1);
+  auto* model = Malloc(svm_model, 1);
   model->param = *param;
   model->free_sv = 0; // XXX
   model->probA = nullptr;
@@ -2465,14 +2465,14 @@ svm_train(const svm_problem* prob, const svm_parameter* param)
     if (nr_class == 1)
       info("WARNING: training data in only one class. See README for details.\n");
 
-    svm_node** x = Malloc(svm_node*, l);
+    auto** x = Malloc(svm_node*, l);
 
     for (int i = 0; i < l; i++)
       x[i] = prob->x[perm[i]];
 
     // calculate weighted C
 
-    double* weighted_C = Malloc(double, nr_class);
+    auto* weighted_C = Malloc(double, nr_class);
 
     for (int i = 0; i < nr_class; i++)
       weighted_C[i] = param->C;
@@ -2499,7 +2499,7 @@ svm_train(const svm_problem* prob, const svm_parameter* param)
     for (int i = 0; i < l; i++)
       nonzero[i] = false;
 
-    decision_function* f = Malloc(decision_function, nr_class * (nr_class - 1) / 2);
+    auto* f = Malloc(decision_function, nr_class * (nr_class - 1) / 2);
 
     double *probA = nullptr, *probB = nullptr;
 
@@ -2783,7 +2783,7 @@ svm_cross_validation(const svm_problem* prob,
     struct svm_model* submodel = svm_train(&subprob, param);
 
     if (param->probability && (param->svm_type == C_SVC || param->svm_type == NU_SVC)) {
-      double* prob_estimates = Malloc(double, svm_get_nr_class(submodel));
+      auto* prob_estimates = Malloc(double, svm_get_nr_class(submodel));
 
       for (int j = begin; j < end; j++)
         target[perm[j]] =
@@ -2860,7 +2860,7 @@ svm_predict_values(const svm_model* model, const svm_node* x, double* dec_values
   int nr_class = model->nr_class;
   int l = model->l;
 
-  double* kvalue = Malloc(double, l);
+  auto* kvalue = Malloc(double, l);
 
   for (int i = 0; i < l; i++)
     kvalue[i] = Kernel::k_function(x, model->SV[i], model->param);
@@ -2948,11 +2948,11 @@ svm_predict_probability(const svm_model* model,
   if ((model->param.svm_type == C_SVC || model->param.svm_type == NU_SVC) &&
       model->probA != nullptr && model->probB != nullptr) {
     int nr_class = model->nr_class;
-    double* dec_values = Malloc(double, nr_class*(nr_class - 1) / 2);
+    auto* dec_values = Malloc(double, nr_class*(nr_class - 1) / 2);
     svm_predict_values(model, x, dec_values);
 
     double min_prob = 1e-7;
-    double** pairwise_prob = Malloc(double*, nr_class);
+    auto** pairwise_prob = Malloc(double*, nr_class);
 
     for (int i = 0; i < nr_class; i++)
       pairwise_prob[i] = Malloc(double, nr_class);
@@ -3143,7 +3143,7 @@ svm_load_model(const char* model_file_name)
 
   // read parameters
 
-  svm_model* model = Malloc(svm_model, 1);
+  auto* model = Malloc(svm_model, 1);
 
   svm_parameter& param = model->param;
 

--- a/ml/src/svm_wrapper.cpp
+++ b/ml/src/svm_wrapper.cpp
@@ -71,7 +71,7 @@ pcl::SVMTrain::doCrossValidation()
 {
   int total_correct = 0;
   double sumv = 0, sumy = 0, sumvv = 0, sumyy = 0, sumvy = 0;
-  double* target = Malloc(double, prob_.l);
+  auto* target = Malloc(double, prob_.l);
 
   // number of fold for the cross validation (n of folds = number of splitting of the
   // input dataset)

--- a/octree/include/pcl/octree/impl/octree2buf_base.hpp
+++ b/octree/include/pcl/octree/impl/octree2buf_base.hpp
@@ -491,7 +491,7 @@ Octree2BufBase<LeafContainerT, BranchContainerT>::findLeafRecursive(
     // we reached leaf node level
     if (branch_arg->hasChild(buffer_selector_, child_idx)) {
       // return existing leaf node
-      LeafNode* leaf_node =
+      auto* leaf_node =
           static_cast<LeafNode*>(branch_arg->getChildPtr(buffer_selector_, child_idx));
       result_arg = leaf_node->getContainerPtr();
     }
@@ -601,7 +601,7 @@ Octree2BufBase<LeafContainerT, BranchContainerT>::serializeTreeRecursive(
         break;
       }
       case LEAF_NODE: {
-        LeafNode* child_leaf = static_cast<LeafNode*>(child_node);
+        auto* child_leaf = static_cast<LeafNode*>(child_node);
 
         if (new_leafs_filter_arg) {
           if (!branch_arg->hasChild(!buffer_selector_, child_idx)) {

--- a/octree/include/pcl/octree/impl/octree_base.hpp
+++ b/octree/include/pcl/octree/impl/octree_base.hpp
@@ -467,7 +467,7 @@ OctreeBase<LeafContainerT, BranchContainerT>::serializeTreeRecursive(
         break;
       }
       case LEAF_NODE: {
-        LeafNode* child_leaf = static_cast<LeafNode*>(childNode);
+        auto* child_leaf = static_cast<LeafNode*>(childNode);
 
         if (leaf_container_vector_arg)
           leaf_container_vector_arg->push_back(child_leaf->getContainerPtr());

--- a/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud_adjacency.hpp
@@ -243,7 +243,7 @@ pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT, BranchContainerT>
   }
 
   // Iterate through and add edges to adjacency graph
-  for (typename std::vector<LeafContainerT*>::iterator leaf_itr = leaf_vector_.begin();
+  for (auto leaf_itr = leaf_vector_.begin();
        leaf_itr != leaf_vector_.end();
        ++leaf_itr) {
     VoxelID u = (leaf_vertex_id_map.find(*leaf_itr))->second;

--- a/octree/include/pcl/octree/impl/octree_pointcloud_voxelcentroid.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud_voxelcentroid.hpp
@@ -118,7 +118,7 @@ pcl::octree::OctreePointCloudVoxelCentroid<PointT, LeafContainerT, BranchContain
       case LEAF_NODE: {
         PointT new_centroid;
 
-        LeafNode* container = static_cast<LeafNode*>(child_node);
+        auto* container = static_cast<LeafNode*>(child_node);
 
         container->getContainer().getCentroid(new_centroid);
 

--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -292,7 +292,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
       // we reached leaf node level
       Indices decoded_point_vector;
 
-      const LeafNode* child_leaf = static_cast<const LeafNode*>(child_node);
+      const auto* child_leaf = static_cast<const LeafNode*>(child_node);
 
       // decode leaf node into decoded_point_vector
       (*child_leaf)->getPointIndices(decoded_point_vector);
@@ -388,7 +388,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
       }
       else {
         // we reached leaf node level
-        const LeafNode* child_leaf = static_cast<const LeafNode*>(child_node);
+        const auto* child_leaf = static_cast<const LeafNode*>(child_node);
         Indices decoded_point_vector;
 
         // decode leaf node into decoded_point_vector
@@ -481,7 +481,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
     // we reached leaf node level
     Indices decoded_point_vector;
 
-    const LeafNode* child_leaf = static_cast<const LeafNode*>(child_node);
+    const auto* child_leaf = static_cast<const LeafNode*>(child_node);
 
     float smallest_squared_dist = std::numeric_limits<float>::max();
 
@@ -565,7 +565,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::boxSearchRecur
         // we reached leaf node level
         Indices decoded_point_vector;
 
-        const LeafNode* child_leaf = static_cast<const LeafNode*>(child_node);
+        const auto* child_leaf = static_cast<const LeafNode*>(child_node);
 
         // decode leaf node into decoded_point_vector
         (**child_leaf).getPointIndices(decoded_point_vector);
@@ -875,7 +875,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
 
   // If leaf node, get voxel center and increment intersection count
   if (node->getNodeType() == LEAF_NODE) {
-    const LeafNode* leaf = static_cast<const LeafNode*>(node);
+    const auto* leaf = static_cast<const LeafNode*>(node);
 
     // decode leaf node into k_indices
     (*leaf)->getPointIndices(k_indices);

--- a/octree/include/pcl/octree/octree2buf_base.h
+++ b/octree/include/pcl/octree/octree2buf_base.h
@@ -785,7 +785,7 @@ protected:
   inline BranchNode*
   createBranchChild(BranchNode& branch_arg, unsigned char child_idx_arg)
   {
-    BranchNode* new_branch_child = new BranchNode();
+    auto* new_branch_child = new BranchNode();
 
     branch_arg.setChildPtr(
         buffer_selector_, child_idx_arg, static_cast<OctreeNode*>(new_branch_child));
@@ -801,7 +801,7 @@ protected:
   inline LeafNode*
   createLeafChild(BranchNode& branch_arg, unsigned char child_idx_arg)
   {
-    LeafNode* new_leaf_child = new LeafNode();
+    auto* new_leaf_child = new LeafNode();
 
     branch_arg.setChildPtr(buffer_selector_, child_idx_arg, new_leaf_child);
 

--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -544,7 +544,7 @@ protected:
   BranchNode*
   createBranchChild(BranchNode& branch_arg, unsigned char child_idx_arg)
   {
-    BranchNode* new_branch_child = new BranchNode();
+    auto* new_branch_child = new BranchNode();
     branch_arg[child_idx_arg] = static_cast<OctreeNode*>(new_branch_child);
 
     return new_branch_child;
@@ -558,7 +558,7 @@ protected:
   LeafNode*
   createLeafChild(BranchNode& branch_arg, unsigned char child_idx_arg)
   {
-    LeafNode* new_leaf_child = new LeafNode();
+    auto* new_leaf_child = new LeafNode();
     branch_arg[child_idx_arg] = static_cast<OctreeNode*>(new_leaf_child);
 
     return new_leaf_child;

--- a/octree/include/pcl/octree/octree_container.h
+++ b/octree/include/pcl/octree/octree_container.h
@@ -184,7 +184,7 @@ public:
   bool
   operator==(const OctreeContainerBase& other) const override
   {
-    const OctreeContainerPointIndex* otherConDataT =
+    const auto* otherConDataT =
         dynamic_cast<const OctreeContainerPointIndex*>(&other);
 
     return (this->data_ == otherConDataT->data_);
@@ -263,7 +263,7 @@ public:
   bool
   operator==(const OctreeContainerBase& other) const override
   {
-    const OctreeContainerPointIndices* otherConDataTVec =
+    const auto* otherConDataTVec =
         dynamic_cast<const OctreeContainerPointIndices*>(&other);
 
     return (this->leafDataTVector_ == otherConDataTVec->leafDataTVector_);

--- a/octree/include/pcl/octree/octree_pointcloud_adjacency_container.h
+++ b/octree/include/pcl/octree/octree_pointcloud_adjacency_container.h
@@ -143,7 +143,7 @@ protected:
   virtual OctreePointCloudAdjacencyContainer*
   deepCopy() const
   {
-    OctreePointCloudAdjacencyContainer* new_container =
+    auto* new_container =
         new OctreePointCloudAdjacencyContainer;
     new_container->setNeighbors(this->neighbors_);
     new_container->setPointCounter(this->num_points_);
@@ -199,7 +199,7 @@ protected:
   void
   removeNeighbor(OctreePointCloudAdjacencyContainer* neighbor)
   {
-    for (iterator neighb_it = neighbors_.begin(); neighb_it != neighbors_.end();
+    for (auto neighb_it = neighbors_.begin(); neighb_it != neighbors_.end();
          ++neighb_it) {
       if (*neighb_it == neighbor) {
         neighbors_.erase(neighb_it);

--- a/octree/include/pcl/octree/octree_pointcloud_density.h
+++ b/octree/include/pcl/octree/octree_pointcloud_density.h
@@ -68,7 +68,7 @@ public:
   bool
   operator==(const OctreeContainerBase& other) const override
   {
-    const OctreePointCloudDensityContainer* otherContainer =
+    const auto* otherContainer =
         dynamic_cast<const OctreePointCloudDensityContainer*>(&other);
 
     return (this->point_counter_ == otherContainer->point_counter_);

--- a/outofcore/include/pcl/outofcore/impl/lru_cache.hpp
+++ b/outofcore/include/pcl/outofcore/impl/lru_cache.hpp
@@ -89,7 +89,7 @@ public:
     int evict_count = 0;
 
     // Get LRU key iterator
-    KeyIndexIterator key_it = key_index_.begin ();
+    auto key_it = key_index_.begin ();
 
     while (size + item_size >= capacity_)
     {
@@ -116,7 +116,7 @@ public:
     size_ += item_size;
 
     // Insert most-recently-used key at the end of our key index
-    KeyIndexIterator it = key_index_.insert (key_index_.end (), key);
+    auto it = key_index_.insert (key_index_.end (), key);
 
     // Add to cache
     cache_.insert (std::make_pair (key, std::make_pair (value, it)));

--- a/outofcore/include/pcl/outofcore/impl/octree_base.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base.hpp
@@ -536,7 +536,7 @@ namespace pcl
       Eigen::Vector3d min, max;
       this->getBoundingBox (min, max);
       
-      double depth = static_cast<double> (metadata_->getDepth ());
+      auto depth = static_cast<double> (metadata_->getDepth ());
       Eigen::Vector3d diff = max-min;
 
       y = diff[1] * pow (.5, depth);
@@ -612,11 +612,11 @@ namespace pcl
         assert (leaf_input_cloud->width*leaf_input_cloud->height > 0);
         
         //go up the tree, re-downsampling the full resolution leaf cloud at lower and lower resolution
-        for (std::int64_t level = static_cast<std::int64_t>(current_branch.size ()-1); level >= 1; level--)
+        for (auto level = static_cast<std::int64_t>(current_branch.size ()-1); level >= 1; level--)
         {
           BranchNode* target_parent = current_branch[level-1];
           assert (target_parent != nullptr);
-          double exponent = static_cast<double>(current_branch.size () - target_parent->getDepth ());
+          auto exponent = static_cast<double>(current_branch.size () - target_parent->getDepth ());
           double current_depth_sample_percent = pow (sample_percent_, exponent);
 
           assert (current_depth_sample_percent > 0.0);
@@ -629,7 +629,7 @@ namespace pcl
           lod_filter_ptr_->setInputCloud (leaf_input_cloud);
 
           //set sample size to 1/8 of total points (12.5%)
-          std::uint64_t sample_size = static_cast<std::uint64_t> (static_cast<double> (leaf_input_cloud->width*leaf_input_cloud->height) * current_depth_sample_percent);
+          auto sample_size = static_cast<std::uint64_t> (static_cast<double> (leaf_input_cloud->width*leaf_input_cloud->height) * current_depth_sample_percent);
 
           if (sample_size == 0)
             sample_size = 1;
@@ -736,7 +736,7 @@ namespace pcl
       if (side_length < leaf_resolution)
           return (0);
           
-      std::uint64_t res = static_cast<std::uint64_t> (std::ceil (std::log2 (side_length / leaf_resolution)));
+      auto res = static_cast<std::uint64_t> (std::ceil (std::log2 (side_length / leaf_resolution)));
       
       PCL_DEBUG ("[pcl::outofcore::OutofcoreOctreeBase::calculateDepth] Setting depth to %d\n",res);
       return (res);

--- a/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
@@ -578,7 +578,7 @@ namespace pcl
 
       // Derive percentage from specified sample_percent and tree depth
       const double percent = pow(sample_percent_, double((this->root_node_->m_tree_->getDepth () - depth_)));
-      const std::uint64_t samplesize = static_cast<std::uint64_t>(percent * static_cast<double>(sampleBuff.size()));
+      const auto samplesize = static_cast<std::uint64_t>(percent * static_cast<double>(sampleBuff.size()));
       const std::uint64_t inputsize = sampleBuff.size();
 
       if(samplesize > 0)
@@ -1684,7 +1684,7 @@ namespace pcl
 
           //use STL random_shuffle and push back a random selection of the points onto our list
           std::shuffle (payload_cache_within_region.begin (), payload_cache_within_region.end (), std::mt19937(std::random_device()()));
-          std::size_t numpick = static_cast<std::size_t> (percent * static_cast<double> (payload_cache_within_region.size ()));;
+          auto numpick = static_cast<std::size_t> (percent * static_cast<double> (payload_cache_within_region.size ()));;
 
           for (std::size_t i = 0; i < numpick; i++)
           {

--- a/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_disk_container.hpp
@@ -384,7 +384,7 @@ namespace pcl
         buffcount = count - filecount;
       }
 
-      std::uint64_t filesamp = static_cast<std::uint64_t> (percent * static_cast<double> (filecount));
+      auto filesamp = static_cast<std::uint64_t> (percent * static_cast<double> (filecount));
       
       std::uint64_t buffsamp = (buffcount > 0) ? (static_cast<std::uint64_t > (percent * static_cast<double> (buffcount))) : 0;
 
@@ -610,7 +610,7 @@ namespace pcl
     {
 //      PCL_THROW_EXCEPTION (PCLException, "[pcl::outofcore::OutofcoreOctreeDiskContainer] Deprecated\n");
       //copy the handles to a continuous block
-      PointT* arr = new PointT[count];
+      auto* arr = new PointT[count];
 
       //copy from start of array, element by element
       for (std::size_t i = 0; i < count; i++)

--- a/outofcore/include/pcl/outofcore/impl/octree_ram_container.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_ram_container.hpp
@@ -120,7 +120,7 @@ namespace pcl
                                                       const double percent, 
                                                       AlignedPointTVector& v)
     {
-      std::uint64_t samplesize = static_cast<std::uint64_t> (percent * static_cast<double> (count));
+      auto samplesize = static_cast<std::uint64_t> (percent * static_cast<double> (count));
 
       std::lock_guard<std::mutex> lock (rng_mutex_);
 

--- a/outofcore/include/pcl/outofcore/impl/outofcore_breadth_first_iterator.hpp
+++ b/outofcore/include/pcl/outofcore/impl/outofcore_breadth_first_iterator.hpp
@@ -72,7 +72,7 @@ namespace pcl
         if (!skip_child_voxels_ && node->getDepth () < this->max_depth_ && node->getNodeType () == pcl::octree::BRANCH_NODE)
         {
           // Get the branch node
-          BranchNode* branch = static_cast<BranchNode*> (node);
+          auto* branch = static_cast<BranchNode*> (node);
           OctreeDiskNode* child = nullptr;
 
           // Iterate over the branches children

--- a/outofcore/include/pcl/outofcore/impl/outofcore_depth_first_iterator.hpp
+++ b/outofcore/include/pcl/outofcore/impl/outofcore_depth_first_iterator.hpp
@@ -73,7 +73,7 @@ namespace pcl
 
         if (this->currentNode_->getNodeType () == pcl::octree::BRANCH_NODE)
         {
-          BranchNode* currentBranch = static_cast<BranchNode*> (this->currentNode_);
+          auto* currentBranch = static_cast<BranchNode*> (this->currentNode_);
           
           if (currentChildIdx_ < 8)
           {

--- a/outofcore/src/cJSON.cpp
+++ b/outofcore/src/cJSON.cpp
@@ -78,7 +78,7 @@ void cJSON_InitHooks(cJSON_Hooks* hooks)
 /* Internal constructor. */
 static cJSON *cJSON_New_Item()
 {
-	cJSON* node = static_cast<cJSON*> (cJSON_malloc(sizeof(cJSON)));
+	auto* node = static_cast<cJSON*> (cJSON_malloc(sizeof(cJSON)));
 	if (node) memset(node,0,sizeof(cJSON));
 	return node;
 }

--- a/outofcore/src/visualization/viewport.cpp
+++ b/outofcore/src/visualization/viewport.cpp
@@ -99,7 +99,7 @@ void
 Viewport::viewportModifiedCallback (vtkObject* vtkNotUsed (caller), unsigned long int vtkNotUsed (eventId),
                                     void* clientData, void* vtkNotUsed (callData))
 {
-  Viewport *viewport = reinterpret_cast<Viewport*> (clientData);
+  auto *viewport = reinterpret_cast<Viewport*> (clientData);
   viewport->viewportModified ();
 }
 
@@ -123,7 +123,7 @@ void
 Viewport::viewportActorUpdateCallback (vtkObject* /*caller*/, unsigned long int vtkNotUsed (eventId), void* clientData,
                                        void* vtkNotUsed (callData))
 {
-  Viewport *viewport = reinterpret_cast<Viewport*> (clientData);
+  auto *viewport = reinterpret_cast<Viewport*> (clientData);
   viewport->viewportActorUpdate ();
 }
 
@@ -151,7 +151,7 @@ void
 Viewport::viewportHudUpdateCallback (vtkObject* vtkNotUsed (caller), unsigned long int vtkNotUsed (eventId),
                                      void* clientData, void* vtkNotUsed (callData))
 {
-  Viewport *viewport = reinterpret_cast<Viewport*> (clientData);
+  auto *viewport = reinterpret_cast<Viewport*> (clientData);
   viewport->viewportHudUpdate ();
 }
 

--- a/outofcore/tools/outofcore_viewer.cpp
+++ b/outofcore/tools/outofcore_viewer.cpp
@@ -233,7 +233,7 @@ outofcoreViewer (boost::filesystem::path tree_root, int depth, bool display_octr
   Scene *scene = Scene::instance ();
 
   // Clouds
-  OutofcoreCloud *cloud = new OutofcoreCloud ("my_octree", tree_root);
+  auto *cloud = new OutofcoreCloud ("my_octree", tree_root);
   cloud->setDisplayDepth (depth);
   cloud->setDisplayVoxels (display_octree);
   OutofcoreCloud::cloud_data_cache.setCapacity(gpu_cache_size*1024);
@@ -269,8 +269,8 @@ outofcoreViewer (boost::filesystem::path tree_root, int depth, bool display_octr
   Viewport persp_viewport (window, 0.5, 0.0, 1.0, 1.0);
 
   // Cameras
-  Camera *persp_camera = new Camera ("persp", persp_viewport.getRenderer ()->GetActiveCamera ());
-  Camera *octree_camera = new Camera ("octree", octree_viewport.getRenderer ()->GetActiveCamera ());
+  auto *persp_camera = new Camera ("persp", persp_viewport.getRenderer ()->GetActiveCamera ());
+  auto *octree_camera = new Camera ("octree", octree_viewport.getRenderer ()->GetActiveCamera ());
   scene->addCamera (persp_camera);
   scene->addCamera (octree_camera);
   octree_camera->setDisplay(true);

--- a/people/apps/main_ground_based_people_detection.cpp
+++ b/people/apps/main_ground_based_people_detection.cpp
@@ -101,7 +101,7 @@ struct callback_args{
 void
 pp_callback (const pcl::visualization::PointPickingEvent& event, void* args)
 {
-  struct callback_args* data = (struct callback_args *)args;
+  auto* data = (struct callback_args *)args;
   if (event.getPointIndex () == -1)
     return;
   PointT current_point;

--- a/people/include/pcl/people/impl/ground_based_people_detection_app.hpp
+++ b/people/include/pcl/people/impl/ground_based_people_detection_app.hpp
@@ -400,7 +400,7 @@ pcl::people::GroundBasedPeopleDetectionApp<PointT>::compute (std::vector<pcl::pe
   {
     swapDimensions(rgb_image_);
   }
-  for(typename std::vector<pcl::people::PersonCluster<PointT> >::iterator it = clusters.begin(); it != clusters.end(); ++it)
+  for(auto it = clusters.begin(); it != clusters.end(); ++it)
   {
     //Evaluate confidence for the current PersonCluster:
     Eigen::Vector3f centroid = intrinsics_matrix_transformed_ * (it->getTCenter());

--- a/people/include/pcl/people/impl/head_based_subcluster.hpp
+++ b/people/include/pcl/people/impl/head_based_subcluster.hpp
@@ -300,7 +300,7 @@ pcl::people::HeadBasedSubclustering<PointT>::subcluster (std::vector<pcl::people
   height_map_obj.setInputCloud(cloud_);
   height_map_obj.setSensorPortraitOrientation(vertical_);
   height_map_obj.setMinimumDistanceBetweenMaxima(heads_minimum_distance_);
-  for(typename std::vector<pcl::people::PersonCluster<PointT> >::iterator it = clusters.begin(); it != clusters.end(); ++it)   // for every cluster
+  for(auto it = clusters.begin(); it != clusters.end(); ++it)   // for every cluster
   {
     float height = it->getHeight();
     int number_of_points = it->getNumberPoints();

--- a/people/include/pcl/people/impl/person_classifier.hpp
+++ b/people/include/pcl/people/impl/person_classifier.hpp
@@ -237,7 +237,7 @@ pcl::people::PersonClassifier<PointT>::evaluate (float height_person,
     resize(box, sample, window_width_, window_height_);
 
     // Convert the image to array of float:
-    float* sample_float = new float[sample->width * sample->height * 3]; 
+    auto* sample_float = new float[sample->width * sample->height * 3]; 
     int delta = sample->height * sample->width;
     for (std::uint32_t row = 0; row < sample->height; row++)
     {
@@ -251,7 +251,7 @@ pcl::people::PersonClassifier<PointT>::evaluate (float height_person,
 
     // Calculate HOG descriptor:
     pcl::people::HOG hog;
-    float *descriptor = new float[SVM_weights_.size()];
+    auto *descriptor = new float[SVM_weights_.size()];
     std::fill_n(descriptor, SVM_weights_.size(), 0.0f);
     hog.compute(sample_float, descriptor);
  

--- a/people/src/hog.cpp
+++ b/people/src/hog.cpp
@@ -409,8 +409,8 @@ pcl::people::HOG::grad1 (float *I, float *Gx, float *Gy, int h, int w, int x) co
       *Gx++ = (*In++ - *Ip++) * r;
   } else {
     _G = (__m128*) Gx;
-    __m128 *_Ip = (__m128*) Ip;
-    __m128 *_In = (__m128*) In;
+    auto *_Ip = (__m128*) Ip;
+    auto *_In = (__m128*) In;
     _r = pcl::sse_set(r);
     for(y = 0; y < h; y += 4)
       *_G++ = pcl::sse_mul(pcl::sse_sub(*_In++,*_Ip++), _r);

--- a/recognition/include/pcl/recognition/3rdparty/metslib/abstract-search.hh
+++ b/recognition/include/pcl/recognition/3rdparty/metslib/abstract-search.hh
@@ -338,7 +338,7 @@ inline mets::solution_recorder::~solution_recorder()  = default;
 inline bool
 mets::best_ever_solution::accept(const mets::feasible_solution& sol)
 {
-  const evaluable_solution& s = dynamic_cast<const mets::evaluable_solution&>(sol);
+  const auto& s = dynamic_cast<const mets::evaluable_solution&>(sol);
   if(s.cost_function() < best_ever_m.cost_function())
     {
       best_ever_m.copy_from(s);

--- a/recognition/include/pcl/recognition/3rdparty/metslib/model.hh
+++ b/recognition/include/pcl/recognition/3rdparty/metslib/model.hh
@@ -393,14 +393,14 @@ namespace mets {
     /// @brief Virtual method that applies the move on a point
     gol_type
     evaluate(const mets::feasible_solution& s) const override
-    { const permutation_problem& sol = 
+    { const auto& sol = 
 	static_cast<const permutation_problem&>(s);
       return sol.cost_function() + sol.evaluate_swap(p1, p2); }
     
     /// @brief Virtual method that applies the move on a point
     void
     apply(mets::feasible_solution& s) const override
-    { permutation_problem& sol = static_cast<permutation_problem&>(s);
+    { auto& sol = static_cast<permutation_problem&>(s);
       sol.apply_swap(p1, p2); }
             
     /// @brief Clones this move (so that the tabu list can store it)
@@ -602,7 +602,7 @@ namespace mets {
   mets::swap_neighborhood<random_generator>::~swap_neighborhood()
   {
     // delete all moves
-    for(iterator ii = begin(); ii != end(); ++ii)
+    for(auto ii = begin(); ii != end(); ++ii)
       delete (*ii);
   }
 
@@ -610,13 +610,13 @@ namespace mets {
   void
   mets::swap_neighborhood<random_generator>::refresh(mets::feasible_solution& s)
   {
-    permutation_problem& sol = dynamic_cast<permutation_problem&>(s);
-    iterator ii = begin();
+    auto& sol = dynamic_cast<permutation_problem&>(s);
+    auto ii = begin();
     
     // the first n are simple qap_moveS
     for(unsigned int cnt = 0; cnt != n; ++cnt)
       {
-	swap_elements* m = static_cast<swap_elements*>(*ii);
+	auto* m = static_cast<swap_elements*>(*ii);
 	randomize_move(*m, sol.size());
 	++ii;
       }
@@ -656,7 +656,7 @@ namespace mets {
 
     /// @brief Dtor.
     ~swap_full_neighborhood() override { 
-      for(move_manager::iterator it = moves_m.begin(); 
+      for(auto it = moves_m.begin(); 
 	  it != moves_m.end(); ++it)
 	delete *it;
     }
@@ -681,7 +681,7 @@ namespace mets {
 
     /// @brief Dtor.
     ~invert_full_neighborhood() override { 
-      for(std::deque<move*>::iterator it = moves_m.begin(); 
+      for(auto it = moves_m.begin(); 
 	  it != moves_m.end(); ++it)
 	delete *it;
     }
@@ -718,7 +718,7 @@ namespace mets {
 inline void
 mets::permutation_problem::copy_from(const mets::copyable& other)
 {
-  const mets::permutation_problem& o = 
+  const auto& o = 
     dynamic_cast<const mets::permutation_problem&>(other);
   pi_m = o.pi_m;
   cost_m = o.cost_m;
@@ -729,7 +729,7 @@ inline bool
 mets::swap_elements::operator==(const mets::mana_move& o) const
 {
   try {
-    const mets::swap_elements& other = 
+    const auto& other = 
       dynamic_cast<const mets::swap_elements&>(o);
     return (this->p1 == other.p1 && this->p2 == other.p2);
   } catch (std::bad_cast& e) {
@@ -742,7 +742,7 @@ mets::swap_elements::operator==(const mets::mana_move& o) const
 inline void
 mets::invert_subsequence::apply(mets::feasible_solution& s) const
 { 
-  mets::permutation_problem& sol = 
+  auto& sol = 
     static_cast<mets::permutation_problem&>(s);
   int size = static_cast<int>(sol.size());
   int top = p1 < p2 ? (p2-p1+1) : (size+p2-p1+1);
@@ -759,7 +759,7 @@ mets::invert_subsequence::apply(mets::feasible_solution& s) const
 inline mets::gol_type
 mets::invert_subsequence::evaluate(const mets::feasible_solution& s) const
 { 
-  const mets::permutation_problem& sol = 
+  const auto& sol = 
     static_cast<const mets::permutation_problem&>(s);
   int size = static_cast<int>(sol.size());
   int top = p1 < p2 ? (p2-p1+1) : (size+p2-p1+1);
@@ -779,7 +779,7 @@ inline bool
 mets::invert_subsequence::operator==(const mets::mana_move& o) const
 {
   try {
-    const mets::invert_subsequence& other = 
+    const auto& other = 
       dynamic_cast<const mets::invert_subsequence&>(o);
     return (this->p1 == other.p1 && this->p2 == other.p2);
   } catch (std::bad_cast& e) {

--- a/recognition/include/pcl/recognition/3rdparty/metslib/observer.hh
+++ b/recognition/include/pcl/recognition/3rdparty/metslib/observer.hh
@@ -161,7 +161,7 @@ namespace mets {
   subject<observed_subject>::notify() 
   {
     // upcast the object to the real observer_subject type
-    observed_subject* real_subject = static_cast<observed_subject*>(this);
+    auto* real_subject = static_cast<observed_subject*>(this);
     std::for_each(observers_m.begin(), observers_m.end(), 
 		  update_observer<observed_subject>(real_subject));
   }

--- a/recognition/include/pcl/recognition/3rdparty/metslib/simulated-annealing.hh
+++ b/recognition/include/pcl/recognition/3rdparty/metslib/simulated-annealing.hh
@@ -232,7 +232,7 @@ mets::simulated_annealing<move_manager_t>::search()
 	.cost_function();*/
 
       base_t::moves_m.refresh(base_t::working_solution_m);
-      for(typename move_manager_t::iterator movit = base_t::moves_m.begin(); 
+      for(auto movit = base_t::moves_m.begin(); 
           movit != base_t::moves_m.end(); ++movit)
       {
         // apply move and record proposed cost function

--- a/recognition/include/pcl/recognition/color_gradient_modality.h
+++ b/recognition/include/pcl/recognition/color_gradient_modality.h
@@ -450,12 +450,12 @@ extractFeatures (const MaskMap & mask, const std::size_t nr_features, const std:
       while (!feature_selection_finished)
       {
         float best_score = 0.0f;
-        typename std::list<Candidate>::iterator best_iter = list1.end ();
-        for (typename std::list<Candidate>::iterator iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
+        auto best_iter = list1.end ();
+        for (auto iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
         {
           // find smallest distance
           float smallest_distance = std::numeric_limits<float>::max ();
-          for (typename std::list<Candidate>::iterator iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
+          for (auto iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
           {
             const float dx = static_cast<float> (iter1->x) - static_cast<float> (iter2->x);
             const float dy = static_cast<float> (iter1->y) - static_cast<float> (iter2->y);
@@ -480,10 +480,10 @@ extractFeatures (const MaskMap & mask, const std::size_t nr_features, const std:
 
         float min_min_sqr_distance = std::numeric_limits<float>::max ();
         float max_min_sqr_distance = 0;
-        for (typename std::list<Candidate>::iterator iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
+        for (auto iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
         {
           float min_sqr_distance = std::numeric_limits<float>::max ();
-          for (typename std::list<Candidate>::iterator iter3 = list2.begin (); iter3 != list2.end (); ++iter3)
+          for (auto iter3 = list2.begin (); iter3 != list2.end (); ++iter3)
           {
             if (iter2 == iter3)
               continue;
@@ -543,7 +543,7 @@ extractFeatures (const MaskMap & mask, const std::size_t nr_features, const std:
     {
       if (list1.size () <= nr_features)
       {
-        for (typename std::list<Candidate>::iterator iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
+        for (auto iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
         {
           QuantizedMultiModFeature feature;
           
@@ -561,12 +561,12 @@ extractFeatures (const MaskMap & mask, const std::size_t nr_features, const std:
       while (list2.size () != nr_features)
       {
         float best_score = 0.0f;
-        typename std::list<Candidate>::iterator best_iter = list1.end ();
-        for (typename std::list<Candidate>::iterator iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
+        auto best_iter = list1.end ();
+        for (auto iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
         {
           // find smallest distance
           float smallest_distance = std::numeric_limits<float>::max ();
-          for (typename std::list<Candidate>::iterator iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
+          for (auto iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
           {
             const float dx = static_cast<float> (iter1->x) - static_cast<float> (iter2->x);
             const float dy = static_cast<float> (iter1->y) - static_cast<float> (iter2->y);
@@ -631,7 +631,7 @@ extractFeatures (const MaskMap & mask, const std::size_t nr_features, const std:
 
     if (list1.size () <= nr_features)
     {
-      for (typename std::list<Candidate>::iterator iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
+      for (auto iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
       {
         QuantizedMultiModFeature feature;
           
@@ -649,11 +649,11 @@ extractFeatures (const MaskMap & mask, const std::size_t nr_features, const std:
     while (list2.size () != nr_features)
     {
       const std::size_t sqr_distance = distance*distance;
-      for (typename std::list<Candidate>::iterator iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
+      for (auto iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
       {
         bool candidate_accepted = true;
 
-        for (typename std::list<Candidate>::iterator iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
+        for (auto iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
         {
           const int dx = iter1->x - iter2->x;
           const int dy = iter1->y - iter2->y;
@@ -677,7 +677,7 @@ extractFeatures (const MaskMap & mask, const std::size_t nr_features, const std:
     }
   }
 
-  for (typename std::list<Candidate>::iterator iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
+  for (auto iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
   {
     QuantizedMultiModFeature feature;
     
@@ -726,7 +726,7 @@ extractAllFeatures (const MaskMap & mask, const std::size_t, const std::size_t m
 
   list1.sort();
 
-  for (typename std::list<Candidate>::iterator iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
+  for (auto iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
   {
     QuantizedMultiModFeature feature;
           

--- a/recognition/include/pcl/recognition/dense_quantized_multi_mod_template.h
+++ b/recognition/include/pcl/recognition/dense_quantized_multi_mod_template.h
@@ -51,7 +51,7 @@ namespace pcl
     void 
     serialize (std::ostream & stream) const
     {
-      const std::size_t num_of_features = static_cast<std::size_t> (features.size ());
+      const auto num_of_features = static_cast<std::size_t> (features.size ());
       write (stream, num_of_features);
       for (std::size_t feature_index = 0; feature_index < num_of_features; ++feature_index)
       {
@@ -84,7 +84,7 @@ namespace pcl
     void 
     serialize (std::ostream & stream) const
     {
-      const std::size_t num_of_modalities = static_cast<std::size_t> (modalities.size ());
+      const auto num_of_modalities = static_cast<std::size_t> (modalities.size ());
       write (stream, num_of_modalities);
       for (std::size_t modality_index = 0; modality_index < num_of_modalities; ++modality_index)
       {

--- a/recognition/include/pcl/recognition/face_detection/rf_face_utils.h
+++ b/recognition/include/pcl/recognition/face_detection/rf_face_utils.h
@@ -164,8 +164,8 @@ namespace pcl
           int el_f2 = te.iimages_[feature.used_ii_]->getFiniteElementsCount (te.col_ + feature.col2_, te.row_ + feature.row2_, feature.wsizex2_,
               feature.wsizey2_);
 
-          float sum_f1 = static_cast<float>(te.iimages_[feature.used_ii_]->getFirstOrderSum (te.col_ + feature.col1_, te.row_ + feature.row1_, feature.wsizex1_, feature.wsizey1_));
-          float sum_f2 = static_cast<float>(te.iimages_[feature.used_ii_]->getFirstOrderSum (te.col_ + feature.col2_, te.row_ + feature.row2_, feature.wsizex2_, feature.wsizey2_));
+          auto sum_f1 = static_cast<float>(te.iimages_[feature.used_ii_]->getFirstOrderSum (te.col_ + feature.col1_, te.row_ + feature.row1_, feature.wsizex1_, feature.wsizey1_));
+          auto sum_f2 = static_cast<float>(te.iimages_[feature.used_ii_]->getFirstOrderSum (te.col_ + feature.col2_, te.row_ + feature.row2_, feature.wsizex2_, feature.wsizey2_));
 
           float f = min_valid_small_patch_depth_;
           if (el_f1 == 0 || el_f2 == 0 || (el_f1 <= static_cast<int> (f * static_cast<float>(feature.wsizex1_ * feature.wsizey1_)))
@@ -230,7 +230,7 @@ namespace pcl
             Eigen::Vector3d & centroid) const
         {
           Eigen::Matrix<double, 1, 9, Eigen::RowMajor> accu = Eigen::Matrix<double, 1, 9, Eigen::RowMajor>::Zero ();
-          unsigned int point_count = static_cast<unsigned int> (examples.size ());
+          auto point_count = static_cast<unsigned int> (examples.size ());
 
           for (std::size_t i = 0; i < point_count; ++i)
           {
@@ -274,7 +274,7 @@ namespace pcl
             Eigen::Vector3d & centroid) const
         {
           Eigen::Matrix<double, 1, 9, Eigen::RowMajor> accu = Eigen::Matrix<double, 1, 9, Eigen::RowMajor>::Zero ();
-          unsigned int point_count = static_cast<unsigned int> (examples.size ());
+          auto point_count = static_cast<unsigned int> (examples.size ());
 
           for (std::size_t i = 0; i < point_count; ++i)
           {

--- a/recognition/include/pcl/recognition/hv/hv_go.h
+++ b/recognition/include/pcl/recognition/hv/hv_go.h
@@ -72,7 +72,7 @@ namespace pcl
 
           void copy_from(const mets::copyable& o) override
           {
-            const SAModel& s = dynamic_cast<const SAModel&> (o);
+            const auto& s = dynamic_cast<const SAModel&> (o);
             solution_ = s.solution_;
             opt_ = s.opt_;
             cost_ = s.cost_;
@@ -137,7 +137,7 @@ namespace pcl
 
           mets::gol_type apply_and_evaluate(mets::feasible_solution& cs)
           {
-            SAModel& model = dynamic_cast<SAModel&> (cs);
+            auto& model = dynamic_cast<SAModel&> (cs);
             return model.apply_and_evaluate (index_, !model.solution_[index_]);
           }
 
@@ -147,7 +147,7 @@ namespace pcl
 
           void unapply(mets::feasible_solution& s) const
           {
-            SAModel& model = dynamic_cast<SAModel&> (s);
+            auto& model = dynamic_cast<SAModel&> (s);
             model.unapply (index_, !model.solution_[index_]);
           }
       };
@@ -175,7 +175,7 @@ namespace pcl
           ~move_manager()
           {
             // delete all moves
-            for (iterator ii = begin (); ii != end (); ++ii)
+            for (auto ii = begin (); ii != end (); ++ii)
               delete (*ii);
           }
 

--- a/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/hv_go.hpp
@@ -717,7 +717,7 @@ void pcl::GlobalHypothesesVerification<ModelT, SceneT>::computeClutterCue(Recogn
         {
           //neighborhood_indices[i].first gives the index to the scene point and second to the explained scene point by the model causing this...
           //calculate weight of this clutter point based on the distance of the scene point and the model point causing it
-          float d = static_cast<float> (pow (
+          auto d = static_cast<float> (pow (
               ((*scene_cloud_downsampled_)[recog_model->explained_[neighborhood_index.second]].getVector3fMap ()
                   - (*scene_cloud_downsampled_)[neighborhood_index.first].getVector3fMap ()).norm (), 2));
           float d_weight = -(d / rn_sqr) + 1; //points that are close have a strong weight*/

--- a/recognition/include/pcl/recognition/impl/hv/occlusion_reasoning.hpp
+++ b/recognition/include/pcl/recognition/impl/hv/occlusion_reasoning.hpp
@@ -165,7 +165,7 @@ pcl::occlusion_reasoning::ZBuffering<ModelT, SceneT>::computeDepthMap (typename 
     //Dilate and smooth the depth map
     int ws = wsize;
     int ws2 = int (std::floor (static_cast<float> (ws) / 2.f));
-    float * depth_smooth = new float[cx_ * cy_];
+    auto * depth_smooth = new float[cx_ * cy_];
     for (int i = 0; i < (cx_ * cy_); i++)
       depth_smooth[i] = std::numeric_limits<float>::quiet_NaN ();
 

--- a/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
+++ b/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
@@ -770,7 +770,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::findObject
   estimateFeatures (sampled_point_cloud, sampled_normal_cloud, feature_cloud);
 
   //find nearest cluster
-  const unsigned int n_key_points = static_cast<unsigned int> (sampled_point_cloud->size ());
+  const auto n_key_points = static_cast<unsigned int> (sampled_point_cloud->size ());
   std::vector<int> min_dist_inds (n_key_points, -1);
   for (unsigned int i_point = 0; i_point < n_key_points; i_point++)
   {
@@ -808,7 +808,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::findObject
     if (min_dist_idx == -1)
       continue;
 
-    const unsigned int n_words = static_cast<unsigned int> (model->clusters_[min_dist_idx].size ());
+    const auto n_words = static_cast<unsigned int> (model->clusters_[min_dist_idx].size ());
     //compute coord system transform
     Eigen::Matrix3f transform = alignYCoordWithNormal ((*sampled_normal_cloud)[i_point]);
     for (unsigned int i_word = 0; i_word < n_words; i_word++)
@@ -949,7 +949,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::calculateS
   std::vector<std::vector<float> > objects_sigmas;
   objects_sigmas.resize (number_of_classes, vec);
 
-  unsigned int number_of_objects = static_cast<unsigned int> (training_clouds_.size ());
+  auto number_of_objects = static_cast<unsigned int> (training_clouds_.size ());
   for (unsigned int i_object = 0; i_object < number_of_objects; i_object++)
   {
     float max_distance = 0.0f;
@@ -972,7 +972,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::calculateS
   for (unsigned int i_class = 0; i_class < number_of_classes; i_class++)
   {
     float sig = 0.0f;
-    unsigned int number_of_objects_in_class = static_cast<unsigned int> (objects_sigmas[i_class].size ());
+    auto number_of_objects_in_class = static_cast<unsigned int> (objects_sigmas[i_class].size ());
     for (unsigned int i_object = 0; i_object < number_of_objects_in_class; i_object++)
       sig += objects_sigmas[i_class][i_object];
     sig /= (static_cast<float> (number_of_objects_in_class) * 10.0f);
@@ -1037,7 +1037,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::calculateW
   learned_weights.resize (locations.size (), 0.0);
   for (unsigned int i_cluster = 0; i_cluster < number_of_clusters_; i_cluster++)
   {
-    unsigned int number_of_words_in_cluster = static_cast<unsigned int> (clusters[i_cluster].size ());
+    auto number_of_words_in_cluster = static_cast<unsigned int> (clusters[i_cluster].size ());
     for (unsigned int i_visual_word = 0; i_visual_word < number_of_words_in_cluster; i_visual_word++)
     {
       unsigned int i_index = clusters[i_cluster][i_visual_word];
@@ -1093,8 +1093,8 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::calculateW
         continue;//this cluster has never been used
       if (n_ftr[i_class] == 0)
         continue;//there were no objects of this class in the training dataset
-      float part_1 = static_cast<float> (n_vw[i_class]);
-	  float part_2 = static_cast<float> (n_vot[i_cluster]);
+      auto part_1 = static_cast<float> (n_vw[i_class]);
+	  auto part_2 = static_cast<float> (n_vot[i_cluster]);
       float part_3 = static_cast<float> (n_vot_2[i_cluster][i_class]) / static_cast<float> (n_ftr[i_class]);
       float part_4 = 0.0f;
 
@@ -1200,14 +1200,14 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::alignYCoor
   float B = 0.0f;
   float sign = -1.0f;
 
-  float denom_X = static_cast<float> (sqrt (in_normal.normal_z * in_normal.normal_z + in_normal.normal_y * in_normal.normal_y));
+  auto denom_X = static_cast<float> (sqrt (in_normal.normal_z * in_normal.normal_z + in_normal.normal_y * in_normal.normal_y));
   A = in_normal.normal_y / denom_X;
   B = sign * in_normal.normal_z / denom_X;
   rotation_matrix_X << 1.0f,   0.0f,   0.0f,
                        0.0f,      A,     -B,
                        0.0f,      B,      A;
 
-  float denom_Z = static_cast<float> (sqrt (in_normal.normal_x * in_normal.normal_x + in_normal.normal_y * in_normal.normal_y));
+  auto denom_Z = static_cast<float> (sqrt (in_normal.normal_x * in_normal.normal_x + in_normal.normal_y * in_normal.normal_y));
   A = in_normal.normal_y / denom_Z;
   B = sign * in_normal.normal_x / denom_Z;
   rotation_matrix_Z <<    A,     -B,   0.0f,
@@ -1426,7 +1426,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::generateCe
   int trials)
 {
   std::size_t dimension = data.cols ();
-  unsigned int number_of_points = static_cast<unsigned int> (data.rows ());
+  auto number_of_points = static_cast<unsigned int> (data.rows ());
   std::vector<int> centers_vec (number_of_clusters);
   int* centers = &centers_vec[0];
   std::vector<double> dist (number_of_points);

--- a/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
+++ b/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
@@ -687,7 +687,7 @@ LineRGBD<PointXYZT, PointRGBT>::refineDetectionsAlongDepth ()
 
         if (/*std::isfinite (point.x) && std::isfinite (point.y) && */std::isfinite (point.z))
         {
-          const std::size_t bin_index = static_cast<std::size_t> ((point.z - min_depth) / step_size);
+          const auto bin_index = static_cast<std::size_t> ((point.z - min_depth) / step_size);
           ++depth_bins[bin_index];
         }
       }
@@ -701,7 +701,7 @@ LineRGBD<PointXYZT, PointRGBT>::refineDetectionsAlongDepth ()
       integral_depth_bins[bin_index] = depth_bins[bin_index] + integral_depth_bins[bin_index-1];
     }
 
-    const std::size_t bb_depth_range = static_cast<std::size_t> (detection.bounding_box.depth / step_size);
+    const auto bb_depth_range = static_cast<std::size_t> (detection.bounding_box.depth / step_size);
 
     std::size_t max_nr_points = 0;
     std::size_t max_index = 0;

--- a/recognition/include/pcl/recognition/impl/ransac_based/simple_octree.hpp
+++ b/recognition/include/pcl/recognition/impl/ransac_based/simple_octree.hpp
@@ -230,7 +230,7 @@ SimpleOctree<NodeData, NodeDataCreator, Scalar>::build (const Scalar* bounds, Sc
     tree_levels_ = 0;
 
   // Compute the number of octree levels and the bounds of the root
-  Scalar half_root_side = static_cast<Scalar> (0.5f*pow (2.0, tree_levels_)*voxel_size);
+  auto half_root_side = static_cast<Scalar> (0.5f*pow (2.0, tree_levels_)*voxel_size);
 
   // Determine the bounding box of the octree
   bounds_[0] = center[0] - half_root_side;

--- a/recognition/include/pcl/recognition/ransac_based/model_library.h
+++ b/recognition/include/pcl/recognition/ransac_based/model_library.h
@@ -76,7 +76,7 @@ namespace pcl
                 return;
 
               // Initialize
-              std::vector<ORROctree::Node*>::const_iterator it = full_leaves.begin ();
+              auto it = full_leaves.begin ();
               const float *p = (*it)->getData ()->getPoint ();
               aux::copy3 (p, octree_center_of_mass_);
               bounds_of_octree_points_[0] = bounds_of_octree_points_[1] = p[0];
@@ -232,7 +232,7 @@ namespace pcl
         inline const Model*
         getModel (const std::string& name) const
         {
-          std::map<std::string,Model*>::const_iterator it = models_.find (name);
+          auto it = models_.find (name);
           if ( it != models_.end () )
             return (it->second);
 

--- a/recognition/include/pcl/recognition/ransac_based/orr_graph.h
+++ b/recognition/include/pcl/recognition/ransac_based/orr_graph.h
@@ -130,7 +130,7 @@ namespace pcl
         inline void
         clear ()
         {
-          for ( typename std::vector<Node*>::iterator nit = nodes_.begin () ; nit != nodes_.end () ; ++nit )
+          for ( auto nit = nodes_.begin () ; nit != nodes_.end () ; ++nit )
             delete *nit;
 
           nodes_.clear ();
@@ -143,7 +143,7 @@ namespace pcl
           if ( !n )
             return;
 
-          for ( typename std::vector<Node*>::iterator nit = nodes_.begin () ; nit != nodes_.end () ; ++nit )
+          for ( auto nit = nodes_.begin () ; nit != nodes_.end () ; ++nit )
             delete *nit;
 
           nodes_.resize (static_cast<std::size_t> (n));
@@ -159,7 +159,7 @@ namespace pcl
           int i = 0;
 
           // Set all nodes to undefined
-          for ( typename std::vector<Node*>::iterator it = nodes_.begin () ; it != nodes_.end () ; ++it )
+          for ( auto it = nodes_.begin () ; it != nodes_.end () ; ++it )
           {
             sorted_nodes[i++] = *it;
             (*it)->state_ = Node::UNDEF;
@@ -169,7 +169,7 @@ namespace pcl
           std::sort (sorted_nodes.begin (), sorted_nodes.end (), Node::compare);
 
           // Now run through the array and start switching nodes on and off
-          for ( typename std::vector<Node*>::iterator it = sorted_nodes.begin () ; it != sorted_nodes.end () ; ++it )
+          for ( auto it = sorted_nodes.begin () ; it != sorted_nodes.end () ; ++it )
           {
             // Ignore graph nodes which are already OFF
             if ( (*it)->state_ == Node::OFF )
@@ -179,7 +179,7 @@ namespace pcl
             (*it)->state_ = Node::ON;
 
             // Set all its neighbors to OFF
-            for ( typename std::set<Node*>::iterator neigh = (*it)->neighbors_.begin () ; neigh != (*it)->neighbors_.end () ; ++neigh )
+            for ( auto neigh = (*it)->neighbors_.begin () ; neigh != (*it)->neighbors_.end () ; ++neigh )
             {
               (*neigh)->state_ = Node::OFF;
               off_nodes.push_back (*neigh);

--- a/recognition/include/pcl/recognition/ransac_based/orr_octree.h
+++ b/recognition/include/pcl/recognition/ransac_based/orr_octree.h
@@ -322,7 +322,7 @@ namespace pcl
 
           if ( !node->getData () )
           {
-            Node::Data* data = new Node::Data (
+            auto* data = new Node::Data (
                 static_cast<int> ((node->getCenter ()[0] - bounds_[0])/voxel_size_),
                 static_cast<int> ((node->getCenter ()[1] - bounds_[2])/voxel_size_),
                 static_cast<int> ((node->getCenter ()[2] - bounds_[4])/voxel_size_),

--- a/recognition/include/pcl/recognition/ransac_based/rigid_transform_space.h
+++ b/recognition/include/pcl/recognition/ransac_based/rigid_transform_space.h
@@ -153,7 +153,7 @@ namespace pcl
         inline const RotationSpaceCell::Entry*
         getEntry (const ModelLibrary::Model* model) const
         {
-          std::map<const ModelLibrary::Model*, Entry>::const_iterator res = model_to_entry_.find (model);
+          auto res = model_to_entry_.find (model);
 
           if ( res != model_to_entry_.end () )
             return (&res->second);
@@ -301,7 +301,7 @@ namespace pcl
 
         RotationSpace* create(const SimpleOctree<RotationSpace, RotationSpaceCreator, float>::Node* leaf)
         {
-          RotationSpace *rot_space = new RotationSpace (discretization_);
+          auto *rot_space = new RotationSpace (discretization_);
           rot_space->setCenter (leaf->getCenter ());
           rotation_spaces_.push_back (rot_space);
 

--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -272,9 +272,9 @@ namespace pcl
     inline unsigned char 
     operator() (const float x, const float y, const float z) const
     {
-      const std::size_t x_index = static_cast<std::size_t> (x * static_cast<float> (offset_x) + static_cast<float> (offset_x));
-      const std::size_t y_index = static_cast<std::size_t> (y * static_cast<float> (offset_y) + static_cast<float> (offset_y));
-      const std::size_t z_index = static_cast<std::size_t> (z * static_cast<float> (range_z) + static_cast<float> (range_z));
+      const auto x_index = static_cast<std::size_t> (x * static_cast<float> (offset_x) + static_cast<float> (offset_x));
+      const auto y_index = static_cast<std::size_t> (y * static_cast<float> (offset_y) + static_cast<float> (offset_y));
+      const auto z_index = static_cast<std::size_t> (z * static_cast<float> (range_z) + static_cast<float> (range_z));
 
       const std::size_t index = z_index*size_y*size_x + y_index*size_x + x_index;
 
@@ -723,8 +723,8 @@ pcl::SurfaceNormalModality<PointInT>::computeAndQuantizeSurfaceNormals2 ()
   const int width = input_->width;
   const int height = input_->height;
 
-  unsigned short * lp_depth = new unsigned short[width*height];
-  unsigned char * lp_normals = new unsigned char[width*height];
+  auto * lp_depth = new unsigned short[width*height];
+  auto * lp_normals = new unsigned char[width*height];
   memset (lp_normals, 0, width*height);
 
   surface_normal_orientations_.resize (width, height, 0.0f);
@@ -872,9 +872,9 @@ pcl::SurfaceNormalModality<PointInT>::computeAndQuantizeSurfaceNormals2 ()
 
         /// @todo Magic number 1150 is focal length? This is something like
         /// f in SXGA mode, but in VGA is more like 530.
-        float l_nx = static_cast<float>(1150 * l_ddx);
-        float l_ny = static_cast<float>(1150 * l_ddy);
-        float l_nz = static_cast<float>(-l_det * l_d);
+        auto l_nx = static_cast<float>(1150 * l_ddx);
+        auto l_ny = static_cast<float>(1150 * l_ddy);
+        auto l_nz = static_cast<float>(-l_det * l_d);
 
         //// solve
         //double l_det =  l_A[0] * l_A[3] - l_A[1] * l_A[1];
@@ -1068,7 +1068,7 @@ pcl::SurfaceNormalModality<PointInT>::extractFeatures (const MaskMap & mask,
     }
   }
 
-  for (typename std::list<Candidate>::iterator iter = list1.begin (); iter != list1.end (); ++iter)
+  for (auto iter = list1.begin (); iter != list1.end (); ++iter)
     iter->distance *= 1.0f / weights[iter->bin_index];
 
   list1.sort ();
@@ -1080,10 +1080,10 @@ pcl::SurfaceNormalModality<PointInT>::extractFeatures (const MaskMap & mask,
     while (!feature_selection_finished)
     {
       const int sqr_distance = distance*distance;
-      for (typename std::list<Candidate>::iterator iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
+      for (auto iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
       {
         bool candidate_accepted = true;
-        for (typename std::list<Candidate>::iterator iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
+        for (auto iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
         {
           const int dx = static_cast<int> (iter1->x) - static_cast<int> (iter2->x);
           const int dy = static_cast<int> (iter1->y) - static_cast<int> (iter2->y);
@@ -1099,10 +1099,10 @@ pcl::SurfaceNormalModality<PointInT>::extractFeatures (const MaskMap & mask,
 
         float min_min_sqr_distance = std::numeric_limits<float>::max ();
         float max_min_sqr_distance = 0;
-        for (typename std::list<Candidate>::iterator iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
+        for (auto iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
         {
           float min_sqr_distance = std::numeric_limits<float>::max ();
-          for (typename std::list<Candidate>::iterator iter3 = list2.begin (); iter3 != list2.end (); ++iter3)
+          for (auto iter3 = list2.begin (); iter3 != list2.end (); ++iter3)
           {
             if (iter2 == iter3)
               continue;
@@ -1171,7 +1171,7 @@ pcl::SurfaceNormalModality<PointInT>::extractFeatures (const MaskMap & mask,
     if (list1.size () <= nr_features)
     {
       features.reserve (list1.size ());
-      for (typename std::list<Candidate>::iterator iter = list1.begin (); iter != list1.end (); ++iter)
+      for (auto iter = list1.begin (); iter != list1.end (); ++iter)
       {
         QuantizedMultiModFeature feature;
 
@@ -1190,11 +1190,11 @@ pcl::SurfaceNormalModality<PointInT>::extractFeatures (const MaskMap & mask,
     while (list2.size () != nr_features)
     {
       const int sqr_distance = distance*distance;
-      for (typename std::list<Candidate>::iterator iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
+      for (auto iter1 = list1.begin (); iter1 != list1.end (); ++iter1)
       {
         bool candidate_accepted = true;
 
-        for (typename std::list<Candidate>::iterator iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
+        for (auto iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
         {
           const int dx = static_cast<int> (iter1->x) - static_cast<int> (iter2->x);
           const int dy = static_cast<int> (iter1->y) - static_cast<int> (iter2->y);
@@ -1216,7 +1216,7 @@ pcl::SurfaceNormalModality<PointInT>::extractFeatures (const MaskMap & mask,
     }
   }
 
-  for (typename std::list<Candidate>::iterator iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
+  for (auto iter2 = list2.begin (); iter2 != list2.end (); ++iter2)
   {
     QuantizedMultiModFeature feature;
 
@@ -1339,13 +1339,13 @@ pcl::SurfaceNormalModality<PointInT>::extractAllFeatures (
     }
   }
 
-  for (typename std::list<Candidate>::iterator iter = list1.begin (); iter != list1.end (); ++iter)
+  for (auto iter = list1.begin (); iter != list1.end (); ++iter)
     iter->distance *= 1.0f / weights[iter->bin_index];
 
   list1.sort ();
 
   features.reserve (list1.size ());
-  for (typename std::list<Candidate>::iterator iter = list1.begin (); iter != list1.end (); ++iter)
+  for (auto iter = list1.begin (); iter != list1.end (); ++iter)
   {
     QuantizedMultiModFeature feature;
 

--- a/recognition/src/face_detection/face_detector_data_provider.cpp
+++ b/recognition/src/face_detection/face_detector_data_provider.cpp
@@ -254,7 +254,7 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
 
     int element_stride = sizeof(pcl::PointXYZ) / sizeof(float);
     int row_stride = element_stride * cloud->width;
-    const float *data = reinterpret_cast<const float*> (&(*cloud)[0]);
+    const auto *data = reinterpret_cast<const float*> (&(*cloud)[0]);
     integral_image_depth->setInput (data + 2, cloud->width, cloud->height, element_stride, row_stride);
 
     //Compute normals and normal integral images
@@ -282,15 +282,15 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
     if (USE_NORMALS_)
     {
       integral_image_normal_x.reset (new pcl::IntegralImage2D<float, 1> (false));
-      const float *data_nx = reinterpret_cast<const float*> (&(*normals)[0]);
+      const auto *data_nx = reinterpret_cast<const float*> (&(*normals)[0]);
       integral_image_normal_x->setInput (data_nx, normals->width, normals->height, element_stride_normal, row_stride_normal);
 
       integral_image_normal_y.reset (new pcl::IntegralImage2D<float, 1> (false));
-      const float *data_ny = reinterpret_cast<const float*> (&(*normals)[0]);
+      const auto *data_ny = reinterpret_cast<const float*> (&(*normals)[0]);
       integral_image_normal_y->setInput (data_ny + 1, normals->width, normals->height, element_stride_normal, row_stride_normal);
 
       integral_image_normal_z.reset (new pcl::IntegralImage2D<float, 1> (false));
-      const float *data_nz = reinterpret_cast<const float*> (&(*normals)[0]);
+      const auto *data_nz = reinterpret_cast<const float*> (&(*normals)[0]);
       integral_image_normal_z->setInput (data_nz + 2, normals->width, normals->height, element_stride_normal, row_stride_normal);
     }
 

--- a/recognition/src/face_detection/rf_face_detector_trainer.cpp
+++ b/recognition/src/face_detection/rf_face_detector_trainer.cpp
@@ -34,7 +34,7 @@ void pcl::RFFaceDetectorTrainer::trainWithDataProvider()
   if (use_normals_)
     fhda.setNumChannels (4);
 
-  pcl::TernaryTreeMissingDataBranchEstimator * btt = new pcl::TernaryTreeMissingDataBranchEstimator ();
+  auto * btt = new pcl::TernaryTreeMissingDataBranchEstimator ();
   pcl::face_detection::PoseClassRegressionVarianceStatsEstimator<float, NodeType, std::vector<face_detection::TrainingExample>, int> rse (btt);
 
   std::vector<float> thresholds_;
@@ -276,7 +276,7 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
 
   int element_stride = sizeof(pcl::PointXYZ) / sizeof(float);
   int row_stride = element_stride * cloud->width;
-  const float *data = reinterpret_cast<const float*> (&(*cloud)[0]);
+  const auto *data = reinterpret_cast<const float*> (&(*cloud)[0]);
   integral_image_depth->setInput (data + 2, cloud->width, cloud->height, element_stride, row_stride);
 
   //Compute normals and normal integral images
@@ -302,15 +302,15 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
   if (use_normals_)
   {
     integral_image_normal_x.reset (new pcl::IntegralImage2D<float, 1> (false));
-    const float *data_nx = reinterpret_cast<const float*> (&(*normals)[0]);
+    const auto *data_nx = reinterpret_cast<const float*> (&(*normals)[0]);
     integral_image_normal_x->setInput (data_nx, normals->width, normals->height, element_stride_normal, row_stride_normal);
 
     integral_image_normal_y.reset (new pcl::IntegralImage2D<float, 1> (false));
-    const float *data_ny = reinterpret_cast<const float*> (&(*normals)[0]);
+    const auto *data_ny = reinterpret_cast<const float*> (&(*normals)[0]);
     integral_image_normal_y->setInput (data_ny + 1, normals->width, normals->height, element_stride_normal, row_stride_normal);
 
     integral_image_normal_z.reset (new pcl::IntegralImage2D<float, 1> (false));
-    const float *data_nz = reinterpret_cast<const float*> (&(*normals)[0]);
+    const auto *data_nz = reinterpret_cast<const float*> (&(*normals)[0]);
     integral_image_normal_z->setInput (data_nz + 2, normals->width, normals->height, element_stride_normal, row_stride_normal);
   }
 
@@ -324,7 +324,7 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
       fhda.setNumChannels (4);
 
     //pcl::BinaryTreeThresholdBasedBranchEstimator * btt = new pcl::BinaryTreeThresholdBasedBranchEstimator ();
-    pcl::TernaryTreeMissingDataBranchEstimator * btt = new pcl::TernaryTreeMissingDataBranchEstimator ();
+    auto * btt = new pcl::TernaryTreeMissingDataBranchEstimator ();
     face_detection::PoseClassRegressionVarianceStatsEstimator<float, NodeType, std::vector<face_detection::TrainingExample>, int> rse (btt);
 
     std::vector<float> weights(cloud->size(), 0.f);

--- a/recognition/src/linemod.cpp
+++ b/recognition/src/linemod.cpp
@@ -142,11 +142,11 @@ pcl::LINEMOD::matchTemplates (const std::vector<QuantizableModality*> & modaliti
       //energy_maps[bin_index] = new unsigned char[width*height];
       //memset (energy_maps[bin_index], 0, width*height);
 
-      const unsigned char base_bit = static_cast<unsigned char> (0x1);
-      unsigned char val0 = static_cast<unsigned char> (base_bit << bin_index); // e.g. 00100000
-      unsigned char val1 = static_cast<unsigned char> (val0 | (base_bit << (bin_index+1)&7) | (base_bit << (bin_index+7)&7)); // e.g. 01110000
-      unsigned char val2 = static_cast<unsigned char> (val1 | (base_bit << (bin_index+2)&7) | (base_bit << (bin_index+6)&7)); // e.g. 11111000
-      unsigned char val3 = static_cast<unsigned char> (val2 | (base_bit << (bin_index+3)&7) | (base_bit << (bin_index+5)&7)); // e.g. 11111101
+      const auto base_bit = static_cast<unsigned char> (0x1);
+      auto val0 = static_cast<unsigned char> (base_bit << bin_index); // e.g. 00100000
+      auto val1 = static_cast<unsigned char> (val0 | (base_bit << (bin_index+1)&7) | (base_bit << (bin_index+7)&7)); // e.g. 01110000
+      auto val2 = static_cast<unsigned char> (val1 | (base_bit << (bin_index+2)&7) | (base_bit << (bin_index+6)&7)); // e.g. 11111000
+      auto val3 = static_cast<unsigned char> (val2 | (base_bit << (bin_index+3)&7) | (base_bit << (bin_index+5)&7)); // e.g. 11111101
       for (std::size_t index = 0; index < width*height; ++index)
       {
         if ((val0 & quantized_data[index]) != 0)
@@ -217,13 +217,13 @@ pcl::LINEMOD::matchTemplates (const std::vector<QuantizableModality*> & modaliti
     const std::size_t mem_size = mem_width * mem_height;
 
 #ifdef __SSE2__
-    unsigned short * score_sums = reinterpret_cast<unsigned short*> (aligned_malloc (mem_size*sizeof(unsigned short)));
-    unsigned char * tmp_score_sums = reinterpret_cast<unsigned char*> (aligned_malloc (mem_size*sizeof(unsigned char)));
+    auto * score_sums = reinterpret_cast<unsigned short*> (aligned_malloc (mem_size*sizeof(unsigned short)));
+    auto * tmp_score_sums = reinterpret_cast<unsigned char*> (aligned_malloc (mem_size*sizeof(unsigned char)));
     memset (score_sums, 0, mem_size*sizeof (score_sums[0]));
     memset (tmp_score_sums, 0, mem_size*sizeof (tmp_score_sums[0]));
 
     //__m128i * score_sums_m128i = reinterpret_cast<__m128i*> (score_sums);
-    __m128i * tmp_score_sums_m128i = reinterpret_cast<__m128i*> (tmp_score_sums);
+    auto * tmp_score_sums_m128i = reinterpret_cast<__m128i*> (tmp_score_sums);
 
     const std::size_t mem_size_16 = mem_size / 16;
     //const std::size_t mem_size_mod_16 = mem_size & 15;
@@ -240,7 +240,7 @@ pcl::LINEMOD::matchTemplates (const std::vector<QuantizableModality*> & modaliti
           max_score += 4;
 
           unsigned char * data = modality_linearized_maps[feature.modality_index][bin_index].getOffsetMap (feature.x, feature.y);
-          __m128i * data_m128i = reinterpret_cast<__m128i*> (data);
+          auto * data_m128i = reinterpret_cast<__m128i*> (data);
 
           for (std::size_t mem_index = 0; mem_index < mem_size_16; ++mem_index)
           {
@@ -404,11 +404,11 @@ pcl::LINEMOD::detectTemplates (const std::vector<QuantizableModality*> & modalit
       //energy_maps[bin_index] = new unsigned char[width*height];
       //memset (energy_maps[bin_index], 0, width*height);
 
-      const unsigned char base_bit = static_cast<unsigned char> (0x1);
-      unsigned char val0 = static_cast<unsigned char> (base_bit << bin_index); // e.g. 00100000
-      unsigned char val1 = static_cast<unsigned char> (val0 | (base_bit << ((bin_index+1)%8)) | (base_bit << ((bin_index+7)%8))); // e.g. 01110000
-      unsigned char val2 = static_cast<unsigned char> (val1 | (base_bit << ((bin_index+2)%8)) | (base_bit << ((bin_index+6)%8))); // e.g. 11111000
-      unsigned char val3 = static_cast<unsigned char> (val2 | (base_bit << ((bin_index+3)%8)) | (base_bit << ((bin_index+5)%8))); // e.g. 11111101
+      const auto base_bit = static_cast<unsigned char> (0x1);
+      auto val0 = static_cast<unsigned char> (base_bit << bin_index); // e.g. 00100000
+      auto val1 = static_cast<unsigned char> (val0 | (base_bit << ((bin_index+1)%8)) | (base_bit << ((bin_index+7)%8))); // e.g. 01110000
+      auto val2 = static_cast<unsigned char> (val1 | (base_bit << ((bin_index+2)%8)) | (base_bit << ((bin_index+6)%8))); // e.g. 11111000
+      auto val3 = static_cast<unsigned char> (val2 | (base_bit << ((bin_index+3)%8)) | (base_bit << ((bin_index+5)%8))); // e.g. 11111101
       for (std::size_t index = 0; index < width*height; ++index)
       {
         if ((val0 & quantized_data[index]) != 0)
@@ -536,13 +536,13 @@ pcl::LINEMOD::detectTemplates (const std::vector<QuantizableModality*> & modalit
     const std::size_t mem_size = mem_width * mem_height;
 
 #ifdef __SSE2__
-    unsigned short * score_sums = reinterpret_cast<unsigned short*> (aligned_malloc (mem_size*sizeof(unsigned short)));
-    unsigned char * tmp_score_sums = reinterpret_cast<unsigned char*> (aligned_malloc (mem_size*sizeof(unsigned char)));
+    auto * score_sums = reinterpret_cast<unsigned short*> (aligned_malloc (mem_size*sizeof(unsigned short)));
+    auto * tmp_score_sums = reinterpret_cast<unsigned char*> (aligned_malloc (mem_size*sizeof(unsigned char)));
     memset (score_sums, 0, mem_size*sizeof (score_sums[0]));
     memset (tmp_score_sums, 0, mem_size*sizeof (tmp_score_sums[0]));
 
     //__m128i * score_sums_m128i = reinterpret_cast<__m128i*> (score_sums);
-    __m128i * tmp_score_sums_m128i = reinterpret_cast<__m128i*> (tmp_score_sums);
+    auto * tmp_score_sums_m128i = reinterpret_cast<__m128i*> (tmp_score_sums);
 
     const std::size_t mem_size_16 = mem_size / 16;
     //const std::size_t mem_size_mod_16 = mem_size & 15;
@@ -559,7 +559,7 @@ pcl::LINEMOD::detectTemplates (const std::vector<QuantizableModality*> & modalit
           max_score += 4;
 
           unsigned char * data = modality_linearized_maps[feature.modality_index][bin_index].getOffsetMap (feature.x, feature.y);
-          __m128i * data_m128i = reinterpret_cast<__m128i*> (data);
+          auto * data_m128i = reinterpret_cast<__m128i*> (data);
 
           for (std::size_t mem_index = 0; mem_index < mem_size_16; ++mem_index)
           {
@@ -748,7 +748,7 @@ pcl::LINEMOD::detectTemplates (const std::vector<QuantizableModality*> & modalit
               if (sup_col_index >= mem_width)
                 continue;
 
-              const std::size_t weight = static_cast<std::size_t> (score_sums[sup_row_index*mem_width + sup_col_index]);
+              const auto weight = static_cast<std::size_t> (score_sums[sup_row_index*mem_width + sup_col_index]);
               average_col += sup_col_index * weight;
               average_row += sup_row_index * weight;
               sum += weight;
@@ -873,11 +873,11 @@ pcl::LINEMOD::detectTemplatesSemiScaleInvariant (
       //energy_maps[bin_index] = new unsigned char[width*height];
       //memset (energy_maps[bin_index], 0, width*height);
 
-      const unsigned char base_bit = static_cast<unsigned char> (0x1);
-      unsigned char val0 = static_cast<unsigned char> (base_bit << bin_index); // e.g. 00100000
-      unsigned char val1 = static_cast<unsigned char> (val0 | (base_bit << ((bin_index+1)%8)) | (base_bit << ((bin_index+7)%8))); // e.g. 01110000
-      unsigned char val2 = static_cast<unsigned char> (val1 | (base_bit << ((bin_index+2)%8)) | (base_bit << ((bin_index+6)%8))); // e.g. 11111000
-      unsigned char val3 = static_cast<unsigned char> (val2 | (base_bit << ((bin_index+3)%8)) | (base_bit << ((bin_index+5)%8))); // e.g. 11111101
+      const auto base_bit = static_cast<unsigned char> (0x1);
+      auto val0 = static_cast<unsigned char> (base_bit << bin_index); // e.g. 00100000
+      auto val1 = static_cast<unsigned char> (val0 | (base_bit << ((bin_index+1)%8)) | (base_bit << ((bin_index+7)%8))); // e.g. 01110000
+      auto val2 = static_cast<unsigned char> (val1 | (base_bit << ((bin_index+2)%8)) | (base_bit << ((bin_index+6)%8))); // e.g. 11111000
+      auto val3 = static_cast<unsigned char> (val2 | (base_bit << ((bin_index+3)%8)) | (base_bit << ((bin_index+5)%8))); // e.g. 11111101
       for (std::size_t index = 0; index < width*height; ++index)
       {
         if ((val0 & quantized_data[index]) != 0)
@@ -1007,13 +1007,13 @@ pcl::LINEMOD::detectTemplatesSemiScaleInvariant (
     for (float scale = min_scale; scale <= max_scale; scale *= scale_multiplier)
     {
 #ifdef __SSE2__
-      unsigned short * score_sums = reinterpret_cast<unsigned short*> (aligned_malloc (mem_size*sizeof(unsigned short)));
-      unsigned char * tmp_score_sums = reinterpret_cast<unsigned char*> (aligned_malloc (mem_size*sizeof(unsigned char)));
+      auto * score_sums = reinterpret_cast<unsigned short*> (aligned_malloc (mem_size*sizeof(unsigned short)));
+      auto * tmp_score_sums = reinterpret_cast<unsigned char*> (aligned_malloc (mem_size*sizeof(unsigned char)));
       memset (score_sums, 0, mem_size*sizeof (score_sums[0]));
       memset (tmp_score_sums, 0, mem_size*sizeof (tmp_score_sums[0]));
 
       //__m128i * score_sums_m128i = reinterpret_cast<__m128i*> (score_sums);
-      __m128i * tmp_score_sums_m128i = reinterpret_cast<__m128i*> (tmp_score_sums);
+      auto * tmp_score_sums_m128i = reinterpret_cast<__m128i*> (tmp_score_sums);
 
       const std::size_t mem_size_16 = mem_size / 16;
       //const std::size_t mem_size_mod_16 = mem_size & 15;
@@ -1031,7 +1031,7 @@ pcl::LINEMOD::detectTemplatesSemiScaleInvariant (
 
             unsigned char *data = modality_linearized_maps[feature.modality_index][bin_index].getOffsetMap (
                 std::size_t (float (feature.x) * scale), std::size_t (float (feature.y) * scale));
-            __m128i * data_m128i = reinterpret_cast<__m128i*> (data);
+            auto * data_m128i = reinterpret_cast<__m128i*> (data);
 
             for (std::size_t mem_index = 0; mem_index < mem_size_16; ++mem_index)
             {
@@ -1220,7 +1220,7 @@ pcl::LINEMOD::detectTemplatesSemiScaleInvariant (
                 if (sup_col_index >= mem_width)
                   continue;
 
-                const std::size_t weight = static_cast<std::size_t> (score_sums[sup_row_index*mem_width + sup_col_index]);
+                const auto weight = static_cast<std::size_t> (score_sums[sup_row_index*mem_width + sup_col_index]);
                 average_col += sup_col_index * weight;
                 average_row += sup_row_index * weight;
                 sum += weight;

--- a/recognition/src/ransac_based/model_library.cpp
+++ b/recognition/src/ransac_based/model_library.cpp
@@ -118,7 +118,7 @@ ModelLibrary::addModel (const PointCloudIn& points, const PointCloudN& normals, 
   }
 
   // It is unique -> create a new library model and save it
-  Model* new_model = new Model (points, normals, voxel_size_, object_name, frac_of_points_for_registration, user_data);
+  auto* new_model = new Model (points, normals, voxel_size_, object_name, frac_of_points_for_registration, user_data);
   result.first->second = new_model;
 
   const ORROctree& octree = new_model->getOctree ();

--- a/recognition/src/ransac_based/obj_rec_ransac.cpp
+++ b/recognition/src/ransac_based/obj_rec_ransac.cpp
@@ -133,10 +133,10 @@ pcl::recognition::ObjRecRANSAC::recognize (const PointCloudIn& scene, const Poin
   int i = 0;
 
   // Initialize the vector with bounded objects
-  for ( std::vector<Hypothesis>::iterator hypo = accepted_hypotheses_.begin () ; hypo != accepted_hypotheses_.end () ; ++hypo, ++i )
+  for ( auto hypo = accepted_hypotheses_.begin () ; hypo != accepted_hypotheses_.end () ; ++hypo, ++i )
   {
     // Create, initialize and save a bounded object based on the hypothesis
-    BVHH::BoundedObject *bounded_object = new BVHH::BoundedObject (&(*hypo));
+    auto *bounded_object = new BVHH::BoundedObject (&(*hypo));
     hypo->computeCenterOfMass (bounded_object->getCentroid ());
     hypo->computeBounds (bounded_object->getBounds ());
     bounded_objects[i] = bounded_object;
@@ -360,7 +360,7 @@ pcl::recognition::ObjRecRANSAC::groupHypotheses(std::list<HypothesisBase>& hypot
       this->testHypothesis (&hypothesis, int_match, penalty);
 
       // For better code readability
-      float num_full_leaves = static_cast<float> (hypothesis.obj_model_->getOctree ().getFullLeaves ().size ());
+      auto num_full_leaves = static_cast<float> (hypothesis.obj_model_->getOctree ().getFullLeaves ().size ());
       float match_thresh = num_full_leaves*visibility_;
       int penalty_thresh = static_cast<int> (num_full_leaves*relative_num_of_illegal_pts_ + 0.5f);
 
@@ -423,7 +423,7 @@ pcl::recognition::ObjRecRANSAC::buildGraphOfCloseHypotheses (HypothesisOctree& h
 
   graph.resize (static_cast<int> (hypo_leaves.size ()));
 
-  for ( std::vector<HypothesisOctree::Node*>::iterator hypo = hypo_leaves.begin () ; hypo != hypo_leaves.end () ; ++hypo, ++i )
+  for ( auto hypo = hypo_leaves.begin () ; hypo != hypo_leaves.end () ; ++hypo, ++i )
     (*hypo)->getData ().setLinearId (i);
 
   i = 0;
@@ -493,7 +493,7 @@ pcl::recognition::ObjRecRANSAC::buildGraphOfConflictingHypotheses (const BVHH& b
   graph.resize (static_cast<int> (bounded_objects->size ()));
 
   // Setup the hypotheses' ids
-  for ( std::vector<BVHH::BoundedObject*>::const_iterator obj = bounded_objects->begin () ; obj != bounded_objects->end () ; ++obj, ++lin_id )
+  for ( auto obj = bounded_objects->begin () ; obj != bounded_objects->end () ; ++obj, ++lin_id )
   {
     (*obj)->getData ()->setLinearId (lin_id);
     graph.getNodes ()[lin_id]->setData ((*obj)->getData ());
@@ -680,7 +680,7 @@ pcl::recognition::ObjRecRANSAC::testHypothesisNormalBased (Hypothesis* hypothesi
       // Compute the match based on the normal agreement
       const std::set<ORROctree::Node*, bool(*)(ORROctree::Node*,ORROctree::Node*)>* nodes = scene_octree_proj_.getOctreeNodes (transformed_point);
 
-      std::set<ORROctree::Node*, bool(*)(ORROctree::Node*,ORROctree::Node*)>::const_iterator n = nodes->begin ();
+      auto n = nodes->begin ();
       ORROctree::Node *closest_node = *n;
       float min_sqr_dist = aux::sqrDistance3 (closest_node->getData ()->getPoint (), transformed_point);
 

--- a/recognition/src/ransac_based/orr_octree.cpp
+++ b/recognition/src/ransac_based/orr_octree.cpp
@@ -88,7 +88,7 @@ pcl::recognition::ORROctree::build (const float* bounds, float voxel_size)
     tree_levels_ = 0;
 
   // Compute the number of octree levels and the bounds of the root
-  float half_root_side = static_cast<float> (0.5f*pow (2.0, tree_levels_)*voxel_size);
+  auto half_root_side = static_cast<float> (0.5f*pow (2.0, tree_levels_)*voxel_size);
 
   // Determine the bounding box of the octree
   bounds_[0] = center[0] - half_root_side;
@@ -414,7 +414,7 @@ pcl::recognition::ORROctree::getFullLeavesPoints (PointCloudOut& out) const
   std::size_t i = 0;
 
   // Now iterate over all full leaves and compute the normals and average points
-  for ( std::vector<ORROctree::Node*>::const_iterator it = full_leaves_.begin() ; it != full_leaves_.end() ; ++it, ++i )
+  for ( auto it = full_leaves_.begin() ; it != full_leaves_.end() ; ++it, ++i )
   {
     out[i].x = (*it)->getData ()->getPoint ()[0];
     out[i].y = (*it)->getData ()->getPoint ()[1];
@@ -431,7 +431,7 @@ pcl::recognition::ORROctree::getNormalsOfFullLeaves (PointCloudN& out) const
   std::size_t i = 0;
 
   // Now iterate over all full leaves and compute the normals and average points
-  for ( std::vector<ORROctree::Node*>::const_iterator it = full_leaves_.begin() ; it != full_leaves_.end() ; ++it, ++i )
+  for ( auto it = full_leaves_.begin() ; it != full_leaves_.end() ; ++it, ++i )
   {
     out[i].normal_x = (*it)->getData ()->getNormal ()[0];
     out[i].normal_y = (*it)->getData ()->getNormal ()[1];

--- a/recognition/src/ransac_based/orr_octree_zprojection.cpp
+++ b/recognition/src/ransac_based/orr_octree_zprojection.cpp
@@ -169,7 +169,7 @@ pcl::recognition::ORROctreeZProjection::build (const ORROctree& input, float eps
   for (const auto &full_set : full_sets_)
   {
     // Get the first node in the set
-    std::set<ORROctree::Node*, bool(*)(ORROctree::Node*,ORROctree::Node*)>::iterator node = full_set->get_nodes ().begin ();
+    auto node = full_set->get_nodes ().begin ();
     // Initialize
     float best_min = (*node)->getBounds ()[4];
     float best_max = (*node)->getBounds ()[5];

--- a/registration/include/pcl/registration/impl/elch.hpp
+++ b/registration/include/pcl/registration/impl/elch.hpp
@@ -63,8 +63,8 @@ pcl::registration::ELCH<PointT>::loopOptimizerAlgorithm(LOAGraph& g, double* wei
 
   int* p = new int[num_vertices(g)];
   int* p_min = new int[num_vertices(g)];
-  double* d = new double[num_vertices(g)];
-  double* d_min = new double[num_vertices(g)];
+  auto* d = new double[num_vertices(g)];
+  auto* d_min = new double[num_vertices(g)];
   bool do_swap = false;
   std::list<int>::iterator start_min, end_min;
 

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -71,7 +71,7 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget>::computeCovariances(
   if (cloud_covariances.size() < cloud->size())
     cloud_covariances.resize(cloud->size());
 
-  MatricesVector::iterator matrices_iterator = cloud_covariances.begin();
+  auto matrices_iterator = cloud_covariances.begin();
   for (auto points_iterator = cloud->begin(); points_iterator != cloud->end();
        ++points_iterator, ++matrices_iterator) {
     const PointT& query_point = *points_iterator;

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -653,7 +653,7 @@ pcl::registration::FPCSInitialAlignment<PointSource, PointTarget, NormalT, Scala
   // point cloud
   PointCloudSourcePtr cloud_e(new PointCloudSource);
   cloud_e->resize(pairs_a.size() * 2);
-  PointCloudSourceIterator it_pt = cloud_e->begin();
+  auto it_pt = cloud_e->begin();
   for (const auto& pair : pairs_a) {
     const PointSource* pt1 = &((*input_)[pair.index_match]);
     const PointSource* pt2 = &((*input_)[pair.index_query]);
@@ -876,7 +876,7 @@ pcl::registration::FPCSInitialAlignment<PointSource, PointTarget, NormalT, Scala
   float inlier_score_temp = 0;
   pcl::Indices ids;
   std::vector<float> dists_sqr;
-  PointCloudSourceIterator it = source_transformed.begin();
+  auto it = source_transformed.begin();
 
   for (std::size_t i = 0; i < nr_points; it++, i++) {
     // search for nearest point using kd tree search

--- a/registration/include/pcl/registration/impl/ia_kfpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_kfpcs.hpp
@@ -156,7 +156,7 @@ KFPCSInitialAlignment<PointSource, PointTarget, NormalT, Scalar>::
   // residual costs based on mse
   pcl::Indices ids;
   std::vector<float> dists_sqr;
-  for (PointCloudSourceIterator it = source_transformed.begin(),
+  for (auto it = source_transformed.begin(),
                                 it_e = source_transformed.end();
        it != it_e;
        ++it) {
@@ -240,7 +240,7 @@ KFPCSInitialAlignment<PointSource, PointTarget, NormalT, Scalar>::getNBestCandid
   candidates.clear();
 
   // loop over all candidates starting from the best one
-  for (MatchingCandidates::iterator it_candidate = candidates_.begin(),
+  for (auto it_candidate = candidates_.begin(),
                                     it_e = candidates_.end();
        it_candidate != it_e;
        ++it_candidate) {
@@ -251,7 +251,7 @@ KFPCSInitialAlignment<PointSource, PointTarget, NormalT, Scalar>::getNBestCandid
     // check if current candidate is a unique one compared to previous using the
     // min_diff threshold
     bool unique = true;
-    MatchingCandidates::iterator it = candidates.begin(), it_e2 = candidates.end();
+    auto it = candidates.begin(), it_e2 = candidates.end();
     while (unique && it != it_e2) {
       Eigen::Matrix4f diff =
           it_candidate->transformation.colPivHouseholderQr().solve(it->transformation);
@@ -279,7 +279,7 @@ KFPCSInitialAlignment<PointSource, PointTarget, NormalT, Scalar>::getTBestCandid
   candidates.clear();
 
   // loop over all candidates starting from the best one
-  for (MatchingCandidates::iterator it_candidate = candidates_.begin(),
+  for (auto it_candidate = candidates_.begin(),
                                     it_e = candidates_.end();
        it_candidate != it_e;
        ++it_candidate) {
@@ -290,7 +290,7 @@ KFPCSInitialAlignment<PointSource, PointTarget, NormalT, Scalar>::getTBestCandid
     // check if current candidate is a unique one compared to previous using the
     // min_diff threshold
     bool unique = true;
-    MatchingCandidates::iterator it = candidates.begin(), it_e2 = candidates.end();
+    auto it = candidates.begin(), it_e2 = candidates.end();
     while (unique && it != it_e2) {
       Eigen::Matrix4f diff =
           it_candidate->transformation.colPivHouseholderQr().solve(it->transformation);

--- a/registration/include/pcl/registration/impl/icp.hpp
+++ b/registration/include/pcl/registration/impl/icp.hpp
@@ -60,8 +60,8 @@ IterativeClosestPoint<PointSource, PointTarget, Scalar>::transformCloud(
     Eigen::Matrix3f rot = tr.block<3, 3>(0, 0);
 
     for (std::size_t i = 0; i < input.size(); ++i) {
-      const std::uint8_t* data_in = reinterpret_cast<const std::uint8_t*>(&input[i]);
-      std::uint8_t* data_out = reinterpret_cast<std::uint8_t*>(&output[i]);
+      const auto* data_in = reinterpret_cast<const std::uint8_t*>(&input[i]);
+      auto* data_out = reinterpret_cast<std::uint8_t*>(&output[i]);
       memcpy(&pt[0], data_in + x_idx_offset_, sizeof(float));
       memcpy(&pt[1], data_in + y_idx_offset_, sizeof(float));
       memcpy(&pt[2], data_in + z_idx_offset_, sizeof(float));
@@ -91,8 +91,8 @@ IterativeClosestPoint<PointSource, PointTarget, Scalar>::transformCloud(
   }
   else {
     for (std::size_t i = 0; i < input.size(); ++i) {
-      const std::uint8_t* data_in = reinterpret_cast<const std::uint8_t*>(&input[i]);
-      std::uint8_t* data_out = reinterpret_cast<std::uint8_t*>(&output[i]);
+      const auto* data_in = reinterpret_cast<const std::uint8_t*>(&input[i]);
+      auto* data_out = reinterpret_cast<std::uint8_t*>(&output[i]);
       memcpy(&pt[0], data_in + x_idx_offset_, sizeof(float));
       memcpy(&pt[1], data_in + y_idx_offset_, sizeof(float));
       memcpy(&pt[2], data_in + z_idx_offset_, sizeof(float));

--- a/registration/include/pcl/registration/impl/ppf_registration.hpp
+++ b/registration/include/pcl/registration/impl/ppf_registration.hpp
@@ -160,7 +160,7 @@ pcl::PPFRegistration<PointSource, PointTarget>::computeTransformation(
             else if (alpha > M_PI) {
               alpha -= (2 * M_PI);
             }
-            unsigned int alpha_discretized = static_cast<unsigned int>(std::floor(
+            auto alpha_discretized = static_cast<unsigned int>(std::floor(
                 (alpha + M_PI) / search_method_->getAngleDiscretizationStep()));
             accumulator_array[model_reference_index][alpha_discretized]++;
           }

--- a/registration/include/pcl/registration/impl/pyramid_feature_matching.hpp
+++ b/registration/include/pcl/registration/impl/pyramid_feature_matching.hpp
@@ -118,7 +118,7 @@ PyramidFeatureHistogram<PointFeature>::comparePyramidFeatureHistograms(
   }
 
   // include self-similarity factors
-  float self_similarity_a = static_cast<float>(pyramid_a->nr_features),
+  auto self_similarity_a = static_cast<float>(pyramid_a->nr_features),
         self_similarity_b = static_cast<float>(pyramid_b->nr_features);
   PCL_DEBUG("[pcl::PyramidFeatureMatching::comparePyramidFeatureHistograms] Self "
             "similarity measures: %f, %f\n",
@@ -145,7 +145,7 @@ PyramidFeatureHistogram<
     PointFeature>::PyramidFeatureHistogramLevel::initializeHistogramLevel()
 {
   std::size_t total_vector_size = 1;
-  for (std::vector<std::size_t>::iterator dim_it = bins_per_dimension.begin();
+  for (auto dim_it = bins_per_dimension.begin();
        dim_it != bins_per_dimension.end();
        ++dim_it)
     total_vector_size *= *dim_it;
@@ -187,7 +187,7 @@ PyramidFeatureHistogram<PointFeature>::initializeHistogram()
   nr_dimensions = dimension_range_target_.size();
   nr_features = input_->size();
   float D = 0.0f;
-  for (std::vector<std::pair<float, float>>::iterator range_it =
+  for (auto range_it =
            dimension_range_target_.begin();
        range_it != dimension_range_target_.end();
        ++range_it) {

--- a/registration/src/correspondence_rejection_var_trimmed.cpp
+++ b/registration/src/correspondence_rejection_var_trimmed.cpp
@@ -79,7 +79,7 @@ float
 pcl::registration::CorrespondenceRejectorVarTrimmed::optimizeInlierRatio(
     std::vector<double>& dists) const
 {
-  unsigned int points_nbr = static_cast<unsigned int>(dists.size());
+  auto points_nbr = static_cast<unsigned int>(dists.size());
   std::sort(dists.begin(), dists.end());
 
   const int min_el = int(std::floor(min_ratio_ * points_nbr));

--- a/registration/src/ppf_registration.cpp
+++ b/registration/src/ppf_registration.cpp
@@ -52,7 +52,7 @@ pcl::PPFHashMapSearch::setInputFeatureCloud(
 {
   // Discretize the feature cloud and insert it in the hash map
   feature_hash_map_->clear();
-  unsigned int n =
+  auto n =
       static_cast<unsigned int>(std::sqrt(static_cast<float>(feature_cloud->size())));
   int d1, d2, d3, d4;
   max_dist_ = -1.0;

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_stick.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_stick.hpp
@@ -114,7 +114,7 @@ pcl::SampleConsensusModelStick<PointT>::getDistancesToModel (
     return;
   }
 
-  float sqr_threshold = static_cast<float> (radius_max_ * radius_max_);
+  auto sqr_threshold = static_cast<float> (radius_max_ * radius_max_);
   distances.resize (indices_->size ());
 
   // Obtain the line point and direction
@@ -154,7 +154,7 @@ pcl::SampleConsensusModelStick<PointT>::selectWithinDistance (
     return;
   }
 
-  float sqr_threshold = static_cast<float> (threshold * threshold);
+  auto sqr_threshold = static_cast<float> (threshold * threshold);
 
   inliers.clear ();
   error_sqr_dists_.clear ();
@@ -204,7 +204,7 @@ pcl::SampleConsensusModelStick<PointT>::countWithinDistance (
     return (0);
   }
 
-  float sqr_threshold = static_cast<float> (threshold * threshold);
+  auto sqr_threshold = static_cast<float> (threshold * threshold);
 
   std::size_t nr_i = 0, nr_o = 0;
 
@@ -388,7 +388,7 @@ pcl::SampleConsensusModelStick<PointT>::doSamplesVerifyModel (
   //Eigen::Vector4f line_dir (model_coefficients[3], model_coefficients[4], model_coefficients[5], 0);
   line_dir.normalize ();
 
-  float sqr_threshold = static_cast<float> (threshold * threshold);
+  auto sqr_threshold = static_cast<float> (threshold * threshold);
   // Iterate through the 3d points and calculate the distances from them to the line
   for (const auto &index : indices)
   {

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_registration.h
@@ -131,7 +131,7 @@ namespace pcl
       {
         target_ = target;
         // Cache the size and fill the target indices
-        const index_t target_size = static_cast<index_t> (target->size ());
+        const auto target_size = static_cast<index_t> (target->size ());
         indices_tgt_.reset (new Indices (target_size));
         std::iota (indices_tgt_->begin (), indices_tgt_->end (), 0);
         computeOriginalIndexMapping ();

--- a/search/include/pcl/search/impl/flann_search.hpp
+++ b/search/include/pcl/search/impl/flann_search.hpp
@@ -201,7 +201,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::nearestKSearch (
       }
     }
 
-    float* data=new float [dim_*indices.size ()];
+    auto* data=new float [dim_*indices.size ()];
     for (std::size_t i = 0; i < indices.size (); ++i)
     {
       float* out = data+i*dim_;
@@ -330,7 +330,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::radiusSearch (
       }
     }
 
-    float* data = new float [dim_ * indices.size ()];
+    auto* data = new float [dim_ * indices.size ()];
     for (std::size_t i = 0; i < indices.size (); ++i)
     {
       float* out = data+i*dim_;

--- a/search/include/pcl/search/impl/organized.hpp
+++ b/search/include/pcl/search/impl/organized.hpp
@@ -290,8 +290,8 @@ pcl::search::OrganizedNeighbor<PointT>::getProjectedRadiusSearchBox (const Point
   }
   else
   {
-    float y1 = static_cast<float> ((b - std::sqrt (det)) / a);
-    float y2 = static_cast<float> ((b + std::sqrt (det)) / a);
+    auto y1 = static_cast<float> ((b - std::sqrt (det)) / a);
+    auto y2 = static_cast<float> ((b + std::sqrt (det)) / a);
 
     min = std::min (static_cast<int> (std::floor (y1)), static_cast<int> (std::floor (y2)));
     max = std::max (static_cast<int> (std::ceil (y1)), static_cast<int> (std::ceil (y2)));
@@ -310,8 +310,8 @@ pcl::search::OrganizedNeighbor<PointT>::getProjectedRadiusSearchBox (const Point
   }
   else
   {
-    float x1 = static_cast<float> ((b - std::sqrt (det)) / a);
-    float x2 = static_cast<float> ((b + std::sqrt (det)) / a);
+    auto x1 = static_cast<float> ((b - std::sqrt (det)) / a);
+    auto x2 = static_cast<float> ((b + std::sqrt (det)) / a);
 
     min = std::min (static_cast<int> (std::floor (x1)), static_cast<int> (std::floor (x2)));
     max = std::max (static_cast<int> (std::ceil (x1)), static_cast<int> (std::ceil (x2)));

--- a/segmentation/include/pcl/segmentation/impl/grabcut_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/grabcut_segmentation.hpp
@@ -318,7 +318,7 @@ GrabCut<PointT>::initGraph ()
     if (n_link.nb_links > 0)
     {
       const auto point_index = (*indices_) [i_point];
-      std::vector<float>::const_iterator weights_it  = n_link.weights.begin ();
+      auto weights_it  = n_link.weights.begin ();
       for (auto indices_it = n_link.indices.cbegin (); indices_it != n_link.indices.cend (); ++indices_it, ++weights_it)
       {
         if ((*indices_it != point_index) && (*indices_it != UNAVAILABLE))

--- a/segmentation/include/pcl/segmentation/impl/lccp_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/lccp_segmentation.hpp
@@ -252,7 +252,7 @@ pcl::LCCPSegmentation<PointT>::prepareSegmentation (const std::map<std::uint32_t
   std::map<std::uint32_t, VertexID> label_ID_map;
 
   // Add all supervoxel labels as vertices
-  for (typename std::map<std::uint32_t, typename pcl::Supervoxel<PointT>::Ptr>::iterator svlabel_itr = sv_label_to_supervoxel_map_.begin ();
+  for (auto svlabel_itr = sv_label_to_supervoxel_map_.begin ();
       svlabel_itr != sv_label_to_supervoxel_map_.end (); ++svlabel_itr)
   {
     const std::uint32_t& sv_label = svlabel_itr->first;
@@ -276,7 +276,7 @@ pcl::LCCPSegmentation<PointT>::prepareSegmentation (const std::map<std::uint32_t
   // Initialization
   // clear the processed_ map
   seg_label_to_sv_list_map_.clear ();
-  for (typename std::map<std::uint32_t, typename pcl::Supervoxel<PointT>::Ptr>::iterator svlabel_itr = sv_label_to_supervoxel_map_.begin ();
+  for (auto svlabel_itr = sv_label_to_supervoxel_map_.begin ();
       svlabel_itr != sv_label_to_supervoxel_map_.end (); ++svlabel_itr)
   {
     const std::uint32_t& sv_label = svlabel_itr->first;
@@ -293,7 +293,7 @@ pcl::LCCPSegmentation<PointT>::doGrouping ()
 {
   // clear the processed_ map
   seg_label_to_sv_list_map_.clear ();
-  for (typename std::map<std::uint32_t, typename pcl::Supervoxel<PointT>::Ptr>::iterator svlabel_itr = sv_label_to_supervoxel_map_.begin ();
+  for (auto svlabel_itr = sv_label_to_supervoxel_map_.begin ();
       svlabel_itr != sv_label_to_supervoxel_map_.end (); ++svlabel_itr)
   {
     const std::uint32_t& sv_label = svlabel_itr->first;

--- a/segmentation/include/pcl/segmentation/impl/min_cut_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/min_cut_segmentation.hpp
@@ -422,7 +422,7 @@ pcl::MinCutSegmentation<PointT>::calculateUnaryPotential (int point, double& sou
 template <typename PointT> bool
 pcl::MinCutSegmentation<PointT>::addEdge (int source, int target, double weight)
 {
-  std::set<int>::iterator iter_out = edge_marker_[source].find (target);
+  auto iter_out = edge_marker_[source].find (target);
   if ( iter_out != edge_marker_[source].end () )
     return (false);
 
@@ -512,7 +512,7 @@ pcl::MinCutSegmentation<PointT>::recalculateBinaryPotentials ()
 
       //If we already changed weight for this edge then continue
       VertexDescriptor target_vertex = boost::target (*edge_iter, *graph_);
-      std::set<VertexDescriptor>::iterator iter_out = edge_marker[static_cast<int> (source_vertex)].find (target_vertex);
+      auto iter_out = edge_marker[static_cast<int> (source_vertex)].find (target_vertex);
       if ( iter_out != edge_marker[static_cast<int> (source_vertex)].end () )
         continue;
 

--- a/segmentation/include/pcl/segmentation/impl/region_growing.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing.hpp
@@ -275,7 +275,7 @@ pcl::RegionGrowing<PointT, NormalT>::extract (std::vector <pcl::PointIndices>& c
   assembleRegions ();
 
   clusters.resize (clusters_.size ());
-  std::vector<pcl::PointIndices>::iterator cluster_iter_input = clusters.begin ();
+  auto cluster_iter_input = clusters.begin ();
   for (const auto& cluster : clusters_)
   {
     if ((cluster.indices.size () >= min_pts_per_cluster_) &&

--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -195,7 +195,7 @@ pcl::RegionGrowingRGB<PointT, NormalT>::extract (std::vector <pcl::PointIndices>
   findSegmentNeighbours ();
   applyRegionMergingAlgorithm ();
 
-  std::vector<pcl::PointIndices>::iterator cluster_iter = clusters_.begin ();
+  auto cluster_iter = clusters_.begin ();
   while (cluster_iter != clusters_.end ())
   {
     if (cluster_iter->indices.size () < min_pts_per_cluster_ ||

--- a/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
+++ b/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
@@ -207,8 +207,8 @@ pcl::SupervoxelClustering<PointT>::computeVoxelData ()
 {
   voxel_centroid_cloud_.reset (new PointCloudT);
   voxel_centroid_cloud_->resize (adjacency_octree_->getLeafCount ());
-  typename LeafVectorT::iterator leaf_itr = adjacency_octree_->begin ();
-  typename PointCloudT::iterator cent_cloud_itr = voxel_centroid_cloud_->begin ();
+  auto leaf_itr = adjacency_octree_->begin ();
+  auto cent_cloud_itr = voxel_centroid_cloud_->begin ();
   for (int idx = 0 ; leaf_itr != adjacency_octree_->end (); ++leaf_itr, ++cent_cloud_itr, ++idx)
   {
     VoxelData& new_voxel_data = (*leaf_itr)->getData ();
@@ -224,8 +224,8 @@ pcl::SupervoxelClustering<PointT>::computeVoxelData ()
     //Verify that input normal cloud size is same as input cloud size
     assert (input_normals_->size () == input_->size ());
     //For every point in the input cloud, find its corresponding leaf
-    typename NormalCloudT::const_iterator normal_itr = input_normals_->begin ();
-    for (typename PointCloudT::const_iterator input_itr = input_->begin (); input_itr != input_->end (); ++input_itr, ++normal_itr)
+    auto normal_itr = input_normals_->begin ();
+    for (auto input_itr = input_->begin (); input_itr != input_->end (); ++input_itr, ++normal_itr)
     {
       //If the point is not finite we ignore it
       if ( !pcl::isFinite<PointT> (*input_itr))
@@ -261,13 +261,13 @@ pcl::SupervoxelClustering<PointT>::computeVoxelData ()
       indices.reserve (81); 
       //Push this point
       indices.push_back (new_voxel_data.idx_);
-      for (typename LeafContainerT::const_iterator neighb_itr=(*leaf_itr)->cbegin (); neighb_itr!=(*leaf_itr)->cend (); ++neighb_itr)
+      for (auto neighb_itr=(*leaf_itr)->cbegin (); neighb_itr!=(*leaf_itr)->cend (); ++neighb_itr)
       {
         VoxelData& neighb_voxel_data = (*neighb_itr)->getData ();
         //Push neighbor index
         indices.push_back (neighb_voxel_data.idx_);
         //Get neighbors neighbors, push onto cloud
-        for (typename LeafContainerT::const_iterator neighb_neighb_itr=(*neighb_itr)->cbegin (); neighb_neighb_itr!=(*neighb_itr)->cend (); ++neighb_neighb_itr)
+        for (auto neighb_neighb_itr=(*neighb_itr)->cbegin (); neighb_neighb_itr!=(*neighb_itr)->cend (); ++neighb_neighb_itr)
         {
           VoxelData& neighb2_voxel_data = (*neighb_neighb_itr)->getData ();
           indices.push_back (neighb2_voxel_data.idx_);
@@ -564,7 +564,7 @@ pcl::SupervoxelClustering<PointT>::getLabeledVoxelCloud () const
     pcl::PointCloud<pcl::PointXYZL> xyzl_copy;
     copyPointCloud (*voxels, xyzl_copy);
     
-    pcl::PointCloud<pcl::PointXYZL>::iterator xyzl_copy_itr = xyzl_copy.begin ();
+    auto xyzl_copy_itr = xyzl_copy.begin ();
     for ( ; xyzl_copy_itr != xyzl_copy.end (); ++xyzl_copy_itr) 
       xyzl_copy_itr->label = sv_itr->getLabel ();
     
@@ -581,7 +581,7 @@ pcl::SupervoxelClustering<PointT>::getLabeledCloud () const
   pcl::PointCloud<pcl::PointXYZL>::Ptr labeled_cloud (new pcl::PointCloud<pcl::PointXYZL>);
   pcl::copyPointCloud (*input_,*labeled_cloud);
   
-  typename pcl::PointCloud <PointT>::const_iterator i_input = input_->begin ();
+  auto i_input = input_->begin ();
   for (auto i_labeled = labeled_cloud->begin (); i_labeled != labeled_cloud->end (); ++i_labeled,++i_input)
   {
     if ( !pcl::isFinite<PointT> (*i_input))
@@ -607,7 +607,7 @@ pcl::SupervoxelClustering<PointT>::makeSupervoxelNormalCloud (std::map<std::uint
 {
   pcl::PointCloud<pcl::PointNormal>::Ptr normal_cloud (new pcl::PointCloud<pcl::PointNormal>);
   normal_cloud->resize (supervoxel_clusters.size ());
-  pcl::PointCloud<pcl::PointNormal>::iterator normal_cloud_itr = normal_cloud->begin ();
+  auto normal_cloud_itr = normal_cloud->begin ();
   for (auto sv_itr = supervoxel_clusters.cbegin (), sv_itr_end = supervoxel_clusters.cend ();
        sv_itr != sv_itr_end; ++sv_itr, ++normal_cloud_itr)
   {
@@ -794,7 +794,7 @@ pcl::SupervoxelClustering<PointT>::SupervoxelHelper::expand ()
   for (auto leaf_itr = leaves_.cbegin (); leaf_itr != leaves_.cend (); ++leaf_itr)
   {
     //for each neighbor of the leaf
-    for (typename LeafContainerT::const_iterator neighb_itr=(*leaf_itr)->cbegin (); neighb_itr!=(*leaf_itr)->cend (); ++neighb_itr)
+    for (auto neighb_itr=(*leaf_itr)->cbegin (); neighb_itr!=(*leaf_itr)->cend (); ++neighb_itr)
     {
       //Get a reference to the data contained in the leaf
       VoxelData& neighbor_voxel = ((*neighb_itr)->getData ());
@@ -837,7 +837,7 @@ pcl::SupervoxelClustering<PointT>::SupervoxelHelper::refineNormals ()
     indices.reserve (81); 
     //Push this point
     indices.push_back (voxel_data.idx_);
-    for (typename LeafContainerT::const_iterator neighb_itr=(*leaf_itr)->cbegin (); neighb_itr!=(*leaf_itr)->cend (); ++neighb_itr)
+    for (auto neighb_itr=(*leaf_itr)->cbegin (); neighb_itr!=(*leaf_itr)->cend (); ++neighb_itr)
     {
       //Get a reference to the data contained in the leaf
       VoxelData& neighbor_voxel_data = ((*neighb_itr)->getData ());
@@ -846,7 +846,7 @@ pcl::SupervoxelClustering<PointT>::SupervoxelHelper::refineNormals ()
       {
         indices.push_back (neighbor_voxel_data.idx_);
         //Also check its neighbors
-        for (typename LeafContainerT::const_iterator neighb_neighb_itr=(*neighb_itr)->cbegin (); neighb_neighb_itr!=(*neighb_itr)->cend (); ++neighb_neighb_itr)
+        for (auto neighb_neighb_itr=(*neighb_itr)->cbegin (); neighb_neighb_itr!=(*neighb_itr)->cend (); ++neighb_neighb_itr)
         {
           VoxelData& neighb_neighb_voxel_data = (*neighb_neighb_itr)->getData ();
           if (neighb_neighb_voxel_data.owner_ == this)
@@ -890,7 +890,7 @@ pcl::SupervoxelClustering<PointT>::SupervoxelHelper::getVoxels (typename pcl::Po
   voxels.reset (new pcl::PointCloud<PointT>);
   voxels->clear ();
   voxels->resize (leaves_.size ());
-  typename pcl::PointCloud<PointT>::iterator voxel_itr = voxels->begin ();
+  auto voxel_itr = voxels->begin ();
   for (auto leaf_itr = leaves_.cbegin (); leaf_itr != leaves_.cend (); ++leaf_itr, ++voxel_itr)
   {
     const VoxelData& leaf_data = (*leaf_itr)->getData ();
@@ -905,7 +905,7 @@ pcl::SupervoxelClustering<PointT>::SupervoxelHelper::getNormals (typename pcl::P
   normals.reset (new pcl::PointCloud<Normal>);
   normals->clear ();
   normals->resize (leaves_.size ());
-  typename pcl::PointCloud<Normal>::iterator normal_itr = normals->begin ();
+  auto normal_itr = normals->begin ();
   for (auto leaf_itr = leaves_.cbegin (); leaf_itr != leaves_.cend (); ++leaf_itr, ++normal_itr)
   {
     const VoxelData& leaf_data = (*leaf_itr)->getData ();
@@ -922,7 +922,7 @@ pcl::SupervoxelClustering<PointT>::SupervoxelHelper::getNeighborLabels (std::set
   for (auto leaf_itr = leaves_.cbegin (); leaf_itr != leaves_.cend (); ++leaf_itr)
   {
     //for each neighbor of the leaf
-    for (typename LeafContainerT::const_iterator neighb_itr=(*leaf_itr)->cbegin (); neighb_itr!=(*leaf_itr)->cend (); ++neighb_itr)
+    for (auto neighb_itr=(*leaf_itr)->cbegin (); neighb_itr!=(*leaf_itr)->cend (); ++neighb_itr)
     {
       //Get a reference to the data contained in the leaf
       VoxelData& neighbor_voxel = ((*neighb_itr)->getData ());

--- a/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
+++ b/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
@@ -332,7 +332,7 @@ pcl::UnaryClassifier<PointT>::assignLabels (pcl::Indices &indi,
                                             pcl::PointCloud<pcl::PointXYZRGBL>::Ptr out)
                               
 {
-  float nfm = static_cast<float> (n_feature_means);
+  auto nfm = static_cast<float> (n_feature_means);
   for (std::size_t i = 0; i < out->size (); i++)
   {
     if (dist[i] < feature_threshold)

--- a/segmentation/src/grabcut_segmentation.cpp
+++ b/segmentation/src/grabcut_segmentation.cpp
@@ -63,7 +63,7 @@ pcl::segmentation::grabcut::BoykovKolmogorov::operator() (int u, int v) const
   if ((u < 0) && (v < 0)) return flow_value_;
   if (u < 0) { return source_edges_[v]; }
   if (v < 0) { return target_edges_[u]; }
-  capacitated_edge::const_iterator it = nodes_[u].find (v);
+  auto it = nodes_[u].find (v);
   if (it == nodes_[u].end ()) return 0.0;
   return it->second;
 }
@@ -97,7 +97,7 @@ pcl::segmentation::grabcut::BoykovKolmogorov::preAugmentPaths ()
     if (source_edges_[u] == 0.0) continue;
 
     // augment s-u-v-t paths
-    for (std::map<int, double>::iterator it = nodes_[u].begin (); it != nodes_[u].end (); ++it)
+    for (auto it = nodes_[u].begin (); it != nodes_[u].end (); ++it)
     {
       const int v = it->first;
       if ((it->second == 0.0) || (target_edges_[v] == 0.0)) continue;
@@ -163,7 +163,7 @@ pcl::segmentation::grabcut::BoykovKolmogorov::addEdge (int u, int v, double cap_
   assert ((v >= 0) && (v < (int)nodes_.size ()));
   assert (u != v);
 
-  capacitated_edge::iterator it = nodes_[u].find (v);
+  auto it = nodes_[u].find (v);
   if (it == nodes_[u].end ())
   {
     assert (cap_uv + cap_vu >= 0.0);
@@ -194,7 +194,7 @@ pcl::segmentation::grabcut::BoykovKolmogorov::addEdge (int u, int v, double cap_
   }
   else
   {
-    capacitated_edge::iterator jt = nodes_[v].find (u);
+    auto jt = nodes_[v].find (u);
     it->second += cap_uv;
     jt->second += cap_vu;
     assert (it->second + jt->second >= 0.0);
@@ -312,7 +312,7 @@ pcl::segmentation::grabcut::BoykovKolmogorov::expandTrees ()
     const int u = active_head_;
 
     if (cut_[u] == SOURCE) {
-      for (capacitated_edge::iterator it = nodes_[u].begin (); it != nodes_[u].end (); ++it)
+      for (auto it = nodes_[u].begin (); it != nodes_[u].end (); ++it)
       {
         if (it->second > 0.0)
         {
@@ -335,7 +335,7 @@ pcl::segmentation::grabcut::BoykovKolmogorov::expandTrees ()
     }
     else
     {
-      for (capacitated_edge::iterator it = nodes_[u].begin (); it != nodes_[u].end (); ++it)
+      for (auto it = nodes_[u].begin (); it != nodes_[u].end (); ++it)
       {
         if (cut_[it->first] == TARGET) continue;
         if (nodes_[it->first][u] > 0.0)
@@ -456,7 +456,7 @@ pcl::segmentation::grabcut::BoykovKolmogorov::adoptOrphans (std::deque<int>& orp
 
     // look for new parent
     bool b_free_orphan = true;
-    for (capacitated_edge::iterator jt = nodes_[u].begin (); jt != nodes_[u].end (); ++jt) {
+    for (auto jt = nodes_[u].begin (); jt != nodes_[u].end (); ++jt) {
       // skip if different trees
       if (cut_[jt->first] != tree_label) continue;
 
@@ -576,7 +576,7 @@ pcl::segmentation::grabcut::GaussianFitter::fit (Gaussian& g, std::size_t total_
   }
   else
   {
-    const float count_f = static_cast<float> (count_);
+    const auto count_f = static_cast<float> (count_);
 
     // Compute mean of gaussian
     g.mu.r = sum_[0]/count_f;
@@ -784,7 +784,7 @@ pcl::segmentation::grabcut::learnGMMs (const Image& image,
                                        std::vector<std::size_t>& components,
                                        GMM& background_GMM, GMM& foreground_GMM)
 {
-  const std::size_t indices_size = static_cast<std::size_t> (indices.size ());
+  const auto indices_size = static_cast<std::size_t> (indices.size ());
   // Step 4: Assign each pixel to the component which maximizes its probability
   for (std::size_t idx = 0; idx < indices_size; ++idx)
   {

--- a/simulation/src/range_likelihood.cpp
+++ b/simulation/src/range_likelihood.cpp
@@ -517,8 +517,8 @@ pcl::simulation::RangeLikelihood::setupProjectionMatrix() const
   // Prepare scaled simulated camera projection matrix
   float sx = static_cast<float>(camera_width_) / static_cast<float>(col_width_);
   float sy = static_cast<float>(camera_height_) / static_cast<float>(row_height_);
-  float width = static_cast<float>(col_width_);
-  float height = static_cast<float>(row_height_);
+  auto width = static_cast<float>(col_width_);
+  auto height = static_cast<float>(row_height_);
 
   float fx = camera_fx_ / sx;
   float fy = camera_fy_ / sy;
@@ -681,7 +681,7 @@ costFunction4(float ref_val, float depth_val)
   if (top_lup > 300) {
     top_lup = 300;
   }
-  float top =
+  auto top =
       static_cast<float>(top_lookup[top_lup]); // round( std::abs(x-mu) *1000+1) );
 
   // bottom:
@@ -1023,7 +1023,7 @@ RangeLikelihood::computeLikelihoods(
       int reduced_col_width = col_width_ >> levels;
       int reduced_row_height = row_height_ >> levels;
 
-      float* score_sum = new float[reduced_width * reduced_height];
+      auto* score_sum = new float[reduced_width * reduced_height];
       sum_reduce_.sum(score_texture_, score_sum);
       for (int n = 0, row = 0; row < reduced_height; ++row) {
         for (int col = 0; col < reduced_width; ++col, ++n) {

--- a/simulation/tools/sim_test_performance.cpp
+++ b/simulation/tools/sim_test_performance.cpp
@@ -71,7 +71,7 @@ void
 display_score_image(const float* score_buffer)
 {
   int npixels = range_likelihood_->getWidth() * range_likelihood_->getHeight();
-  std::uint8_t* score_img = new std::uint8_t[npixels * 3];
+  auto* score_img = new std::uint8_t[npixels * 3];
 
   float min_score = score_buffer[0];
   float max_score = score_buffer[0];
@@ -97,7 +97,7 @@ void
 display_depth_image(const float* depth_buffer, int width, int height)
 {
   int npixels = width * height;
-  std::uint8_t* depth_img = new std::uint8_t[npixels * 3];
+  auto* depth_img = new std::uint8_t[npixels * 3];
 
   float min_depth = depth_buffer[0];
   float max_depth = depth_buffer[0];
@@ -122,7 +122,7 @@ display_depth_image(const float* depth_buffer, int width, int height)
       kd = 2047;
 
     int pval = t_gamma[kd];
-    std::uint8_t lb = static_cast<std::uint8_t>(pval & 0xff);
+    auto lb = static_cast<std::uint8_t>(pval & 0xff);
     switch (pval >> 8) {
     case 0:
       depth_img[3 * i + 0] = 255;
@@ -171,7 +171,7 @@ display_depth_image(const float* depth_buffer, int width, int height)
 void
 display()
 {
-  float* reference =
+  auto* reference =
       new float[range_likelihood_->getRowHeight() * range_likelihood_->getColWidth()];
   const float* depth_buffer = range_likelihood_->getDepthBuffer();
   // Copy one image from our last as a reference.
@@ -184,7 +184,7 @@ display()
     }
   }
 
-  float* reference_vis = new float[range_likelihood_visualization_->getRowHeight() *
+  auto* reference_vis = new float[range_likelihood_visualization_->getRowHeight() *
                                    range_likelihood_visualization_->getColWidth()];
   const float* depth_buffer_vis = range_likelihood_visualization_->getDepthBuffer();
   // Copy one image from our last as a reference.
@@ -387,7 +387,7 @@ main(int argc, char** argv)
   }
 
   for (int i = 0; i < 2048; ++i) {
-    float v = static_cast<float>(i / 2048.0);
+    auto v = static_cast<float>(i / 2048.0);
     v = powf(v, 3) * 6;
     t_gamma[i] = static_cast<std::uint16_t>(v * 6 * 256);
   }

--- a/simulation/tools/sim_test_simple.cpp
+++ b/simulation/tools/sim_test_simple.cpp
@@ -91,7 +91,7 @@ void
 display_score_image(const float* score_buffer)
 {
   int npixels = range_likelihood_->getWidth() * range_likelihood_->getHeight();
-  std::uint8_t* score_img = new std::uint8_t[npixels * 3];
+  auto* score_img = new std::uint8_t[npixels * 3];
 
   float min_score = score_buffer[0];
   float max_score = score_buffer[0];
@@ -123,7 +123,7 @@ void
 display_depth_image(const float* depth_buffer, int width, int height)
 {
   int npixels = width * height;
-  std::uint8_t* depth_img = new std::uint8_t[npixels * 3];
+  auto* depth_img = new std::uint8_t[npixels * 3];
 
   float min_depth = depth_buffer[0];
   float max_depth = depth_buffer[0];
@@ -141,7 +141,7 @@ display_depth_image(const float* depth_buffer, int width, int height)
     float z = -zf * zn / ((zf - zn) * (d - zf / (zf - zn)));
     float b = 0.075f;
     float f = 580.0f;
-    std::uint16_t kd = static_cast<std::uint16_t>(1090 - b * f / z * 8);
+    auto kd = static_cast<std::uint16_t>(1090 - b * f / z * 8);
     if (kd > 2047)
       kd = 2047;
 
@@ -296,7 +296,7 @@ simpleVis(pcl::PointCloud<pcl::PointXYZRGB>::ConstPtr cloud)
 void
 display()
 {
-  float* reference =
+  auto* reference =
       new float[range_likelihood_->getRowHeight() * range_likelihood_->getColWidth()];
   const float* depth_buffer = range_likelihood_->getDepthBuffer();
   // Copy one image from our last as a reference.

--- a/simulation/tools/sim_viewer.cpp
+++ b/simulation/tools/sim_viewer.cpp
@@ -237,7 +237,7 @@ void
 capture(Eigen::Isometry3d pose_in)
 {
   // No reference image - but this is kept for compatibility with range_test_v2:
-  float* reference =
+  auto* reference =
       new float[range_likelihood_->getRowHeight() * range_likelihood_->getColWidth()];
   const float* depth_buffer = range_likelihood_->getDepthBuffer();
   // Copy one image from our last as a reference.

--- a/simulation/tools/simulation_io.cpp
+++ b/simulation/tools/simulation_io.cpp
@@ -91,7 +91,7 @@ void
 pcl::simulation::SimExample::doSim(Eigen::Isometry3d pose_in)
 {
   // No reference image - but this is kept for compatibility with range_test_v2:
-  float* reference = new float[rl_->getRowHeight() * rl_->getColWidth()];
+  auto* reference = new float[rl_->getRowHeight() * rl_->getColWidth()];
   const float* depth_buffer = rl_->getDepthBuffer();
   // Copy one image from our last as a reference.
   for (int i = 0, n = 0; i < rl_->getRowHeight(); ++i) {
@@ -116,7 +116,7 @@ pcl::simulation::SimExample::write_score_image(const float* score_buffer,
                                                std::string fname)
 {
   int npixels = rl_->getWidth() * rl_->getHeight();
-  std::uint8_t* score_img = new std::uint8_t[npixels * 3];
+  auto* score_img = new std::uint8_t[npixels * 3];
 
   float min_score = score_buffer[0];
   float max_score = score_buffer[0];
@@ -150,7 +150,7 @@ pcl::simulation::SimExample::write_depth_image(const float* depth_buffer,
                                                std::string fname)
 {
   int npixels = rl_->getWidth() * rl_->getHeight();
-  std::uint8_t* depth_img = new std::uint8_t[npixels * 3];
+  auto* depth_img = new std::uint8_t[npixels * 3];
 
   float min_depth = depth_buffer[0];
   float max_depth = depth_buffer[0];
@@ -172,7 +172,7 @@ pcl::simulation::SimExample::write_depth_image(const float* depth_buffer,
       float z = -zf * zn / ((zf - zn) * (d - zf / (zf - zn)));
       float b = 0.075;
       float f = 580.0;
-      std::uint16_t kd = static_cast<std::uint16_t>(1090 - b * f / z * 8);
+      auto kd = static_cast<std::uint16_t>(1090 - b * f / z * 8);
       if (kd > 2047)
         kd = 2047;
 
@@ -229,7 +229,7 @@ pcl::simulation::SimExample::write_depth_image_uint(const float* depth_buffer,
                                                     std::string fname)
 {
   int npixels = rl_->getWidth() * rl_->getHeight();
-  unsigned short* depth_img = new unsigned short[npixels];
+  auto* depth_img = new unsigned short[npixels];
 
   float min_depth = depth_buffer[0];
   float max_depth = depth_buffer[0];
@@ -271,7 +271,7 @@ pcl::simulation::SimExample::write_rgb_image(const std::uint8_t* rgb_buffer,
                                              std::string fname)
 {
   int npixels = rl_->getWidth() * rl_->getHeight();
-  std::uint8_t* rgb_img = new std::uint8_t[npixels * 3];
+  auto* rgb_img = new std::uint8_t[npixels * 3];
 
   for (int y = 0; y < height_; ++y) {
     for (int x = 0; x < width_; ++x) {

--- a/stereo/src/digital_elevation_map.cpp
+++ b/stereo/src/digital_elevation_map.cpp
@@ -98,7 +98,7 @@ pcl::DigitalElevationMapBuilder::compute(pcl::PointCloud<PointDEM>& out_cloud)
   const float kHeightMin = -0.5f;
   const float kHeightMax = 1.5f;
   const float kHeightResolution = 0.01f;
-  const std::size_t kHeightBins =
+  const auto kHeightBins =
       static_cast<std::size_t>((kHeightMax - kHeightMin) / kHeightResolution);
   // Histogram for initializing other height histograms.
   FeatureHistogram height_histogram_example(kHeightBins, kHeightMin, kHeightMax);
@@ -132,12 +132,12 @@ pcl::DigitalElevationMapBuilder::compute(pcl::PointCloud<PointDEM>& out_cloud)
         float height = point_3D.y;
 
         RGB point_RGB = (*image_)[column + row * disparity_map_width_];
-        float intensity =
+        auto intensity =
             static_cast<float>((point_RGB.r + point_RGB.g + point_RGB.b) / 3);
 
         // Calculate index of histograms.
         std::size_t index_column = column / kColumnStep;
-        std::size_t index_disparity = static_cast<std::size_t>(
+        auto index_disparity = static_cast<std::size_t>(
             (disparity - disparity_threshold_min_) / kDisparityStep);
 
         std::size_t index = index_column + index_disparity * resolution_column_;

--- a/stereo/src/stereo_adaptive_cost_so.cpp
+++ b/stereo/src/stereo_adaptive_cost_so.cpp
@@ -58,15 +58,15 @@ pcl::AdaptiveCostSOStereoMatching::compute_impl(unsigned char* ref_img,
   // int n = radius_ * 2 + 1;
   // int sad_max = std::numeric_limits<int>::max ();
 
-  float** acc = new float*[width_];
+  auto** acc = new float*[width_];
   for (int d = 0; d < width_; d++) {
     acc[d] = new float[max_disp_];
     memset(acc[d], 0, sizeof(float) * max_disp_);
   }
 
   // data structures for Scanline Optimization
-  float** fwd = new float*[width_];
-  float** bck = new float*[width_];
+  auto** fwd = new float*[width_];
+  auto** bck = new float*[width_];
   for (int d = 0; d < width_; d++) {
     fwd[d] = new float[max_disp_];
     memset(fwd[d], 0, sizeof(float) * max_disp_);
@@ -75,7 +75,7 @@ pcl::AdaptiveCostSOStereoMatching::compute_impl(unsigned char* ref_img,
   }
 
   // spatial distance init
-  float* ds = new float[2 * radius_ + 1];
+  auto* ds = new float[2 * radius_ + 1];
   for (int j = -radius_; j <= radius_; j++)
     ds[j + radius_] = static_cast<float>(std::exp(-std::abs(j) / gamma_s_));
 
@@ -85,7 +85,7 @@ pcl::AdaptiveCostSOStereoMatching::compute_impl(unsigned char* ref_img,
     lut[j] = float(std::exp(-j / gamma_c_));
 
   // left weight array alloc
-  float* wl = new float[2 * radius_ + 1];
+  auto* wl = new float[2 * radius_ + 1];
 
   for (int y = radius_ + 1; y < height_ - radius_; y++) {
     for (int x = x_off_ + max_disp_ + 1; x < width_; x++) {

--- a/stereo/src/stereo_matching.cpp
+++ b/stereo/src/stereo_matching.cpp
@@ -86,10 +86,10 @@ pcl::StereoMatching::medianFilter(int radius)
   // TODO: do median filter
   int side = radius * 2 + 1;
 
-  short int* out = new short int[width_ * height_];
+  auto* out = new short int[width_ * height_];
   memset(out, 0, width_ * height_ * sizeof(short int));
 
-  short int* v = new short int[side * side];
+  auto* v = new short int[side * side];
 
   for (int y = radius; y < height_ - radius; y++) {
     for (int x = radius; x < width_ - radius; x++) {
@@ -149,7 +149,7 @@ pcl::StereoMatching::getVisualMap(pcl::PointCloud<pcl::RGB>::Ptr vMap)
         vMap->at(x, y) = invalid_val;
       }
       else {
-        unsigned char val =
+        auto val =
             static_cast<unsigned char>(std::floor(scale * disp_map_[y * width_ + x]));
         vMap->at(x, y).r = val;
         vMap->at(x, y).g = val;
@@ -373,7 +373,7 @@ pcl::GrayStereoMatching::preProcessing(unsigned char* img, unsigned char* pp_img
                        img[(y - radius - 1) * width_ + x + radius];
       sum += v[x + radius] - v[x - radius - 1];
 
-      short int temp = static_cast<short int>(img[y * width_ + x] - (sum / area));
+      auto temp = static_cast<short int>(img[y * width_ + x] - (sum / area));
 
       if (temp < -threshold)
         pp_img[y * width_ + x] = 0;
@@ -401,7 +401,7 @@ pcl::GrayStereoMatching::preProcessing(unsigned char* img, unsigned char* pp_img
 void
 pcl::GrayStereoMatching::imgFlip(unsigned char*& img)
 {
-  unsigned char* temp_row = new unsigned char[width_];
+  auto* temp_row = new unsigned char[width_];
 
   for (int j = 0; j < height_; j++) {
     memcpy(temp_row, img + j * width_, sizeof(unsigned char) * width_);

--- a/surface/include/pcl/surface/impl/bilateral_upsampling.hpp
+++ b/surface/include/pcl/surface/impl/bilateral_upsampling.hpp
@@ -111,7 +111,7 @@ pcl::BilateralUpsampling<PointInT, PointOutT>::performProcessing (PointCloudOut 
             float val_exp_depth = val_exp_depth_matrix (static_cast<Eigen::MatrixXf::Index> (x - x_w + window_size_),
                                                         static_cast<Eigen::MatrixXf::Index> (y - y_w + window_size_));
 
-            Eigen::VectorXf::Index d_color = static_cast<Eigen::VectorXf::Index> (
+            auto d_color = static_cast<Eigen::VectorXf::Index> (
                 std::abs ((*input_)[y_w * input_->width + x_w].r - (*input_)[y * input_->width + x].r) +
                 std::abs ((*input_)[y_w * input_->width + x_w].g - (*input_)[y * input_->width + x].g) +
                 std::abs ((*input_)[y_w * input_->width + x_w].b - (*input_)[y * input_->width + x].b));

--- a/surface/include/pcl/surface/impl/concave_hull.hpp
+++ b/surface/include/pcl/surface/impl/concave_hull.hpp
@@ -272,7 +272,7 @@ pcl::ConcaveHull<PointInT>::performReconstruction (PointCloud &alpha_shape, std:
       // Facets are tetrahedrons (3d)
       if (!facet->upperdelaunay)
       {
-        vertexT *anyVertex = static_cast<vertexT*> (facet->vertices->e[0].p);
+        auto *anyVertex = static_cast<vertexT*> (facet->vertices->e[0].p);
         double *center = facet->center;
         double r = qh_pointdist (anyVertex->point,center,dim_);
 
@@ -400,7 +400,7 @@ pcl::ConcaveHull<PointInT>::performReconstruction (PointCloud &alpha_shape, std:
       {
         // Check if the distance from any vertex to the facet->center
         // (center of the voronoi cell) is smaller than alpha
-        vertexT *anyVertex = static_cast<vertexT*>(facet->vertices->e[0].p);
+        auto *anyVertex = static_cast<vertexT*>(facet->vertices->e[0].p);
         double r = (sqrt ((anyVertex->point[0] - facet->center[0]) *
                           (anyVertex->point[0] - facet->center[0]) +
                           (anyVertex->point[1] - facet->center[1]) *
@@ -480,7 +480,7 @@ pcl::ConcaveHull<PointInT>::performReconstruction (PointCloud &alpha_shape, std:
     alpha_shape_sorted.resize (vertices);
 
     // iterate over edges until they are empty!
-    std::map<int, std::vector<int> >::iterator curr = edges.begin ();
+    auto curr = edges.begin ();
     int next = - 1;
     std::vector<bool> used (vertices, false);   // used to decide which direction should we take!
     std::vector<int> pcd_idx_start_polygons;

--- a/surface/include/pcl/surface/impl/gp3.hpp
+++ b/surface/include/pcl/surface/impl/gp3.hpp
@@ -785,10 +785,10 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
       // Set the state of the point
       state_[R_] = is_boundary ? BOUNDARY : COMPLETED;
 
-      std::vector<int>::iterator first_gap_after = angleIdx.end ();
-      std::vector<int>::iterator last_gap_before = angleIdx.begin ();
+      auto first_gap_after = angleIdx.end ();
+      auto last_gap_before = angleIdx.begin ();
       int nr_gaps = 0;
-      for (std::vector<int>::iterator it = angleIdx.begin (); it != angleIdx.end () - 1; ++it)
+      for (auto it = angleIdx.begin (); it != angleIdx.end () - 1; ++it)
       {
         if (gaps[*it])
         {
@@ -812,7 +812,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
         Eigen::Vector2f S1;
         Eigen::Vector2f S2;
         std::vector<int> to_erase;
-        for (std::vector<int>::iterator it = angleIdx.begin()+1; it != angleIdx.end()-1; ++it)
+        for (auto it = angleIdx.begin()+1; it != angleIdx.end()-1; ++it)
         {
           if (gaps[*(it-1)])
             angle_so_far = 0;
@@ -850,7 +850,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
                 else
                   break;
               bool can_delete = true;
-              for (std::vector<int>::iterator curr_it = prev_it+1; curr_it != it+1; ++curr_it)
+              for (auto curr_it = prev_it+1; curr_it != it+1; ++curr_it)
               {
                 tmp_ = coords_[angles_[*curr_it].index] - proj_qp_;
                 X[0] = tmp_.dot(u_);
@@ -880,7 +880,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
         }
         for (const auto &idx : to_erase)
         {
-          for (std::vector<int>::iterator iter = angleIdx.begin(); iter != angleIdx.end(); ++iter)
+          for (auto iter = angleIdx.begin(); iter != angleIdx.end(); ++iter)
             if (idx == *iter)
             {
               angleIdx.erase(iter);
@@ -893,7 +893,7 @@ pcl::GreedyProjectionTriangulation<PointInT>::reconstructPolygons (std::vector<p
       changed_1st_fn_ = false;
       changed_2nd_fn_ = false;
       new2boundary_ = NONE;
-      for (std::vector<int>::iterator it = angleIdx.begin()+1; it != angleIdx.end()-1; ++it)
+      for (auto it = angleIdx.begin()+1; it != angleIdx.end()-1; ++it)
       {
         current_index_ = angles_[*it].index;
 

--- a/surface/include/pcl/surface/impl/marching_cubes_rbf.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes_rbf.hpp
@@ -50,7 +50,7 @@ template <typename PointNT> void
 pcl::MarchingCubesRBF<PointNT>::voxelizeData ()
 {
   // Initialize data structures
-  const unsigned int N = static_cast<unsigned int> (input_->size ());
+  const auto N = static_cast<unsigned int> (input_->size ());
   Eigen::MatrixXd M (2*N, 2*N),
                   d (2*N, 1);
 

--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -407,7 +407,7 @@ pcl::MovingLeastSquares<PointInT, PointOutT>::performUpsampling (PointCloudOut &
     for (int iteration = 0; iteration < dilation_iteration_num_; ++iteration)
       voxel_grid.dilate ();
 
-    for (typename MLSVoxelGrid::HashMap::iterator m_it = voxel_grid.voxel_grid_.begin (); m_it != voxel_grid.voxel_grid_.end (); ++m_it)
+    for (auto m_it = voxel_grid.voxel_grid_.begin (); m_it != voxel_grid.voxel_grid_.end (); ++m_it)
     {
       // Get 3D position of point
       Eigen::Vector3f pos;
@@ -835,7 +835,7 @@ template <typename PointInT, typename PointOutT> void
 pcl::MovingLeastSquares<PointInT, PointOutT>::MLSVoxelGrid::dilate ()
 {
   HashMap new_voxel_grid = voxel_grid_;
-  for (typename MLSVoxelGrid::HashMap::iterator m_it = voxel_grid_.begin (); m_it != voxel_grid_.end (); ++m_it)
+  for (auto m_it = voxel_grid_.begin (); m_it != voxel_grid_.end (); ++m_it)
   {
     Eigen::Vector3i index;
     getIndexIn3D (m_it->first, index);

--- a/surface/src/3rdparty/poisson4/factor.cpp
+++ b/surface/src/3rdparty/poisson4/factor.cpp
@@ -220,8 +220,8 @@ namespace pcl
       double v,m;
       int *index=new int[dim];
       int *set=new int[dim];
-      double* myEqns=new double[dim*dim];
-      double* myValues=new double[dim];
+      auto* myEqns=new double[dim*dim];
+      auto* myValues=new double[dim];
 
       for(i=0;i<dim*dim;i++){myEqns[i]=eqns[i];}
       for(i=0;i<dim;i++){

--- a/surface/src/vtk_smoothing/vtk_utils.cpp
+++ b/surface/src/vtk_smoothing/vtk_utils.cpp
@@ -224,7 +224,7 @@ pcl::VTKUtils::mesh2vtk (const pcl::PolygonMesh& mesh, vtkSmartPointer<vtkPolyDa
   {
     for (int i = 0; i < nr_polygons; i++)
     {
-      unsigned int nr_points_in_polygon = static_cast<unsigned int> (mesh.polygons[i].vertices.size ());
+      auto nr_points_in_polygon = static_cast<unsigned int> (mesh.polygons[i].vertices.size ());
       vtk_mesh_polygons->InsertNextCell (nr_points_in_polygon);
       for (unsigned int j = 0; j < nr_points_in_polygon; j++)
         vtk_mesh_polygons->InsertCellPoint(mesh.polygons[i].vertices[j]);

--- a/test/common/test_eigen.cpp
+++ b/test/common/test_eigen.cpp
@@ -425,8 +425,8 @@ inline void generateSymPosMatrix2x2 (Matrix& matrix)
 
   unsigned test_case = rand_uint (rng) % 10;
 
-  Scalar val1 = Scalar (rand_double (rng));
-  Scalar val2 = Scalar (rand_double (rng));
+  auto val1 = Scalar (rand_double (rng));
+  auto val2 = Scalar (rand_double (rng));
 
   // 10% of test cases include equal eigenvalues
   if (test_case == 0)
@@ -592,9 +592,9 @@ inline void generateSymPosMatrix3x3 (Matrix& matrix)
 
   unsigned test_case = rand_uint (rng);
 
-  Scalar val1 = Scalar (rand_double (rng));
-  Scalar val2 = Scalar (rand_double (rng));
-  Scalar val3 = Scalar (rand_double (rng));
+  auto val1 = Scalar (rand_double (rng));
+  auto val2 = Scalar (rand_double (rng));
+  auto val3 = Scalar (rand_double (rng));
 
   // 1%: all three values are equal and non-zero
   if (test_case == 0)

--- a/test/common/test_pointcloud.cpp
+++ b/test/common/test_pointcloud.cpp
@@ -41,7 +41,7 @@ TEST_F (pointCloudTest, getMatrixXfMap)
   cloud.width = 10;
   for (std::uint32_t i = 0; i < cloud.width*cloud.height; ++i)
   {
-    float j = static_cast<float> (i);
+    auto j = static_cast<float> (i);
     cloud.emplace_back(3.0f * j + 0.0f, 3.0f * j + 1.0f, 3.0f * j + 2.0f);
   }
 

--- a/test/common/test_wrappers.cpp
+++ b/test/common/test_wrappers.cpp
@@ -120,7 +120,7 @@ TEST (PointCloud, insert_range)
   for (std::uint32_t i = 0; i < 10; ++i)
     cloud2[i] = PointXYZ (5.0f * static_cast<float>(i) + 0, 5.0f * static_cast<float> (i) + 1, 5.0f * static_cast<float> (i) + 2);
 
-  std::uint32_t old_size = static_cast<std::uint32_t> (cloud.size ());
+  auto old_size = static_cast<std::uint32_t> (cloud.size ());
   cloud.insert (cloud.begin (), cloud2.begin (), cloud2.end ());
   EXPECT_EQ (cloud.width, cloud.size ());
   EXPECT_EQ (cloud.height, 1);

--- a/test/features/test_brisk.cpp
+++ b/test/features/test_brisk.cpp
@@ -111,7 +111,7 @@ TEST (PCL, BRISK_2D)
     float sqr_dist = 0.0f;
     for (std::size_t index = 0; index < 33; ++index)
     {
-      const float dist = float (descriptor.descriptor[index] - descriptor_gt.descriptor[index]);
+      const auto dist = float (descriptor.descriptor[index] - descriptor_gt.descriptor[index]);
       sqr_dist += dist * dist;
     }
 

--- a/test/features/test_ii_normals.cpp
+++ b/test/features/test_ii_normals.cpp
@@ -63,7 +63,7 @@ TEST(PCL, IntegralImage1D)
   IntegralImage2D<float,1> integral_image2(false);// calculate just first order (other if branch)
 
   // test for dense data with element stride = 1
-  float* data = new float[width * height];
+  auto* data = new float[width * height];
   for(unsigned yIdx = 0; yIdx < height; ++yIdx)
   {
     for(unsigned xIdx = 0; xIdx < width; ++xIdx)
@@ -275,7 +275,7 @@ TEST(PCL, IntegralImage3D)
   IntegralImage2D<float, 3> integral_image3(true);
   unsigned element_stride = 4;
   unsigned row_stride = width * element_stride + 1;
-  float* data = new float[row_stride * height];
+  auto* data = new float[row_stride * height];
   for(unsigned yIdx = 0; yIdx < height; ++yIdx)
   {
     for(unsigned xIdx = 0; xIdx < width; ++xIdx)

--- a/test/features/test_moment_of_inertia_estimation.cpp
+++ b/test/features/test_moment_of_inertia_estimation.cpp
@@ -70,8 +70,8 @@ TEST (MomentOfInertia, FeatureExtraction)
   std::vector <float> eccentricity;
   feature_extractor.getMomentOfInertia (moment_of_inertia);
   feature_extractor.getEccentricity (eccentricity);
-  unsigned int m_size = static_cast <unsigned int> (moment_of_inertia.size ());
-  unsigned int e_size = static_cast <unsigned int> (eccentricity.size ());
+  auto m_size = static_cast <unsigned int> (moment_of_inertia.size ());
+  auto e_size = static_cast <unsigned int> (eccentricity.size ());
   EXPECT_EQ (m_size, e_size);
   EXPECT_NE (0, m_size);
 }

--- a/test/filters/test_convolution.cpp
+++ b/test/filters/test_convolution.cpp
@@ -62,7 +62,7 @@ RGB interpolate_color(float lower_bound, float upper_bound, float value)
   if (value <= lower_bound) return colormap[0];
   if (value >= upper_bound) return colormap.back();
   float step_size = (upper_bound - lower_bound) / static_cast<float>(colormap.size() - 1);
-  std::size_t lower_index = static_cast<std::size_t>((value - lower_bound) / step_size);
+  auto lower_index = static_cast<std::size_t>((value - lower_bound) / step_size);
   value -= (lower_bound + static_cast<float>(lower_index) * step_size);
   if (value == 0) return colormap[lower_index];
   auto interpolate = [](std::uint8_t lower, std::uint8_t upper, float step_size, float value) {

--- a/test/geometry/test_iterator.cpp
+++ b/test/geometry/test_iterator.cpp
@@ -246,11 +246,11 @@ TEST (PCL, LineIterator8NeighborsGeneral)
   unsigned length = 45;
   
   const unsigned angular_resolution = 180;
-  float d_alpha = float(M_PI / angular_resolution);
+  auto d_alpha = float(M_PI / angular_resolution);
   for (unsigned idx = 0; idx < angular_resolution; ++idx)
   {
-    unsigned x_end = unsigned (length * std::cos (float(idx) * d_alpha) + center_x + 0.5);
-    unsigned y_end = unsigned (length * std::sin (float(idx) * d_alpha) + center_y + 0.5);
+    auto x_end = unsigned (length * std::cos (float(idx) * d_alpha) + center_x + 0.5);
+    auto y_end = unsigned (length * std::sin (float(idx) * d_alpha) + center_y + 0.5);
     
     // right
     checkGeneralLine (center_x, center_y, x_end, y_end, cloud, true);
@@ -270,11 +270,11 @@ TEST (PCL, LineIterator4NeighborsGeneral)
   unsigned length = 45;
   
   const unsigned angular_resolution = 360;
-  float d_alpha = float(2.0 * M_PI / angular_resolution);
+  auto d_alpha = float(2.0 * M_PI / angular_resolution);
   for (unsigned idx = 0; idx < angular_resolution; ++idx)
   {
-    unsigned x_end = unsigned (length * std::cos (float(idx) * d_alpha) + center_x + 0.5);
-    unsigned y_end = unsigned (length * std::sin (float(idx) * d_alpha) + center_y + 0.5);
+    auto x_end = unsigned (length * std::cos (float(idx) * d_alpha) + center_x + 0.5);
+    auto y_end = unsigned (length * std::sin (float(idx) * d_alpha) + center_y + 0.5);
     
     // right
     checkGeneralLine (center_x, center_y, x_end, y_end, cloud, false);

--- a/test/geometry/test_mesh_common_functions.h
+++ b/test/geometry/test_mesh_common_functions.h
@@ -259,7 +259,7 @@ getBoundaryVertices (const MeshT& mesh, const int first, const bool verbose = fa
 template <class ContainerT> bool
 isCircularPermutation (const ContainerT& expected, const ContainerT& actual, const bool verbose = false)
 {
-  const unsigned int n = static_cast <unsigned int> (expected.size ());
+  const auto n = static_cast <unsigned int> (expected.size ());
   EXPECT_EQ (n, actual.size ());
   if (n != actual.size ())
   {
@@ -295,7 +295,7 @@ isCircularPermutation (const ContainerT& expected, const ContainerT& actual, con
 template <class ContainerT> bool
 isCircularPermutationVec (const std::vector <ContainerT> &expected, const std::vector <ContainerT> &actual, const bool verbose = false)
 {
-  const unsigned int n = static_cast<unsigned int> (expected.size ());
+  const auto n = static_cast<unsigned int> (expected.size ());
   EXPECT_EQ (n, actual.size ());
   if (n != actual.size ())
   {

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -1213,7 +1213,7 @@ TEST (PCL, LZFInMem)
   EXPECT_EQ (blob2.height, blob.height);
   EXPECT_EQ (data_type, 2); // since it was written by writeBinaryCompressed(), it should be compressed.
 
-  const unsigned char *data = reinterpret_cast<const unsigned char *> (pcd_str.data ());
+  const auto *data = reinterpret_cast<const unsigned char *> (pcd_str.data ());
   res = reader.readBodyBinary (data, blob2, pcd_version, data_type == 2, data_idx);
   PointCloud<PointXYZRGBNormal> cloud2;
   pcl::fromPCLPointCloud2 (blob2, cloud2);

--- a/test/io/test_iterators.cpp
+++ b/test/io/test_iterators.cpp
@@ -59,7 +59,7 @@ TEST (PCL, Iterators)
 {
   Point mean (0,0,0);
 
-  for (PointCloud::iterator it = cloud.begin(); it != cloud.end(); ++it) 
+  for (auto it = cloud.begin(); it != cloud.end(); ++it) 
   {
     for (int i=0;i<3;i++) mean.data[i] += it->data[i];
   }

--- a/test/io/test_point_cloud_image_extractors.cpp
+++ b/test/io/test_point_cloud_image_extractors.cpp
@@ -178,7 +178,7 @@ TEST (PCL, PointCloudImageExtractorFromLabelFieldMono)
   pcie.setColorMode (pcie.COLORS_MONO);
 
   ASSERT_TRUE (pcie.extract (cloud, image));
-  unsigned short* data = reinterpret_cast<unsigned short*> (&image.data[0]);
+  auto* data = reinterpret_cast<unsigned short*> (&image.data[0]);
 
   EXPECT_EQ ("mono16", image.encoding);
   EXPECT_EQ (cloud.width, image.width);
@@ -279,7 +279,7 @@ TEST (PCL, PointCloudImageExtractorFromZField)
   PointCloudImageExtractorFromZField<PointT> pcie;
 
   ASSERT_TRUE (pcie.extract (cloud, image));
-  unsigned short* data = reinterpret_cast<unsigned short*> (&image.data[0]);
+  auto* data = reinterpret_cast<unsigned short*> (&image.data[0]);
 
   EXPECT_EQ ("mono16", image.encoding);
   EXPECT_EQ (cloud.width, image.width);
@@ -309,7 +309,7 @@ TEST (PCL, PointCloudImageExtractorFromCurvatureField)
   PointCloudImageExtractorFromCurvatureField<PointT> pcie;
 
   ASSERT_TRUE (pcie.extract (cloud, image));
-  unsigned short* data = reinterpret_cast<unsigned short*> (&image.data[0]);
+  auto* data = reinterpret_cast<unsigned short*> (&image.data[0]);
 
   EXPECT_EQ ("mono16", image.encoding);
   EXPECT_EQ (cloud.width, image.width);
@@ -341,7 +341,7 @@ TEST (PCL, PointCloudImageExtractorFromIntensityField)
   PointCloudImageExtractorFromIntensityField<PointT> pcie;
 
   ASSERT_TRUE (pcie.extract (cloud, image));
-  unsigned short* data = reinterpret_cast<unsigned short*> (&image.data[0]);
+  auto* data = reinterpret_cast<unsigned short*> (&image.data[0]);
 
   EXPECT_EQ ("mono16", image.encoding);
   EXPECT_EQ (cloud.width, image.width);
@@ -412,7 +412,7 @@ TEST (PCL, PointCloudImageExtractorBlackNaNs)
   ASSERT_TRUE (pcie.extract (cloud, image));
 
   {
-    unsigned short* data = reinterpret_cast<unsigned short*> (&image.data[0]);
+    auto* data = reinterpret_cast<unsigned short*> (&image.data[0]);
     EXPECT_EQ (std::numeric_limits<unsigned short>::max (), data[3]);
   }
 
@@ -421,7 +421,7 @@ TEST (PCL, PointCloudImageExtractorBlackNaNs)
   ASSERT_TRUE (pcie.extract (cloud, image));
 
   {
-    unsigned short* data = reinterpret_cast<unsigned short*> (&image.data[0]);
+    auto* data = reinterpret_cast<unsigned short*> (&image.data[0]);
     EXPECT_EQ (0, data[3]);
   }
 }

--- a/test/kdtree/test_kdtree.cpp
+++ b/test/kdtree/test_kdtree.cpp
@@ -107,7 +107,7 @@ TEST (PCL, KdTreeFLANN_radiusSearch)
   
   for (const auto &k_index : k_indices)
   {
-    std::set<int>::iterator brute_force_result_it = brute_force_result.find (k_index);
+    auto brute_force_result_it = brute_force_result.find (k_index);
     bool ok = brute_force_result_it != brute_force_result.end ();
     //if (!ok)  std::cerr << k_indices[i] << " is not correct...\n";
     //else      std::cerr << k_indices[i] << " is correct...\n";
@@ -172,7 +172,7 @@ TEST (PCL, KdTreeFLANN_nearestKSearch)
   }
   float max_dist = 0.0f;
   unsigned int counter = 0;
-  for (std::multimap<float, int>::iterator it = sorted_brute_force_result.begin (); it != sorted_brute_force_result.end () && counter < no_of_neighbors; ++it)
+  for (auto it = sorted_brute_force_result.begin (); it != sorted_brute_force_result.end () && counter < no_of_neighbors; ++it)
   {
     max_dist = std::max (max_dist, it->first);
     ++counter;

--- a/test/octree/test_octree.cpp
+++ b/test/octree/test_octree.cpp
@@ -1189,7 +1189,7 @@ TEST (PCL, Octree_Pointcloud_Nearest_K_Neighbour_Search)
         pointCandidates.pop ();
 
       // copy results into vectors
-      unsigned idx = static_cast<unsigned> (pointCandidates.size ());
+      auto idx = static_cast<unsigned> (pointCandidates.size ());
       k_indices_bruteforce.resize (idx);
       k_sqr_distances_bruteforce.resize (idx);
       while (!pointCandidates.empty ())

--- a/test/search/test_flann_search.cpp
+++ b/test/search/test_flann_search.cpp
@@ -87,7 +87,7 @@ TEST (PCL, FlannSearch_nearestKSearch)
   }
   float max_dist = 0.0f;
   unsigned int counter = 0;
-  for (std::multimap<float, int>::iterator it = sorted_brute_force_result.begin (); it != sorted_brute_force_result.end ()
+  for (auto it = sorted_brute_force_result.begin (); it != sorted_brute_force_result.end ()
       && counter < no_of_neighbors; ++it)
   {
     max_dist = std::max (max_dist, it->first);

--- a/test/search/test_kdtree.cpp
+++ b/test/search/test_kdtree.cpp
@@ -83,7 +83,7 @@ init ()
   }
   float max_dist = 0.0f;
   unsigned int counter = 0;
-  for (std::multimap<float, int>::iterator it = sorted_brute_force_result.begin (); it != sorted_brute_force_result.end ()
+  for (auto it = sorted_brute_force_result.begin (); it != sorted_brute_force_result.end ()
       && counter < no_of_neighbors; ++it)
   {
     max_dist = std::max (max_dist, it->first);

--- a/test/search/test_octree.cpp
+++ b/test/search/test_octree.cpp
@@ -133,7 +133,7 @@ TEST (PCL, Octree_Pointcloud_Nearest_K_Neighbour_Search)
       pointCandidates.pop ();
 
     // copy results into vectors
-    unsigned idx = static_cast<unsigned> (pointCandidates.size ());
+    auto idx = static_cast<unsigned> (pointCandidates.size ());
     k_indices_bruteforce.resize (idx);
     k_sqr_distances_bruteforce.resize (idx);
     while (!pointCandidates.empty ())

--- a/test/segmentation/test_random_walker.cpp
+++ b/test/segmentation/test_random_walker.cpp
@@ -122,7 +122,7 @@ struct GraphInfo
     // Read expected potentials
     for (ptree::value_type& v : pt.get_child ("Potentials"))
     {
-      Color color = boost::lexical_cast<std::uint32_t> (v.first);
+      auto color = boost::lexical_cast<std::uint32_t> (v.first);
       potentials[color] = Vector::Zero (size);
       std::stringstream ss (v.second.data ());
       for (std::size_t i = 0; i < size; ++i)

--- a/test/visualization/test_visualization.cpp
+++ b/test/visualization/test_visualization.cpp
@@ -114,7 +114,7 @@ TEST (PCL, PCLVisualizer_camera)
   given_intrinsics (0, 2) = 320.f;
   given_intrinsics (1, 2) = 240.f;
 
-  float M_PI_f = static_cast<float> (M_PI);
+  auto M_PI_f = static_cast<float> (M_PI);
   Eigen::Matrix4f given_extrinsics (Eigen::Matrix4f::Identity ());
   given_extrinsics.block<3, 3> (0, 0) = Eigen::AngleAxisf (30.f * M_PI_f / 180.f, Eigen::Vector3f (1.f, 0.f, 0.f)).matrix ();
   given_extrinsics.block<3, 1> (0, 3) = Eigen::Vector3f (10.f, 15.f, 20.f);

--- a/tools/crf_segmentation.cpp
+++ b/tools/crf_segmentation.cpp
@@ -199,7 +199,7 @@ main (int argc, char** argv)
   pcl::removeNaNFromPointCloud (*cloud, *cloud, tmp_indices);
   
   // parse optional input arguments from the command line
-  float normal_radius_search = static_cast<float> (default_normal_radius_search);
+  auto normal_radius_search = static_cast<float> (default_normal_radius_search);
 
   // Command line parsing
   float leaf_x = default_leaf_size,

--- a/tools/generate.cpp
+++ b/tools/generate.cpp
@@ -174,7 +174,7 @@ main (int argc, char** argv)
   if (distribution == "uniform")
   {
     CloudGenerator<pcl::PointXYZ, UniformGenerator<float> > generator;
-    std::uint32_t seed = static_cast<std::uint32_t> (time (nullptr));
+    auto seed = static_cast<std::uint32_t> (time (nullptr));
     UniformGenerator<float>::Parameters x_params (xmin, xmax, seed++);
     generator.setParametersForX (x_params);
     UniformGenerator<float>::Parameters y_params (ymin, ymax, seed++);
@@ -187,7 +187,7 @@ main (int argc, char** argv)
   else if (distribution == "normal")
   {
     CloudGenerator<pcl::PointXYZ, NormalGenerator<float> > generator;
-    std::uint32_t seed = static_cast<std::uint32_t> (time (nullptr));
+    auto seed = static_cast<std::uint32_t> (time (nullptr));
     NormalGenerator<float>::Parameters x_params (xmean, xstddev, seed++);
     generator.setParametersForX (x_params);
     NormalGenerator<float>::Parameters y_params (ymean, ystddev, seed++);

--- a/tools/image_grabber_viewer.cpp
+++ b/tools/image_grabber_viewer.cpp
@@ -118,7 +118,7 @@ keyboard_callback (const pcl::visualization::KeyboardEvent& event, void*)
 void 
 mouse_callback (const pcl::visualization::MouseEvent& mouse_event, void* cookie)
 {
-  std::string* message = static_cast<std::string*> (cookie);
+  auto* message = static_cast<std::string*> (cookie);
   if (mouse_event.getType() == pcl::visualization::MouseEvent::MouseButtonPress && mouse_event.getButton() == pcl::visualization::MouseEvent::LeftButton)
   {
     std::cout << (*message) << " :: " << mouse_event.getX () << " , " << mouse_event.getY () << std::endl;

--- a/tools/image_viewer.cpp
+++ b/tools/image_viewer.cpp
@@ -54,7 +54,7 @@ main (int, char ** argv)
   pcl::fromPCLPointCloud2 (cloud, xyz);
   
   pcl::visualization::ImageViewer depth_image_viewer_;
-  float* img = new float[cloud.width * cloud.height];
+  auto* img = new float[cloud.width * cloud.height];
 
   for (int i = 0; i < static_cast<int> (xyz.size ()); ++i)
     img[i] = xyz[i].z;

--- a/tools/mesh_sampling.cpp
+++ b/tools/mesh_sampling.cpp
@@ -80,9 +80,9 @@ randomPointTriangle (float a1, float a2, float a3, float b1, float b2, float b3,
 inline void
 randPSurface (vtkPolyData * polydata, std::vector<double> * cumulativeAreas, double totalArea, Eigen::Vector3f& p, bool calcNormal, Eigen::Vector3f& n, bool calcColor, Eigen::Vector3f& c)
 {
-  float r = static_cast<float> (uniform_deviate (rand ()) * totalArea);
+  auto r = static_cast<float> (uniform_deviate (rand ()) * totalArea);
 
-  std::vector<double>::iterator low = std::lower_bound (cumulativeAreas->begin (), cumulativeAreas->end (), r);
+  auto low = std::lower_bound (cumulativeAreas->begin (), cumulativeAreas->end (), r);
   vtkIdType el = vtkIdType (low - cumulativeAreas->begin ());
 
   double A[3], B[3], C[3];
@@ -101,8 +101,8 @@ randPSurface (vtkPolyData * polydata, std::vector<double> * cumulativeAreas, dou
     n = v1.cross (v2);
     n.normalize ();
   }
-  float r1 = static_cast<float> (uniform_deviate (rand ()));
-  float r2 = static_cast<float> (uniform_deviate (rand ()));
+  auto r1 = static_cast<float> (uniform_deviate (rand ()));
+  auto r2 = static_cast<float> (uniform_deviate (rand ()));
   randomPointTriangle (float (A[0]), float (A[1]), float (A[2]),
                        float (B[0]), float (B[1]), float (B[2]),
                        float (C[0]), float (C[1]), float (C[2]), r1, r2, p);

--- a/tools/ndt3d.cpp
+++ b/tools/ndt3d.cpp
@@ -118,7 +118,7 @@ main (int argc, char **argv)
     }
     std::cout << argv[pcd_indices[i]] << " width: " << data->width << " height: " << data->height << std::endl;
 
-    pcl::NormalDistributionsTransform<PointType, PointType> * ndt = new pcl::NormalDistributionsTransform<PointType, PointType>();
+    auto * ndt = new pcl::NormalDistributionsTransform<PointType, PointType>();
 
     ndt->setMaximumIterations (iter);
     ndt->setResolution (ndt_res);

--- a/tools/obj_rec_ransac_accepted_hypotheses.cpp
+++ b/tools/obj_rec_ransac_accepted_hypotheses.cpp
@@ -302,7 +302,7 @@ update (CallbackParameters* params)
   std::sort(accepted_hypotheses.begin (), accepted_hypotheses.end (), compareHypotheses);
 
   // Show the hypotheses
-  for ( std::vector<Hypothesis>::iterator acc_hypo = accepted_hypotheses.begin () ; i < params->num_hypotheses_to_show_ && acc_hypo != accepted_hypotheses.end () ; ++i, ++acc_hypo )
+  for ( auto acc_hypo = accepted_hypotheses.begin () ; i < params->num_hypotheses_to_show_ && acc_hypo != accepted_hypotheses.end () ; ++i, ++acc_hypo )
   {
     // Visualize the orientation as a tripod
     char frame_name[128];
@@ -383,7 +383,7 @@ update (CallbackParameters* params)
 void
 keyboardCB (const pcl::visualization::KeyboardEvent &event, void* params_void)
 {
-  CallbackParameters* params = static_cast<CallbackParameters*> (params_void);
+  auto* params = static_cast<CallbackParameters*> (params_void);
 
   if (event.getKeyCode () == 13 /*enter*/ && event.keyUp ())
     update (params);
@@ -392,7 +392,7 @@ keyboardCB (const pcl::visualization::KeyboardEvent &event, void* params_void)
     // Switch models visibility
     params->show_models_ = !params->show_models_;
 
-    for ( std::list<vtkActor*>::iterator it = params->model_actors_.begin () ; it != params->model_actors_.end () ; ++it )
+    for ( auto it = params->model_actors_.begin () ; it != params->model_actors_.end () ; ++it )
       (*it)->SetVisibility (static_cast<int> (params->show_models_));
 
     params->viz_.getRenderWindow ()->Render ();

--- a/tools/obj_rec_ransac_hash_table.cpp
+++ b/tools/obj_rec_ransac_hash_table.cpp
@@ -91,7 +91,7 @@ main (int argc, char** argv)
     return (-1);
 
   // Compute the bounding box diagonal
-  float diag = static_cast<float> (sqrt (my_sqr (b[1]-b[0]) + my_sqr (b[3]-b[2]) + my_sqr (b[5]-b[4])));
+  auto diag = static_cast<float> (sqrt (my_sqr (b[1]-b[0]) + my_sqr (b[3]-b[2]) + my_sqr (b[5]-b[4])));
 
   // Create the recognition object (we need it only for its hash table)
   ObjRecRANSAC objrec (diag/8.0f, diag/60.0f);

--- a/tools/obj_rec_ransac_model_opps.cpp
+++ b/tools/obj_rec_ransac_model_opps.cpp
@@ -187,7 +187,7 @@ void showModelOpps (PCLVisualizer& viz, const ModelLibrary::HashTable& hash_tabl
   for (int i = 0 ; i < num_cells ; ++i )
   {
     // Make sure that we get only point pairs belonging to 'model'
-	ModelLibrary::HashTableCell::const_iterator res = cells[i].find (model);
+	auto res = cells[i].find (model);
     if ( res == cells[i].end () )
       continue;
 

--- a/tools/obj_rec_ransac_orr_octree.cpp
+++ b/tools/obj_rec_ransac_orr_octree.cpp
@@ -106,7 +106,7 @@ int main (int argc, char ** argv)
   }
 
   // Get the voxel size
-  float voxel_size = static_cast<float> (atof (argv[2]));
+  auto voxel_size = static_cast<float> (atof (argv[2]));
   if ( voxel_size <= 0.0 )
   {
     fprintf(stderr, "ERROR: leaf_size has to be positive and not %lf\n", voxel_size);
@@ -120,7 +120,7 @@ int main (int argc, char ** argv)
 
 void keyboardCB (const pcl::visualization::KeyboardEvent &event, void* params_void)
 {
-  CallbackParameters* params = static_cast<CallbackParameters*> (params_void);
+  auto* params = static_cast<CallbackParameters*> (params_void);
 
   if (event.getKeySym () == "Left" && event.keyUp ())
   {
@@ -206,7 +206,7 @@ void run (const char* file_name, float voxel_size)
     octree.build (*points_in, voxel_size);
 
   // Get the first full leaf in the octree (arbitrary order)
-  std::vector<ORROctree::Node*>::iterator leaf = octree.getFullLeaves ().begin ();
+  auto leaf = octree.getFullLeaves ().begin ();
 
   // Get the average points in every full octree leaf
   octree.getFullLeavesPoints (*points_out);
@@ -352,7 +352,7 @@ void show_octree (ORROctree* octree, PCLVisualizer& viz, bool show_full_leaves_o
   }
 
   // Just print the leaf size
-  std::vector<ORROctree::Node*>::iterator first_leaf = octree->getFullLeaves ().begin ();
+  auto first_leaf = octree->getFullLeaves ().begin ();
   if ( first_leaf != octree->getFullLeaves ().end () )
 	  printf("leaf size = %f\n", (*first_leaf)->getBounds ()[1] - (*first_leaf)->getBounds ()[0]);
 

--- a/tools/obj_rec_ransac_orr_octree_zprojection.cpp
+++ b/tools/obj_rec_ransac_orr_octree_zprojection.cpp
@@ -93,7 +93,7 @@ int main (int argc, char ** argv)
   }
 
   // Get the voxel size
-  float voxel_size = static_cast<float> (atof (argv[2]));
+  auto voxel_size = static_cast<float> (atof (argv[2]));
   if ( voxel_size <= 0.0 )
   {
     fprintf(stderr, "ERROR: leaf_size has to be positive and not %lf\n", voxel_size);

--- a/tools/obj_rec_ransac_result.cpp
+++ b/tools/obj_rec_ransac_result.cpp
@@ -255,7 +255,7 @@ update (CallbackParameters* params)
   int i = 0;
 
   // Show the hypotheses
-  for ( std::list<ObjRecRANSAC::Output>::iterator it = rec_output.begin () ; it != rec_output.end () ; ++it, ++i )
+  for ( auto it = rec_output.begin () ; it != rec_output.end () ; ++it, ++i )
   {
     std::cout << it->object_name_ << " has a confidence value of " << it->match_confidence_ << std::endl;
 

--- a/tools/octree_viewer.cpp
+++ b/tools/octree_viewer.cpp
@@ -392,7 +392,7 @@ private:
       // If the asked depth is the depth of the octree, retrieve the centroid at this LeafNode
       if (octree.getTreeDepth () == (unsigned int) depth)
       {
-        pcl::octree::OctreePointCloudVoxelCentroid<pcl::PointXYZ>::LeafNode* container = static_cast<pcl::octree::OctreePointCloudVoxelCentroid<pcl::PointXYZ>::LeafNode*> (tree_it.getCurrentOctreeNode ());
+        auto* container = static_cast<pcl::octree::OctreePointCloudVoxelCentroid<pcl::PointXYZ>::LeafNode*> (tree_it.getCurrentOctreeNode ());
 
         container->getContainer ().getCentroid (pt_centroid);
       }

--- a/tools/oni2pcd.cpp
+++ b/tools/oni2pcd.cpp
@@ -81,7 +81,7 @@ main (int argc, char **argv)
     return (-1);
   }
 
-  pcl::ONIGrabber* grabber = new pcl::ONIGrabber (argv[1], false, false);
+  auto* grabber = new pcl::ONIGrabber (argv[1], false, false);
   std::function<void (const CloudConstPtr&) > f = [] (const CloudConstPtr& cloud) { cloud_cb (cloud); };
   boost::signals2::connection c = grabber->registerCallback (f);
 

--- a/tools/pcd2png.cpp
+++ b/tools/pcd2png.cpp
@@ -150,7 +150,7 @@ parseScaleOption (int argc, char** argv, T& pcie)
   {
     try
     {
-      float factor = boost::lexical_cast<float> (scaling);
+      auto factor = boost::lexical_cast<float> (scaling);
       pcie.setScalingMethod(pcie.SCALING_FIXED_FACTOR);
       pcie.setScalingFactor(factor);
     }

--- a/tools/pcd_grabber_viewer.cpp
+++ b/tools/pcd_grabber_viewer.cpp
@@ -103,7 +103,7 @@ keyboard_callback (const pcl::visualization::KeyboardEvent& event, void*)
 void 
 mouse_callback (const pcl::visualization::MouseEvent& mouse_event, void* cookie)
 {
-  std::string* message = static_cast<std::string*> (cookie);
+  auto* message = static_cast<std::string*> (cookie);
   if (mouse_event.getType() == pcl::visualization::MouseEvent::MouseButtonPress && mouse_event.getButton() == pcl::visualization::MouseEvent::LeftButton)
   {
     std::cout << (*message) << " :: " << mouse_event.getX () << " , " << mouse_event.getY () << std::endl;

--- a/tools/plane_projection.cpp
+++ b/tools/plane_projection.cpp
@@ -160,10 +160,10 @@ main (int argc, char** argv)
   }
 
   // Command line parsing
-  float a = static_cast<float> (atof (argv[3]));
-  float b = static_cast<float> (atof (argv[4]));
-  float c = static_cast<float> (atof (argv[5]));
-  float d = static_cast<float> (atof (argv[6]));
+  auto a = static_cast<float> (atof (argv[3]));
+  auto b = static_cast<float> (atof (argv[4]));
+  auto c = static_cast<float> (atof (argv[5]));
+  auto d = static_cast<float> (atof (argv[6]));
 
   // Load the first file
   pcl::PCLPointCloud2::Ptr cloud (new pcl::PCLPointCloud2);

--- a/tools/png2pcd.cpp
+++ b/tools/png2pcd.cpp
@@ -226,7 +226,7 @@ main (int argc, char** argv)
   }
 
   // Retrieve the entries from the image data and copy them into the output RGB cloud
-  double* pixel = new double [4];
+  auto* pixel = new double [4];
   memset (pixel, 0, sizeof (double) * 4);
   float depth;
 

--- a/tools/train_unary_classifier.cpp
+++ b/tools/train_unary_classifier.cpp
@@ -235,8 +235,8 @@ main (int argc, char** argv)
   
   // parse optional input arguments from the command line
   unsigned int k = default_cluster_size;
-  float normal_radius_search = static_cast<float> (default_normal_radius_search);
-  float fpfh_radius_search = static_cast<float> (default_fpfh_radius_search);
+  auto normal_radius_search = static_cast<float> (default_normal_radius_search);
+  auto fpfh_radius_search = static_cast<float> (default_fpfh_radius_search);
 
   parse_argument (argc, argv, "-k", k);
   parse_argument (argc, argv, "-normal-radius-search", normal_radius_search);

--- a/tools/unary_classifier_segment.cpp
+++ b/tools/unary_classifier_segment.cpp
@@ -189,9 +189,9 @@ main (int argc, char** argv)
   pcl::removeNaNFromPointCloud (*cloud, *cloud, tmp_indices);
   
   // parse optional input arguments from the command line
-  float normal_radius_search = static_cast<float> (default_normal_radius_search);
-  float fpfh_radius_search = static_cast<float> (default_fpfh_radius_search);
-  float feature_threshold = static_cast<float> (default_feature_threshold);
+  auto normal_radius_search = static_cast<float> (default_normal_radius_search);
+  auto fpfh_radius_search = static_cast<float> (default_fpfh_radius_search);
+  auto feature_threshold = static_cast<float> (default_feature_threshold);
   std::string dir_name;
 
   parse_argument (argc, argv, "-d", dir_name);

--- a/tools/vlp_viewer.cpp
+++ b/tools/vlp_viewer.cpp
@@ -224,7 +224,7 @@ main (int argc,
 
   VLPGrabber grabber (pcapFile);
 
-  PointCloudColorHandlerGenericField<PointXYZI> *color_handler = new PointCloudColorHandlerGenericField<PointXYZI> ("intensity");
+  auto *color_handler = new PointCloudColorHandlerGenericField<PointXYZI> ("intensity");
 
   SimpleVLPViewer<PointXYZI> v (grabber, color_handler);
   v.run ();

--- a/tracking/include/pcl/tracking/impl/particle_filter.hpp
+++ b/tracking/include/pcl/tracking/impl/particle_filter.hpp
@@ -62,8 +62,8 @@ ParticleFilterTracker<PointInT, StateT>::genAliasTable(
 {
   /* generate an alias table, a and q */
   std::vector<int> HL(particles->size());
-  std::vector<int>::iterator H = HL.begin();
-  std::vector<int>::iterator L = HL.end() - 1;
+  auto H = HL.begin();
+  auto L = HL.end() - 1;
   const auto num = particles->size();
   for (std::size_t i = 0; i < num; i++)
     q[i] = (*particles)[i].weight * static_cast<float>(num);

--- a/visualization/include/pcl/visualization/impl/histogram_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/histogram_visualizer.hpp
@@ -53,7 +53,7 @@ PCLHistogramVisualizer::addFeatureHistogram (
     const pcl::PointCloud<PointT> &cloud, int hsize,
     const std::string &id, int win_width, int win_height)
 {
-  RenWinInteractMap::iterator am_it = wins_.find (id);
+  auto am_it = wins_.find (id);
   if (am_it != wins_.end ())
   {
     PCL_WARN ("[addFeatureHistogram] A window with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -105,7 +105,7 @@ PCLHistogramVisualizer::addFeatureHistogram (
     return (false);
   }
 
-  RenWinInteractMap::iterator am_it = wins_.find (id);
+  auto am_it = wins_.find (id);
   if (am_it != wins_.end ())
   {
     PCL_WARN ("[addFeatureHistogram] A window with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -141,7 +141,7 @@ PCLHistogramVisualizer::updateFeatureHistogram (
     const pcl::PointCloud<PointT> &cloud, int hsize,
     const std::string &id)
 {
-  RenWinInteractMap::iterator am_it = wins_.find (id);
+  auto am_it = wins_.find (id);
   if (am_it == wins_.end ())
   {
     PCL_WARN ("[updateFeatureHistogram] A window with id <%s> does not exists!.\n", id.c_str ());
@@ -187,7 +187,7 @@ PCLHistogramVisualizer::updateFeatureHistogram (
     return (false);
   }
 
-  RenWinInteractMap::iterator am_it = wins_.find (id);
+  auto am_it = wins_.find (id);
   if (am_it == wins_.end ())
   {
     PCL_WARN ("[updateFeatureHistogram] A window with id <%s> does not exists!.\n", id.c_str ());

--- a/visualization/include/pcl/visualization/impl/image_viewer.hpp
+++ b/visualization/include/pcl/visualization/impl/image_viewer.hpp
@@ -105,7 +105,7 @@ pcl::visualization::ImageViewer::addMask (
     return (false);
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addMask] No layer with ID'=%s' found. Creating new one...\n", layer_id.c_str ());
@@ -159,7 +159,7 @@ pcl::visualization::ImageViewer::addPlanarPolygon (
     return (false);
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addPlanarPolygon] No layer with ID'=%s' found. Creating new one...\n", layer_id.c_str ());
@@ -218,7 +218,7 @@ pcl::visualization::ImageViewer::addRectangle (
     return (false);
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addRectangle] No layer with ID'=%s' found. Creating new one...\n", layer_id.c_str ());
@@ -298,7 +298,7 @@ pcl::visualization::ImageViewer::addRectangle (
     return (false);
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addRectangle] No layer with ID'=%s' found. Creating new one...\n", layer_id.c_str ());
@@ -363,7 +363,7 @@ pcl::visualization::ImageViewer::showCorrespondences (
   }
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addCorrespondences] No layer with ID='%s' found. Creating new one...\n", layer_id.c_str ());
@@ -437,9 +437,9 @@ pcl::visualization::ImageViewer::showCorrespondences (
   {
     double r, g, b;
     getRandomColors (r, g, b);
-    unsigned char u_r = static_cast<unsigned char> (255.0 * r);
-    unsigned char u_g = static_cast<unsigned char> (255.0 * g);
-    unsigned char u_b = static_cast<unsigned char> (255.0 * b);
+    auto u_r = static_cast<unsigned char> (255.0 * r);
+    auto u_g = static_cast<unsigned char> (255.0 * g);
+    auto u_b = static_cast<unsigned char> (255.0 * b);
     vtkSmartPointer<context_items::Circle> query_circle = vtkSmartPointer<context_items::Circle>::New ();
     query_circle->setColors (u_r, u_g, u_b);
     vtkSmartPointer<context_items::Circle> match_circle = vtkSmartPointer<context_items::Circle>::New ();

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -116,7 +116,7 @@ pcl::visualization::PCLVisualizer::addPointCloud (
   {
     // Here we're just pushing the handlers onto the queue. If needed, something fancier could
     // be done such as checking if a specific handler already exists, etc.
-    CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+    auto am_it = cloud_actor_map_->find (id);
     am_it->second.geometry_handlers.push_back (geometry_handler);
     return (true);
   }
@@ -156,7 +156,7 @@ pcl::visualization::PCLVisualizer::addPointCloud (
   const std::string &id, int viewport)
 {
   // Check to see if this entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
   if (am_it != cloud_actor_map_->end ())
   {
     // Here we're just pushing the handlers onto the queue. If needed, something fancier could
@@ -178,7 +178,7 @@ pcl::visualization::PCLVisualizer::addPointCloud (
   const std::string &id, int viewport)
 {
   // Check to see if this entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
   if (am_it != cloud_actor_map_->end ())
   {
     // Here we're just pushing the handlers onto the queue. If needed, something fancier could
@@ -377,7 +377,7 @@ pcl::visualization::PCLVisualizer::addPolygon (
     return (false);
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     vtkSmartPointer<vtkAppendPolyData> all_data = vtkSmartPointer<vtkAppendPolyData>::New ();
@@ -431,7 +431,7 @@ pcl::visualization::PCLVisualizer::addPolygon (
     return (false);
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     vtkSmartPointer<vtkAppendPolyData> all_data = vtkSmartPointer<vtkAppendPolyData>::New ();
@@ -665,7 +665,7 @@ pcl::visualization::PCLVisualizer::updateSphere (const PointT &center, double ra
 
   //////////////////////////////////////////////////////////////////////////
   // Get the actor pointer
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   vtkLODActor* actor = vtkLODActor::SafeDownCast (am_it->second);
   if (!actor)
     return (false);
@@ -898,7 +898,7 @@ pcl::visualization::PCLVisualizer::addPointCloudNormals (
   // If the cloud is organized, then distribute the normal step in both directions
   if (cloud->isOrganized () && normals->isOrganized ())
   {
-    vtkIdType point_step = static_cast<vtkIdType> (sqrt (double (level)));
+    auto point_step = static_cast<vtkIdType> (sqrt (double (level)));
     nr_normals = (static_cast<vtkIdType> ((cloud->width - 1)/ point_step) + 1) *
                  (static_cast<vtkIdType> ((cloud->height - 1) / point_step) + 1);
     pts = new float[2 * nr_normals * 3];
@@ -1120,7 +1120,7 @@ pcl::visualization::PCLVisualizer::addPointCloudIntensityGradients (
   data->SetNumberOfComponents (3);
 
   vtkIdType nr_gradients = (cloud->size () - 1) / level + 1 ;
-  float* pts = new float[2 * nr_gradients * 3];
+  auto* pts = new float[2 * nr_gradients * 3];
 
   for (vtkIdType i = 0, j = 0; j < nr_gradients; j++, i = j * level)
   {
@@ -1206,7 +1206,7 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
   }
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end () && !overwrite)
   {
     PCL_WARN ("[addCorrespondences] A set of correspondences with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -1526,7 +1526,7 @@ pcl::visualization::PCLVisualizer::updatePointCloud (const typename pcl::PointCl
                                                      const std::string &id)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
 
   if (am_it == cloud_actor_map_->end ())
     return (false);
@@ -1560,7 +1560,7 @@ pcl::visualization::PCLVisualizer::updatePointCloud (const typename pcl::PointCl
                                                      const std::string &id)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
 
   if (am_it == cloud_actor_map_->end ())
     return (false);
@@ -1595,7 +1595,7 @@ pcl::visualization::PCLVisualizer::updatePointCloud (const typename pcl::PointCl
                                                      const std::string &id)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
 
   if (am_it == cloud_actor_map_->end ())
     return (false);
@@ -1663,7 +1663,7 @@ pcl::visualization::PCLVisualizer::addPolygonMesh (
     {
       if (!isFinite ((*cloud)[i]))
         continue;
-      const pcl::RGB* const rgb_data = reinterpret_cast<const pcl::RGB*>(reinterpret_cast<const char*> (&(*cloud)[i]) + offset);
+      const auto* const rgb_data = reinterpret_cast<const pcl::RGB*>(reinterpret_cast<const char*> (&(*cloud)[i]) + offset);
       unsigned char color[3];
       color[0] = rgb_data->r;
       color[1] = rgb_data->g;
@@ -1792,7 +1792,7 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
   }
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
   if (am_it == cloud_actor_map_->end ())
     return (false);
 
@@ -1855,7 +1855,7 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
     {
       if (!isFinite ((*cloud)[i]))
         continue;
-      const pcl::RGB* const rgb_data = reinterpret_cast<const pcl::RGB*>(reinterpret_cast<const char*> (&(*cloud)[i]) + offset);
+      const auto* const rgb_data = reinterpret_cast<const pcl::RGB*>(reinterpret_cast<const char*> (&(*cloud)[i]) + offset);
       unsigned char color[3];
       color[0] = rgb_data->r;
       color[1] = rgb_data->g;

--- a/visualization/include/pcl/visualization/impl/point_cloud_geometry_handlers.hpp
+++ b/visualization/include/pcl/visualization/impl/point_cloud_geometry_handlers.hpp
@@ -82,7 +82,7 @@ PointCloudGeometryHandlerXYZ<PointT>::getGeometry (vtkSmartPointer<vtkPoints> &p
 
   // Add all points
   vtkIdType j = 0;    // true point index
-  float* pts = static_cast<float*> (malloc (nr_points * 3 * sizeof (float)));
+  auto* pts = static_cast<float*> (malloc (nr_points * 3 * sizeof (float)));
 
   // If the dataset has no invalid values, just copy all of them
   if (cloud_->is_dense)

--- a/visualization/src/common/float_image_utils.cpp
+++ b/visualization/src/common/float_image_utils.cpp
@@ -162,7 +162,7 @@ pcl::visualization::FloatImageUtils::getVisualImage (const float* float_image, i
   //std::cout << "Image is of size "<<width<<"x"<<height<<"\n";
   int size = width*height;
   int arraySize = 3 * size;
-  unsigned char* data = new unsigned char[arraySize];
+  auto* data = new unsigned char[arraySize];
   unsigned char* dataPtr = data;
   
   bool recalculateMinValue = std::isinf (min_value),
@@ -222,7 +222,7 @@ pcl::visualization::FloatImageUtils::getVisualImage (const unsigned short* short
   //std::cout << "Image is of size "<<width<<"x"<<height<<"\n";
   int size = width*height;
   int arraySize = 3 * size;
-  unsigned char* data = new unsigned char[arraySize];
+  auto* data = new unsigned char[arraySize];
   unsigned char* dataPtr = data;
   
   float factor = 1.0f / float (max_value - min_value), offset = float (-min_value);
@@ -255,7 +255,7 @@ pcl::visualization::FloatImageUtils::getVisualAngleImage (const float* angle_ima
 {
   int size = width*height;
   int arraySize = 3 * size;
-  unsigned char* data = new unsigned char[arraySize];
+  auto* data = new unsigned char[arraySize];
   unsigned char* dataPtr = data;
   
   for (int i=0; i<size; ++i) 
@@ -274,7 +274,7 @@ pcl::visualization::FloatImageUtils::getVisualHalfAngleImage (const float* angle
 {
   int size = width*height;
   int arraySize = 3 * size;
-  unsigned char* data = new unsigned char[arraySize];
+  auto* data = new unsigned char[arraySize];
   unsigned char* dataPtr = data;
   
   for (int i=0; i<size; ++i) 

--- a/visualization/src/histogram_visualizer.cpp
+++ b/visualization/src/histogram_visualizer.cpp
@@ -289,7 +289,7 @@ pcl::visualization::PCLHistogramVisualizer::addFeatureHistogram (
     return (false);
   }
 
-  RenWinInteractMap::iterator am_it = wins_.find (id);
+  auto am_it = wins_.find (id);
   if (am_it != wins_.end ())
   {
     PCL_WARN ("[addFeatureHistogram] A window with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -341,7 +341,7 @@ pcl::visualization::PCLHistogramVisualizer::addFeatureHistogram (
     return (false);
   }
 
-  RenWinInteractMap::iterator am_it = wins_.find (id);
+  auto am_it = wins_.find (id);
   if (am_it != wins_.end ())
   {
     PCL_ERROR ("[addFeatureHistogram] A window with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -382,7 +382,7 @@ pcl::visualization::PCLHistogramVisualizer::updateFeatureHistogram (
     const pcl::PCLPointCloud2 &cloud, const std::string &field_name,
     const std::string &id)
 {
-  RenWinInteractMap::iterator am_it = wins_.find (id);
+  auto am_it = wins_.find (id);
   if (am_it == wins_.end ())
   {
     PCL_WARN ("[updateFeatureHistogram] A window with id <%s> does not exists!.\n", id.c_str ());
@@ -428,7 +428,7 @@ pcl::visualization::PCLHistogramVisualizer::updateFeatureHistogram (
     PCL_ERROR ("[updateFeatureHistogram] Invalid point index (%d) given!\n", index);
     return (false);
   }
-  RenWinInteractMap::iterator am_it = wins_.find (id);
+  auto am_it = wins_.find (id);
   if (am_it == wins_.end ())
   {
     PCL_WARN ("[updateFeatureHistogram] A window with id <%s> does not exists!.\n", id.c_str ());

--- a/visualization/src/image_viewer.cpp
+++ b/visualization/src/image_viewer.cpp
@@ -135,7 +135,7 @@ pcl::visualization::ImageViewer::addRGBImage (
     setSize (width, height);
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addRGBImage] No layer with ID='%s' found. Creating new one...\n", layer_id.c_str ());
@@ -176,7 +176,7 @@ pcl::visualization::ImageViewer::addMonoImage (
     setSize (width, height);
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::showMonoImage] No layer with ID='%s' found. Creating new one...\n", layer_id.c_str ());
@@ -513,7 +513,7 @@ pcl::visualization::ImageViewer::emitKeyboardEvent (unsigned long event_id)
 void
 pcl::visualization::ImageViewer::MouseCallback (vtkObject*, unsigned long eid, void* clientdata, void*)
 {
-  ImageViewer* window = reinterpret_cast<ImageViewer*> (clientdata);
+  auto* window = reinterpret_cast<ImageViewer*> (clientdata);
   window->emitMouseEvent (eid);
 }
 
@@ -521,7 +521,7 @@ pcl::visualization::ImageViewer::MouseCallback (vtkObject*, unsigned long eid, v
 void
 pcl::visualization::ImageViewer::KeyboardCallback (vtkObject*, unsigned long eid, void* clientdata, void*)
 {
-  ImageViewer* window = reinterpret_cast<ImageViewer*> (clientdata);
+  auto* window = reinterpret_cast<ImageViewer*> (clientdata);
   window->emitKeyboardEvent (eid);
 }
 
@@ -557,7 +557,7 @@ pcl::visualization::ImageViewer::addLayer (
     const std::string &layer_id, int width, int height, double opacity)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it != layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addLayer] Layer with ID='%s' already exists!\n", layer_id.c_str ());
@@ -574,7 +574,7 @@ void
 pcl::visualization::ImageViewer::removeLayer (const std::string &layer_id)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::removeLayer] No layer with ID='%s' found.\n", layer_id.c_str ());
@@ -591,7 +591,7 @@ pcl::visualization::ImageViewer::addCircle (
     const std::string &layer_id, double opacity)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addCircle] No layer with ID='%s' found. Creating new one...\n", layer_id.c_str ());
@@ -624,7 +624,7 @@ pcl::visualization::ImageViewer::addFilledRectangle (
     double r, double g, double b, const std::string &layer_id, double opacity)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addFilledRectangle] No layer with ID='%s' found. Creating new one...\n", layer_id.c_str ());
@@ -659,7 +659,7 @@ pcl::visualization::ImageViewer::addRectangle (
     double r, double g, double b, const std::string &layer_id, double opacity)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addRectangle] No layer with ID='%s' found. Creating new one...\n", layer_id.c_str ());
@@ -694,7 +694,7 @@ pcl::visualization::ImageViewer::addRectangle (
     double r, double g, double b, const std::string &layer_id, double opacity)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addRectangle] No layer with ID='%s' found. Creating new one...\n", layer_id.c_str ());
@@ -729,7 +729,7 @@ pcl::visualization::ImageViewer::addLine (unsigned int x_min, unsigned int y_min
                                           const std::string &layer_id, double opacity)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addLine] No layer with ID='%s' found. Creating new one...\n", layer_id.c_str ());
@@ -765,7 +765,7 @@ pcl::visualization::ImageViewer::addText (unsigned int x, unsigned int y,
                                           const std::string &layer_id, double opacity)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::addText] No layer with ID='%s' found. Creating new one...\n", layer_id.c_str ());
@@ -798,7 +798,7 @@ pcl::visualization::ImageViewer::markPoint (
     const std::string &layer_id, double opacity)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::markPoint] No layer with ID='%s' found. Creating new one...\n", layer_id.c_str ());
@@ -845,7 +845,7 @@ pcl::visualization::ImageViewer::markPoints (
     return;
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  LayerMap::iterator am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
+  auto am_it = std::find_if (layer_map_.begin (), layer_map_.end (), LayerComparator (layer_id));
   if (am_it == layer_map_.end ())
   {
     PCL_DEBUG ("[pcl::visualization::ImageViewer::markPoint] No layer with ID='%s' found. Creating new one...\n", layer_id.c_str ());

--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -681,7 +681,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
         else
 #endif
         {
-          vtkPolyDataMapper* mapper = static_cast<vtkPolyDataMapper*>(act.actor->GetMapper ());
+          auto* mapper = static_cast<vtkPolyDataMapper*>(act.actor->GetMapper ());
           mapper->SetInputData (data);
           // Modify the actor
           act.actor->SetMapper (mapper);
@@ -708,7 +708,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
         double minmax[2];
         scalars->GetRange (minmax);
         // Update the data
-        vtkPolyData *data = static_cast<vtkPolyData*>(act.actor->GetMapper ()->GetInput ());
+        auto *data = static_cast<vtkPolyData*>(act.actor->GetMapper ()->GetInput ());
         data->GetPointData ()->SetScalars (scalars);
         // Modify the mapper
 #if VTK_RENDERING_BACKEND_OPENGL_VERSION < 2
@@ -724,7 +724,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
         else
 #endif
         {
-          vtkPolyDataMapper* mapper = static_cast<vtkPolyDataMapper*>(act.actor->GetMapper ());
+          auto* mapper = static_cast<vtkPolyDataMapper*>(act.actor->GetMapper ());
           mapper->SetScalarRange (minmax);
           mapper->SetScalarModeToUsePointData ();
           mapper->SetInputData (data);
@@ -860,7 +860,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
     case 'j': case 'J':
     {
       char cam_fn[80], snapshot_fn[80];
-      unsigned t = static_cast<unsigned> (time (nullptr));
+      auto t = static_cast<unsigned> (time (nullptr));
       sprintf (snapshot_fn, "screenshot-%d.png" , t);
       saveScreenshot (snapshot_fn);
 
@@ -1078,7 +1078,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
 
       vtkSmartPointer<vtkCamera> cam = CurrentRenderer->GetActiveCamera ();
       
-      static CloudActorMap::iterator it = cloud_actors_->begin ();
+      static auto it = cloud_actors_->begin ();
       // it might be that some actors don't have a valid transformation set -> we skip them to avoid a seg fault.
       bool found_transformation = false;
       for (unsigned idx = 0; idx < cloud_actors_->size (); ++idx, ++it)

--- a/visualization/src/pcl_painter2D.cpp
+++ b/visualization/src/pcl_painter2D.cpp
@@ -70,7 +70,7 @@ pcl::visualization::PCLPainter2D::addLine (float x1, float y1, float x2, float y
   line[2] = x2;
   line[3] = y2;
 
-  FPolyLine2D *pline = new FPolyLine2D(line, current_pen_, current_brush_, current_transform_);
+  auto *pline = new FPolyLine2D(line, current_pen_, current_brush_, current_transform_);
   figures_.push_back (pline);
 }
 
@@ -332,7 +332,7 @@ pcl::visualization::PCLPainter2D::setBackgroundColor (const double color[3])
 double*
 pcl::visualization::PCLPainter2D::getBackgroundColor ()
 {
-  double *bc = new double[3];
+  auto *bc = new double[3];
   bc[0] = bkg_color_[0];
   bc[1] = bkg_color_[1];
   bc[2] = bkg_color_[2];

--- a/visualization/src/pcl_plotter.cpp
+++ b/visualization/src/pcl_plotter.cpp
@@ -104,8 +104,8 @@ pcl::visualization::PCLPlotter::addPlotData (
   current_plot_++;
   
   //creating a permanent copy of the arrays
-  double *permanent_X = new double[size];
-  double *permanent_Y = new double[size];
+  auto *permanent_X = new double[size];
+  auto *permanent_Y = new double[size];
   memcpy(permanent_X, array_X, size*sizeof(double));
   memcpy(permanent_Y, array_Y, size*sizeof(double));
   
@@ -157,8 +157,8 @@ pcl::visualization::PCLPlotter::addPlotData (
     int type, 
     std::vector<char> const &color)
 {
-  double *array_x = new double[plot_data.size ()];
-  double *array_y = new double[plot_data.size ()];
+  auto *array_x = new double[plot_data.size ()];
+  auto *array_y = new double[plot_data.size ()];
 
   for (std::size_t i = 0; i < plot_data.size (); i++)
   {
@@ -479,7 +479,7 @@ pcl::visualization::PCLPlotter::setBackgroundColor (const double color[3])
 double*
 pcl::visualization::PCLPlotter::getBackgroundColor ()
 {
-  double *bc = new double[3];
+  auto *bc = new double[3];
   bc[0] = bkg_color_[0];
   bc[1] = bkg_color_[1];
   bc[2] = bkg_color_[2];
@@ -611,7 +611,7 @@ pcl::visualization::PCLPlotter::computeHistogram (
   {
     if (std::isfinite (value))
     {
-      unsigned int index = (unsigned int) (std::floor ((value - min) / size));
+      auto index = (unsigned int) (std::floor ((value - min) / size));
       if (index == (unsigned int) nbins) index = nbins - 1; //including right boundary
       histogram[index].second++;
     }

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -831,7 +831,7 @@ bool
 pcl::visualization::PCLVisualizer::removeCoordinateSystem (const std::string& id, int viewport)
 {
   // Check to see if the given ID entry exists
-  CoordinateActorMap::iterator am_it = coordinate_actor_map_->find (id);
+  auto am_it = coordinate_actor_map_->find (id);
 
   if (am_it == coordinate_actor_map_->end ())
     return (false);
@@ -851,7 +851,7 @@ bool
 pcl::visualization::PCLVisualizer::removePointCloud (const std::string &id, int viewport)
 {
   // Check to see if the given ID entry exists
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
 
   if (am_it == cloud_actor_map_->end ())
     return (false);
@@ -871,9 +871,9 @@ bool
 pcl::visualization::PCLVisualizer::removeShape (const std::string &id, int viewport)
 {
   // Check to see if the given ID entry exists
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   // Extra step: check if there is a cloud with the same ID
-  CloudActorMap::iterator ca_it = cloud_actor_map_->find (id);
+  auto ca_it = cloud_actor_map_->find (id);
 
   bool shape = true;
   // Try to find a shape first
@@ -939,7 +939,7 @@ pcl::visualization::PCLVisualizer::removeText3D (const std::string &id, int view
   for (std::size_t i = viewport; rens_->GetNextItem (); ++i)
   {
     const std::string uid = id + std::string (i, '*');
-    ShapeActorMap::iterator am_it = shape_actor_map_->find (uid);
+    auto am_it = shape_actor_map_->find (uid);
 
     // was it found
     if (am_it == shape_actor_map_->end ())
@@ -972,7 +972,7 @@ bool
 pcl::visualization::PCLVisualizer::removeAllPointClouds (int viewport)
 {
   // Check to see if the given ID entry exists
-  CloudActorMap::iterator am_it = cloud_actor_map_->begin ();
+  auto am_it = cloud_actor_map_->begin ();
   while (am_it != cloud_actor_map_->end () )
   {
     if (removePointCloud (am_it->first, viewport))
@@ -991,7 +991,7 @@ pcl::visualization::PCLVisualizer::removeAllShapes (int viewport)
   style_->lut_enabled_ = false; // Temporally disable LUT to fasten shape removal
 
   // Check to see if the given ID entry exists
-  ShapeActorMap::iterator am_it = shape_actor_map_->begin ();
+  auto am_it = shape_actor_map_->begin ();
   while (am_it != shape_actor_map_->end ())
   {
     if (removeShape (am_it->first, viewport))
@@ -1013,7 +1013,7 @@ bool
 pcl::visualization::PCLVisualizer::removeAllCoordinateSystems (int viewport)
 {
   // Check to see if the given ID entry exists
-  CoordinateActorMap::iterator am_it = coordinate_actor_map_->begin ();
+  auto am_it = coordinate_actor_map_->begin ();
   while (am_it != coordinate_actor_map_->end () )
   {
     if (removeCoordinateSystem (am_it->first, viewport))
@@ -1424,7 +1424,7 @@ pcl::visualization::PCLVisualizer::setPointCloudRenderingProperties (
     int property, double val1, double val2, double val3, const std::string &id, int)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
 
   if (am_it == cloud_actor_map_->end ())
   {
@@ -1462,7 +1462,7 @@ pcl::visualization::PCLVisualizer::setPointCloudRenderingProperties (
     int property, double val1, double val2, const std::string &id, int)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
 
   if (am_it == cloud_actor_map_->end ())
   {
@@ -1513,7 +1513,7 @@ bool
 pcl::visualization::PCLVisualizer::getPointCloudRenderingProperties (int property, double &value, const std::string &id)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
 
   if (am_it == cloud_actor_map_->end ())
     return (false);
@@ -1559,7 +1559,7 @@ pcl::visualization::PCLVisualizer::getPointCloudRenderingProperties (RenderingPr
                                                                      const std::string &id)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
 
   if (am_it == cloud_actor_map_->end ())
     return (false);
@@ -1597,7 +1597,7 @@ pcl::visualization::PCLVisualizer::setPointCloudRenderingProperties (
     int property, double value, const std::string &id, int)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
 
   if (am_it == cloud_actor_map_->end ())
   {
@@ -1702,7 +1702,7 @@ bool
 pcl::visualization::PCLVisualizer::setPointCloudSelected (const bool selected, const std::string &id)
 {
    // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
 
   if (am_it == cloud_actor_map_->end ())
   {
@@ -1735,7 +1735,7 @@ pcl::visualization::PCLVisualizer::setShapeRenderingProperties (
     int property, double val1, double val2, double val3, const std::string &id, int)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
 
   if (am_it == shape_actor_map_->end ())
   {
@@ -1782,7 +1782,7 @@ pcl::visualization::PCLVisualizer::setShapeRenderingProperties (
     int property, double val1, double val2, const std::string &id, int)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
 
   if (am_it == shape_actor_map_->end ())
   {
@@ -1834,7 +1834,7 @@ pcl::visualization::PCLVisualizer::setShapeRenderingProperties (
     int property, double value, const std::string &id, int)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
 
   if (am_it == shape_actor_map_->end ())
   {
@@ -2028,7 +2028,7 @@ pcl::visualization::PCLVisualizer::getCameraFile () const
 bool
 pcl::visualization::PCLVisualizer::updateShapePose (const std::string &id, const Eigen::Affine3f& pose)
 {
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
 
   vtkLODActor* actor;
 
@@ -2053,7 +2053,7 @@ pcl::visualization::PCLVisualizer::updateShapePose (const std::string &id, const
 bool
 pcl::visualization::PCLVisualizer::updateCoordinateSystemPose (const std::string &id, const Eigen::Affine3f& pose)
 {
-  ShapeActorMap::iterator am_it = coordinate_actor_map_->find (id);
+  auto am_it = coordinate_actor_map_->find (id);
 
   vtkLODActor* actor;
 
@@ -2079,7 +2079,7 @@ bool
 pcl::visualization::PCLVisualizer::updatePointCloudPose (const std::string &id, const Eigen::Affine3f& pose)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
 
   if (am_it == cloud_actor_map_->end ())
     return (false);
@@ -2334,7 +2334,7 @@ pcl::visualization::PCLVisualizer::addCylinder (const pcl::ModelCoefficients &co
                                                const std::string &id, int viewport)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr, "[addCylinder] A shape with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -2366,7 +2366,7 @@ pcl::visualization::PCLVisualizer::addCube (const pcl::ModelCoefficients &coeffi
                                             const std::string &id, int viewport)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr, "[addCube] A shape with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -2400,7 +2400,7 @@ pcl::visualization::PCLVisualizer::addCube (
   const std::string &id, int viewport)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr, "[addCube] A shape with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -2429,7 +2429,7 @@ pcl::visualization::PCLVisualizer::addCube (float x_min, float x_max,
                                             const std::string &id, int viewport)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr, "[addCube] A shape with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -2458,7 +2458,7 @@ pcl::visualization::PCLVisualizer::addEllipsoid (
   const std::string &id, int viewport)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr, "[addEllipsoid] A shape with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -2484,7 +2484,7 @@ pcl::visualization::PCLVisualizer::addSphere (const pcl::ModelCoefficients &coef
                                              const std::string &id, int viewport)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr, "[addSphere] A shape with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -2515,7 +2515,7 @@ bool
 pcl::visualization::PCLVisualizer::addModelFromPolyData (
     vtkSmartPointer<vtkPolyData> polydata, const std::string & id, int viewport)
 {
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr,
@@ -2539,7 +2539,7 @@ bool
 pcl::visualization::PCLVisualizer::addModelFromPolyData (
     vtkSmartPointer<vtkPolyData> polydata, vtkSmartPointer<vtkTransform> transform, const std::string & id, int viewport)
 {
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr,
@@ -2569,7 +2569,7 @@ bool
 pcl::visualization::PCLVisualizer::addModelFromPLYFile (const std::string &filename,
                                                        const std::string &id, int viewport)
 {
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr,
@@ -2598,7 +2598,7 @@ pcl::visualization::PCLVisualizer::addModelFromPLYFile (const std::string &filen
                                                        vtkSmartPointer<vtkTransform> transform, const std::string &id,
                                                        int viewport)
 {
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr,
@@ -2631,7 +2631,7 @@ bool
 pcl::visualization::PCLVisualizer::addLine (const pcl::ModelCoefficients &coefficients, const std::string &id, int viewport)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr, "[addLine] A shape with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -2667,7 +2667,7 @@ bool
   pcl::visualization::PCLVisualizer::addPlane (const pcl::ModelCoefficients &coefficients, const std::string &id, int viewport)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr, "[addPlane] A shape with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -2697,7 +2697,7 @@ bool
   pcl::visualization::PCLVisualizer::addPlane (const pcl::ModelCoefficients &coefficients, double x, double y, double z, const std::string &id, int viewport)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr, "[addPlane] A shape with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -2728,7 +2728,7 @@ bool
 pcl::visualization::PCLVisualizer::addCircle (const pcl::ModelCoefficients &coefficients, const std::string &id, int viewport)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr, "[addCircle] A shape with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -2759,7 +2759,7 @@ bool
 pcl::visualization::PCLVisualizer::addCone (const pcl::ModelCoefficients &coefficients, const std::string &id, int viewport)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr, "[addCone] A shape with id <%s> already exists! Please choose a different id and retry.\n", id.c_str ());
@@ -2841,7 +2841,7 @@ pcl::visualization::PCLVisualizer::addText (const std::string &text, int xpos, i
     tid = id;
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (tid);
+  auto am_it = shape_actor_map_->find (tid);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr, "[addText] A text with id <%s> already exists! Please choose a different id and retry.\n", tid.c_str ());
@@ -2877,7 +2877,7 @@ pcl::visualization::PCLVisualizer::addText (const std::string &text, int xpos, i
     tid = id;
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (tid);
+  auto am_it = shape_actor_map_->find (tid);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr, "[addText] A text with id <%s> already exists! Please choose a different id and retry.\n", tid.c_str ());
@@ -2913,7 +2913,7 @@ pcl::visualization::PCLVisualizer::addText (const std::string &text, int xpos, i
     tid = id;
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (tid);
+  auto am_it = shape_actor_map_->find (tid);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr, "[addText] A text with id <%s> already exists! Please choose a different id and retry.\n", tid.c_str ());
@@ -2949,7 +2949,7 @@ pcl::visualization::PCLVisualizer::updateText (const std::string &text, int xpos
     tid = id;
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (tid);
+  auto am_it = shape_actor_map_->find (tid);
   if (am_it == shape_actor_map_->end ())
     return (false);
 
@@ -2975,7 +2975,7 @@ pcl::visualization::PCLVisualizer::updateText (const std::string &text, int xpos
     tid = id;
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (tid);
+  auto am_it = shape_actor_map_->find (tid);
   if (am_it == shape_actor_map_->end ())
     return (false);
 
@@ -3004,7 +3004,7 @@ pcl::visualization::PCLVisualizer::updateText (const std::string &text, int xpos
     tid = id;
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (tid);
+  auto am_it = shape_actor_map_->find (tid);
   if (am_it == shape_actor_map_->end ())
     return (false);
 
@@ -3029,7 +3029,7 @@ pcl::visualization::PCLVisualizer::updateText (const std::string &text, int xpos
 bool
 pcl::visualization::PCLVisualizer::updateColorHandlerIndex (const std::string &id, int index)
 {
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
   if (am_it == cloud_actor_map_->end ())
   {
     pcl::console::print_warn (stderr, "[updateColorHandlerIndex] PointCloud with id <%s> doesn't exist!\n", id.c_str ());
@@ -3049,7 +3049,7 @@ pcl::visualization::PCLVisualizer::updateColorHandlerIndex (const std::string &i
   double minmax[2];
   scalars->GetRange (minmax);
   // Update the data
-  vtkPolyData *data = static_cast<vtkPolyData*>(am_it->second.actor->GetMapper ()->GetInput ());
+  auto *data = static_cast<vtkPolyData*>(am_it->second.actor->GetMapper ()->GetInput ());
   data->GetPointData ()->SetScalars (scalars);
   // Modify the mapper
 #if VTK_RENDERING_BACKEND_OPENGL_VERSION < 2
@@ -3069,7 +3069,7 @@ pcl::visualization::PCLVisualizer::updateColorHandlerIndex (const std::string &i
   else
 #endif
   {
-    vtkPolyDataMapper* mapper = static_cast<vtkPolyDataMapper*>(am_it->second.actor->GetMapper ());
+    auto* mapper = static_cast<vtkPolyDataMapper*>(am_it->second.actor->GetMapper ());
     mapper->SetScalarRange (minmax);
     mapper->SetScalarModeToUsePointData ();
     mapper->SetInputData (data);
@@ -3092,7 +3092,7 @@ pcl::visualization::PCLVisualizer::addPolygonMesh (const pcl::PolygonMesh &poly_
                                                    const std::string &id,
                                                    int viewport)
 {
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
   if (am_it != cloud_actor_map_->end ())
   {
     pcl::console::print_warn (stderr,
@@ -3216,7 +3216,7 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
   }
 
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
   if (am_it == cloud_actor_map_->end ())
     return (false);
 
@@ -3293,7 +3293,7 @@ bool
 pcl::visualization::PCLVisualizer::addPolylineFromPolygonMesh (
     const pcl::PolygonMesh &polymesh, const std::string &id, int viewport)
 {
-  ShapeActorMap::iterator am_it = shape_actor_map_->find (id);
+  auto am_it = shape_actor_map_->find (id);
   if (am_it != shape_actor_map_->end ())
   {
     pcl::console::print_warn (stderr,
@@ -3356,7 +3356,7 @@ pcl::visualization::PCLVisualizer::addTextureMesh (const pcl::TextureMesh &mesh,
                                                    const std::string &id,
                                                    int viewport)
 {
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
   if (am_it != cloud_actor_map_->end ())
   {
     PCL_ERROR ("[PCLVisualizer::addTextureMesh] A shape with id <%s> already exists!"
@@ -3877,7 +3877,7 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
     cloud->height = 1;
 
     double coords[3];
-    float * depth = new float[xres * yres];
+    auto * depth = new float[xres * yres];
     render_win->GetZbufferData (0, 0, xres - 1, yres - 1, &(depth[0]));
 
     int count_valid_depth_pixels = 0;
@@ -3950,7 +3950,7 @@ pcl::visualization::PCLVisualizer::renderViewTesselatedSphere (
     {
       int id_mesh = static_cast<int> (ids->GetValue (sel_id));
       vtkCell * cell = polydata->GetCell (id_mesh);
-      vtkTriangle* triangle = dynamic_cast<vtkTriangle*> (cell);
+      auto* triangle = dynamic_cast<vtkTriangle*> (cell);
       if (!triangle)
       {
         PCL_WARN ("[renderViewTesselatedSphere] Invalid triangle %d, skipping!\n", id_mesh);
@@ -4046,7 +4046,7 @@ pcl::visualization::PCLVisualizer::renderView (int xres, int yres, pcl::PointClo
   cloud->width = xres;
   cloud->height = yres;
 
-  float *depth = new float[xres * yres];
+  auto *depth = new float[xres * yres];
   win_->GetZbufferData (0, 0, xres - 1, yres - 1, &(depth[0]));
 
   // Transform cloud to give camera coordinates instead of world coordinates!
@@ -4294,7 +4294,7 @@ pcl::visualization::PCLVisualizer::addPointCloud (
     const std::string &id, int viewport)
 {
   // Check to see if this entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
   if (am_it != cloud_actor_map_->end ())
   {
     // Here we're just pushing the handlers onto the queue. If needed, something fancier could
@@ -4316,7 +4316,7 @@ pcl::visualization::PCLVisualizer::addPointCloud (
     const std::string &id, int viewport)
 {
   // Check to see if this ID entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
 
   if (am_it != cloud_actor_map_->end ())
   {
@@ -4340,7 +4340,7 @@ pcl::visualization::PCLVisualizer::addPointCloud (
     const std::string &id, int viewport)
 {
   // Check to see if this entry already exists (has it been already added to the visualizer?)
-  CloudActorMap::iterator am_it = cloud_actor_map_->find (id);
+  auto am_it = cloud_actor_map_->find (id);
   if (am_it != cloud_actor_map_->end ())
   {
     // Here we're just pushing the handlers onto the queue. If needed, something fancier could
@@ -4422,7 +4422,7 @@ pcl::visualization::PCLVisualizer::removeCorrespondences (
 int
 pcl::visualization::PCLVisualizer::getColorHandlerIndex (const std::string &id)
 {
-  CloudActorMap::iterator am_it = style_->getCloudActorMap ()->find (id);
+  auto am_it = style_->getCloudActorMap ()->find (id);
   if (am_it == cloud_actor_map_->end ())
     return (-1);
 
@@ -4433,7 +4433,7 @@ pcl::visualization::PCLVisualizer::getColorHandlerIndex (const std::string &id)
 int
 pcl::visualization::PCLVisualizer::getGeometryHandlerIndex (const std::string &id)
 {
-  CloudActorMap::iterator am_it = style_->getCloudActorMap ()->find (id);
+  auto am_it = style_->getCloudActorMap ()->find (id);
   if (am_it != cloud_actor_map_->end ())
     return (-1);
 
@@ -4513,7 +4513,7 @@ void
 pcl::visualization::PCLVisualizer::FPSCallback::Execute (
     vtkObject* caller, unsigned long, void*)
 {
-  vtkRenderer *ren = reinterpret_cast<vtkRenderer *> (caller);
+  auto *ren = reinterpret_cast<vtkRenderer *> (caller);
   last_fps = 1.0f / static_cast<float> (ren->GetLastRenderTimeInSeconds ());
   char buf[128];
   sprintf (buf, "%.1f FPS", last_fps);

--- a/visualization/src/point_cloud_handlers.cpp
+++ b/visualization/src/point_cloud_handlers.cpp
@@ -57,7 +57,7 @@ pcl::visualization::PointCloudColorHandlerCustom<pcl::PCLPointCloud2>::getColor 
   scalars->SetNumberOfTuples (nr_points);
 
   // Get a random color
-  unsigned char* colors = new unsigned char[nr_points * 3];
+  auto* colors = new unsigned char[nr_points * 3];
   
   // Color every point
   for (vtkIdType cp = 0; cp < nr_points; ++cp)
@@ -84,7 +84,7 @@ pcl::visualization::PointCloudColorHandlerRandom<pcl::PCLPointCloud2>::getColor 
   scalars->SetNumberOfTuples (nr_points);
   
   // Get a random color
-  unsigned char* colors = new unsigned char[nr_points * 3];
+  auto* colors = new unsigned char[nr_points * 3];
   double r, g, b;
   pcl::visualization::getRandomColors (r, g, b);
   
@@ -130,7 +130,7 @@ pcl::visualization::PointCloudColorHandlerRGBField<pcl::PCLPointCloud2>::getColo
   vtkIdType nr_points = cloud_->width * cloud_->height;
   scalars->SetNumberOfTuples (nr_points);
   // Allocate enough memory to hold all colors
-  unsigned char* colors = new unsigned char[nr_points * 3];
+  auto* colors = new unsigned char[nr_points * 3];
 
   pcl::RGB rgb_data;
   std::size_t point_offset = cloud_->fields[field_idx_].offset;
@@ -234,7 +234,7 @@ pcl::visualization::PointCloudColorHandlerHSVField<pcl::PCLPointCloud2>::getColo
 
   // Allocate enough memory to hold all colors
   // colors is taken over by SetArray (line 419)
-  unsigned char* colors = new unsigned char[nr_points * 3];
+  auto* colors = new unsigned char[nr_points * 3];
 
   float h_data, v_data, s_data;
   int point_offset = cloud_->fields[field_idx_].offset;
@@ -437,7 +437,7 @@ pcl::visualization::PointCloudColorHandlerGenericField<pcl::PCLPointCloud2>::get
   vtkIdType nr_points = cloud_->width * cloud_->height;
   scalars->SetNumberOfTuples (nr_points);
 
-  float* colors = new float[nr_points];
+  auto* colors = new float[nr_points];
   float field_data;
   int j = 0;
   int point_offset = cloud_->fields[field_idx_].offset;
@@ -512,7 +512,7 @@ pcl::visualization::PointCloudColorHandlerRGBAField<pcl::PCLPointCloud2>::getCol
   vtkIdType nr_points = cloud_->width * cloud_->height;
   scalars->SetNumberOfTuples (nr_points);
   // Allocate enough memory to hold all colors
-  unsigned char* colors = new unsigned char[nr_points * 4];
+  auto* colors = new unsigned char[nr_points * 4];
 
   pcl::RGB rgba_data;
   int point_offset = cloud_->fields[field_idx_].offset;
@@ -597,7 +597,7 @@ pcl::visualization::PointCloudColorHandlerLabelField<pcl::PCLPointCloud2>::getCo
   vtkIdType nr_points = cloud_->width * cloud_->height;
   scalars->SetNumberOfTuples (nr_points);
   // Allocate enough memory to hold all colors
-  unsigned char* colors = new unsigned char[nr_points * 3];
+  auto* colors = new unsigned char[nr_points * 3];
 
   int j = 0;
   int point_offset = cloud_->fields[field_idx_].offset;
@@ -618,7 +618,7 @@ pcl::visualization::PointCloudColorHandlerLabelField<pcl::PCLPointCloud2>::getCo
 
     // Assign Glasbey colors in ascending order of labels
     std::size_t color = 0;
-    for (std::set<std::uint32_t>::iterator iter = labels.begin (); iter != labels.end (); ++iter, ++color)
+    for (auto iter = labels.begin (); iter != labels.end (); ++iter, ++color)
       colormap[*iter] = GlasbeyLUT::at (color % GlasbeyLUT::size ());
   }
   // If XYZ present, check if the points are invalid
@@ -704,7 +704,7 @@ pcl::visualization::PointCloudGeometryHandler<pcl::PCLPointCloud2>::getGeometry 
   {
     for (vtkIdType i = 0; i < nr_points; ++i, point_offset+=cloud_->point_step)
     {
-      const float* ptr = reinterpret_cast<const float*>(&cloud_->data[point_offset + cloud_->fields[field_x_idx_].offset]);
+      const auto* ptr = reinterpret_cast<const float*>(&cloud_->data[point_offset + cloud_->fields[field_x_idx_].offset]);
       data->InsertNextValue(*ptr);
 
       ptr = reinterpret_cast<const float*>(&cloud_->data[point_offset + cloud_->fields[field_y_idx_].offset]);
@@ -719,7 +719,7 @@ pcl::visualization::PointCloudGeometryHandler<pcl::PCLPointCloud2>::getGeometry 
   {
     for (vtkIdType i = 0; i < nr_points; ++i, point_offset+=cloud_->point_step)
     {
-      const float* ptr = reinterpret_cast<const float*>(&cloud_->data[point_offset + cloud_->fields[field_x_idx_].offset]);
+      const auto* ptr = reinterpret_cast<const float*>(&cloud_->data[point_offset + cloud_->fields[field_x_idx_].offset]);
       if (!std::isfinite (*ptr))
         continue;
       data->InsertNextValue(*ptr);

--- a/visualization/src/point_picking_event.cpp
+++ b/visualization/src/point_picking_event.cpp
@@ -56,7 +56,7 @@
 void
 pcl::visualization::PointPickingCallback::Execute (vtkObject *caller, unsigned long eventid, void*)
 {
-  PCLVisualizerInteractorStyle *style = reinterpret_cast<PCLVisualizerInteractorStyle*>(caller);
+  auto *style = reinterpret_cast<PCLVisualizerInteractorStyle*>(caller);
   vtkRenderWindowInteractor* iren = reinterpret_cast<pcl::visualization::PCLVisualizerInteractorStyle*>(caller)->GetInteractor ();
   if (style->CurrentMode == 0)
   {
@@ -168,12 +168,12 @@ int
 pcl::visualization::PointPickingCallback::performAreaPick (vtkRenderWindowInteractor *iren,
                                                            pcl::Indices &indices) const
 {
-  vtkAreaPicker *picker = static_cast<vtkAreaPicker*> (iren->GetPicker ());
+  auto *picker = static_cast<vtkAreaPicker*> (iren->GetPicker ());
   vtkRenderer *ren = iren->FindPokedRenderer (iren->GetEventPosition ()[0], iren->GetEventPosition ()[1]);
   picker->AreaPick (x_, y_, iren->GetEventPosition ()[0], iren->GetEventPosition ()[1], ren);
   if (picker->GetDataSet ())
   {
-    vtkPolyData* points = reinterpret_cast<vtkPolyData*> (picker->GetDataSet ());
+    auto* points = reinterpret_cast<vtkPolyData*> (picker->GetDataSet ());
 
     // This is a naive solution till we fugure out where to add the GlobalIds at an earlier stage
     if (!points->GetPointData ()->GetGlobalIds () ||

--- a/visualization/src/range_image_visualizer.cpp
+++ b/visualization/src/range_image_visualizer.cpp
@@ -64,7 +64,7 @@ pcl::visualization::RangeImageVisualizer*
 pcl::visualization::RangeImageVisualizer::getRangeImageWidget (
     const pcl::RangeImage& range_image, float min_value, float max_value, bool grayscale, const std::string& name)
 {
-  RangeImageVisualizer* range_image_widget = new RangeImageVisualizer (name);
+  auto* range_image_widget = new RangeImageVisualizer (name);
   range_image_widget->showRangeImage (range_image, min_value, max_value, grayscale);
   return range_image_widget;
 }
@@ -102,7 +102,7 @@ pcl::visualization::RangeImageVisualizer::getRangeImageBordersWidget (
     const pcl::PointCloud<pcl::BorderDescription>& border_descriptions, const std::string& name)
 {
   //std::cout << PVARN(range_image)<<PVARN(min_value)<<PVARN(max_value)<<PVARN(grayscale);
-  RangeImageVisualizer* range_image_widget = new RangeImageVisualizer;
+  auto* range_image_widget = new RangeImageVisualizer;
   range_image_widget->visualizeBorders (range_image, min_value, max_value, grayscale,
                                         border_descriptions);
   range_image_widget->setWindowTitle (name);
@@ -113,7 +113,7 @@ pcl::visualization::RangeImageVisualizer*
 pcl::visualization::RangeImageVisualizer::getAnglesWidget (const pcl::RangeImage& range_image, float* angles_image,
                                                            const std::string& name)
 {
-  RangeImageVisualizer* widget = new RangeImageVisualizer;
+  auto* widget = new RangeImageVisualizer;
   widget->showAngleImage(angles_image, range_image.width, range_image.height);
   widget->setWindowTitle (name);
   return widget;
@@ -123,7 +123,7 @@ pcl::visualization::RangeImageVisualizer*
 pcl::visualization::RangeImageVisualizer::getHalfAnglesWidget (const pcl::RangeImage& range_image,
                                                                 float* angles_image, const std::string& name)
 {
-  RangeImageVisualizer* widget = new RangeImageVisualizer;
+  auto* widget = new RangeImageVisualizer;
   widget->showHalfAngleImage(angles_image, range_image.width, range_image.height);
   widget->setWindowTitle (name);
   return widget;
@@ -134,7 +134,7 @@ pcl::visualization::RangeImageVisualizer::getInterestPointsWidget (
     const pcl::RangeImage& range_image, const float* interest_image, float min_value, float max_value, 
     const pcl::PointCloud<pcl::InterestPoint>& interest_points, const std::string& name)
 {
-  RangeImageVisualizer* widget = new RangeImageVisualizer;
+  auto* widget = new RangeImageVisualizer;
   widget->showFloatImage (interest_image, range_image.width, range_image.height, min_value, max_value);
   widget->setWindowTitle (name);
   for (const auto &interest_point : interest_points.points)

--- a/visualization/src/vtk/vtkFixedXRenderWindowInteractor.cxx
+++ b/visualization/src/vtk/vtkFixedXRenderWindowInteractor.cxx
@@ -511,7 +511,7 @@ void vtkXRenderWindowInteractor::DispatchEvent(XEvent* event)
         // just getting the expose configure event
         event = &result;
       }
-      XExposeEvent* exposeEvent = reinterpret_cast<XExposeEvent*>(event);
+      auto* exposeEvent = reinterpret_cast<XExposeEvent*>(event);
       this->SetEventSize(exposeEvent->width, exposeEvent->height);
       xp = exposeEvent->x;
       yp = exposeEvent->y;
@@ -660,7 +660,7 @@ void vtkXRenderWindowInteractor::DispatchEvent(XEvent* event)
       XSetInputFocus(this->DisplayId, this->WindowId, RevertToPointerRoot, CurrentTime);
       if (this->Enabled)
       {
-        XEnterWindowEvent* e = reinterpret_cast<XEnterWindowEvent*>(event);
+        auto* e = reinterpret_cast<XEnterWindowEvent*>(event);
         this->SetEventInformationFlipY(
           e->x, e->y, (e->state & ControlMask) != 0, (e->state & ShiftMask) != 0);
         this->SetAltKey(((reinterpret_cast<XButtonEvent*>(event))->state & Mod1Mask) ? 1 : 0);
@@ -673,7 +673,7 @@ void vtkXRenderWindowInteractor::DispatchEvent(XEvent* event)
     {
       if (this->Enabled)
       {
-        XLeaveWindowEvent* e = reinterpret_cast<XLeaveWindowEvent*>(event);
+        auto* e = reinterpret_cast<XLeaveWindowEvent*>(event);
         this->SetEventInformationFlipY(
           e->x, e->y, (e->state & ControlMask) != 0, (e->state & ShiftMask) != 0);
         this->SetAltKey(((reinterpret_cast<XButtonEvent*>(event))->state & Mod1Mask) ? 1 : 0);

--- a/visualization/src/window.cpp
+++ b/visualization/src/window.cpp
@@ -309,7 +309,7 @@ pcl::visualization::Window::emitKeyboardEvent (unsigned long event_id)
 void 
 pcl::visualization::Window::MouseCallback(vtkObject*, unsigned long eid, void* clientdata, void*)
 {
-  Window* window = reinterpret_cast<Window*> (clientdata);
+  auto* window = reinterpret_cast<Window*> (clientdata);
   window->emitMouseEvent (eid);
 }
 
@@ -317,7 +317,7 @@ pcl::visualization::Window::MouseCallback(vtkObject*, unsigned long eid, void* c
 void 
 pcl::visualization::Window::KeyboardCallback (vtkObject*, unsigned long eid, void* clientdata, void*)
 {
-  Window* window = reinterpret_cast<Window*> (clientdata);
+  auto* window = reinterpret_cast<Window*> (clientdata);
   window->emitKeyboardEvent (eid);
 }
 


### PR DESCRIPTION
One glaring oversight when `clang-tidy` checks were added in #4636: `modernize-use-auto` was omitted.

Using `auto` cleans up a lot of redundancy in the code