### PR TITLE
[CMake] Fix issue with `TARGET_PDB_FILE`

### DIFF
--- a/cmake/pcl_targets.cmake
+++ b/cmake/pcl_targets.cmake
@@ -225,7 +225,7 @@ function(PCL_ADD_LIBRARY _name)
           ARCHIVE DESTINATION ${LIB_INSTALL_DIR} COMPONENT pcl_${ARGS_COMPONENT})
 
   # Copy PDB if available
-  if(MSVC AND PCL_SHARED_LIBS)
+  if(MSVC AND ${PCL_LIB_TYPE} EQUAL "SHARED")
     install(FILES $<TARGET_PDB_FILE:${_name}> DESTINATION ${BIN_INSTALL_DIR} OPTIONAL)
   endif()
 endfunction()


### PR DESCRIPTION
Check for link type of specific library instead of using global PCL_SHARED_LIBS to determine if a PDB file should installed or not.

Fixes:
```
CMake Error:
  Error evaluating generator expression:

    $<TARGET_PDB_FILE:pcl_cc_tool_interface>

  TARGET_PDB_FILE is allowed only for targets with linker created artifacts.
```

Reason for this issue are these lines, so we should not rely on `PCL_SHARED_LIBS`, but on `PCL_LIB_TYPE`

https://github.com/PointCloudLibrary/pcl/blob/6f28bcd7a9d060372478e6212c2db72b527180ae/apps/cloud_composer/CMakeLists.txt#L73-L81