### PR TITLE
Add more tests for functions in pcl/common/centroid.h

### DIFF
--- a/test/common/test_centroid.cpp
+++ b/test/common/test_centroid.cpp
@@ -56,26 +56,31 @@ TEST (PCL, compute3DCentroidFloat)
   Indices indices;
   PointXYZ point;
   PointCloud<PointXYZ> cloud;
-  Eigen::Vector4f centroid;
+  Eigen::Vector4f centroid = Eigen::Vector4f::Random();
+  const Eigen::Vector4f old_centroid = centroid;
 
   // test empty cloud which is dense
   cloud.is_dense = true;
   EXPECT_EQ (compute3DCentroid (cloud, centroid), 0);
+  EXPECT_EQ (old_centroid, centroid); // centroid remains unchanged
 
   // test empty cloud non_dense
   cloud.is_dense = false;
   EXPECT_EQ (compute3DCentroid (cloud, centroid), 0);
+  EXPECT_EQ (old_centroid, centroid); // centroid remains unchanged
 
-  // test non-empty cloud non_dense
+  // test non-empty cloud non_dense (with only invalid points)
   point.x = point.y = point.z = std::numeric_limits<float>::quiet_NaN ();
   cloud.push_back (point);
   EXPECT_EQ (compute3DCentroid (cloud, centroid), 0);
+  EXPECT_EQ (old_centroid, centroid); // centroid remains unchanged
 
-  // test non-empty cloud non_dense
+  // test non-empty cloud non_dense (with only invalid points)
   point.x = point.y = point.z = std::numeric_limits<float>::quiet_NaN ();
   cloud.push_back (point);
   indices.push_back (1);
   EXPECT_EQ (compute3DCentroid (cloud, indices, centroid), 0);
+  EXPECT_EQ (old_centroid, centroid); // centroid remains unchanged
 
   cloud.clear ();
   indices.clear ();
@@ -162,26 +167,31 @@ TEST (PCL, compute3DCentroidDouble)
   Indices indices;
   PointXYZ point;
   PointCloud<PointXYZ> cloud;
-  Eigen::Vector4d centroid;
+  Eigen::Vector4d centroid = Eigen::Vector4d::Random();
+  const Eigen::Vector4d old_centroid = centroid;
 
   // test empty cloud which is dense
   cloud.is_dense = true;
   EXPECT_EQ (compute3DCentroid (cloud, centroid), 0);
+  EXPECT_EQ (old_centroid, centroid); // centroid remains unchanged
 
   // test empty cloud non_dense
   cloud.is_dense = false;
   EXPECT_EQ (compute3DCentroid (cloud, centroid), 0);
+  EXPECT_EQ (old_centroid, centroid); // centroid remains unchanged
 
-  // test non-empty cloud non_dense
+  // test non-empty cloud non_dense (with only invalid points)
   point.x = point.y = point.z = std::numeric_limits<float>::quiet_NaN ();
   cloud.push_back (point);
   EXPECT_EQ (compute3DCentroid (cloud, centroid), 0);
+  EXPECT_EQ (old_centroid, centroid); // centroid remains unchanged
 
-  // test non-empty cloud non_dense
+  // test non-empty cloud non_dense (with only invalid points)
   point.x = point.y = point.z = std::numeric_limits<float>::quiet_NaN ();
   cloud.push_back (point);
   indices.push_back (1);
   EXPECT_EQ (compute3DCentroid (cloud, indices, centroid), 0);
+  EXPECT_EQ (old_centroid, centroid); // centroid remains unchanged
 
   cloud.clear ();
   indices.clear ();
@@ -319,6 +329,14 @@ TEST (PCL, compute3DCentroidCloudIterator)
 
     EXPECT_EQ (8, compute3DCentroid (it, centroid_f));
     EXPECT_EQ_VECTORS (Eigen::Vector4f (0.f, 0.f, 0.f, 1.f), centroid_f);
+
+    const Eigen::Vector4f old_centroid = centroid_f;
+    indices.clear ();
+    indices.push_back (cloud.size () - 1);
+    ConstCloudIterator<PointXYZ> it2 (cloud, indices);
+    // zero valid points and centroid remains unchanged
+    EXPECT_EQ (0, compute3DCentroid (it2, centroid_f));
+    EXPECT_EQ (old_centroid, centroid_f);
   }
 }
 
@@ -330,7 +348,8 @@ TEST (PCL, computeCovarianceMatrix)
   PointXYZ point;
   Indices indices;
   Eigen::Vector4f centroid;
-  Eigen::Matrix3f covariance_matrix;
+  Eigen::Matrix3f covariance_matrix = Eigen::Matrix3f::Random();
+  const Eigen::Matrix3f old_covariance_matrix = covariance_matrix;
 
   centroid [0] = 0;
   centroid [1] = 0;
@@ -339,21 +358,25 @@ TEST (PCL, computeCovarianceMatrix)
   // test empty cloud which is dense
   cloud.is_dense = true;
   EXPECT_EQ (computeCovarianceMatrix (cloud, centroid, covariance_matrix), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
 
   // test empty cloud non_dense
   cloud.is_dense = false;
   EXPECT_EQ (computeCovarianceMatrix (cloud, centroid, covariance_matrix), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
 
-  // test non-empty cloud non_dense
+  // test non-empty cloud non_dense (with only invalid points)
   point.x = point.y = point.z = std::numeric_limits<float>::quiet_NaN ();
   cloud.push_back (point);
   EXPECT_EQ (computeCovarianceMatrix (cloud, centroid, covariance_matrix), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
 
-  // test non-empty cloud non_dense
+  // test non-empty cloud non_dense (with only invalid points)
   point.x = point.y = point.z = std::numeric_limits<float>::quiet_NaN ();
   cloud.push_back (point);
   indices.push_back (1);
   EXPECT_EQ (computeCovarianceMatrix (cloud, indices, centroid, covariance_matrix), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
 
   cloud.clear ();
   indices.clear ();
@@ -446,7 +469,8 @@ TEST (PCL, computeCovarianceMatrixNormalized)
   PointXYZ point;
   Indices indices;
   Eigen::Vector4f centroid;
-  Eigen::Matrix3f covariance_matrix;
+  Eigen::Matrix3f covariance_matrix = Eigen::Matrix3f::Random();
+  const Eigen::Matrix3f old_covariance_matrix = covariance_matrix;
 
   centroid [0] = 0;
   centroid [1] = 0;
@@ -455,21 +479,25 @@ TEST (PCL, computeCovarianceMatrixNormalized)
   // test empty cloud which is dense
   cloud.is_dense = true;
   EXPECT_EQ (computeCovarianceMatrixNormalized (cloud, centroid, covariance_matrix), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
 
   // test empty cloud non_dense
   cloud.is_dense = false;
   EXPECT_EQ (computeCovarianceMatrixNormalized (cloud, centroid, covariance_matrix), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
 
   // test non-empty cloud non_dense
   point.x = point.y = point.z = std::numeric_limits<float>::quiet_NaN ();
   cloud.push_back (point);
   EXPECT_EQ (computeCovarianceMatrixNormalized (cloud, centroid, covariance_matrix), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
 
   // test non-empty cloud non_dense
   point.x = point.y = point.z = std::numeric_limits<float>::quiet_NaN ();
   cloud.push_back (point);
   indices.push_back (1);
   EXPECT_EQ (computeCovarianceMatrixNormalized (cloud, indices, centroid, covariance_matrix), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
 
   cloud.clear ();
   indices.clear ();
@@ -563,26 +591,31 @@ TEST (PCL, computeDemeanedCovariance)
   PointCloud<PointXYZ> cloud;
   PointXYZ point;
   Indices indices;
-  Eigen::Matrix3f covariance_matrix;
+  Eigen::Matrix3f covariance_matrix = Eigen::Matrix3f::Random();
+  const Eigen::Matrix3f old_covariance_matrix = covariance_matrix;
 
   // test empty cloud which is dense
   cloud.is_dense = true;
   EXPECT_EQ (computeCovarianceMatrix (cloud, covariance_matrix), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
 
   // test empty cloud non_dense
   cloud.is_dense = false;
   EXPECT_EQ (computeCovarianceMatrix (cloud, covariance_matrix), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
 
   // test non-empty cloud non_dense
   point.x = point.y = point.z = std::numeric_limits<float>::quiet_NaN ();
   cloud.push_back (point);
   EXPECT_EQ (computeCovarianceMatrix (cloud, covariance_matrix), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
 
   // test non-empty cloud non_dense
   point.x = point.y = point.z = std::numeric_limits<float>::quiet_NaN ();
   cloud.push_back (point);
   indices.push_back (1);
   EXPECT_EQ (computeCovarianceMatrix (cloud, indices, covariance_matrix), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
 
   cloud.clear ();
   indices.clear ();
@@ -669,27 +702,37 @@ TEST (PCL, computeMeanAndCovariance)
   PointCloud<PointXYZ> cloud;
   PointXYZ point;
   Indices indices;
-  Eigen::Matrix3f covariance_matrix;
-  Eigen::Vector4f centroid;
+  Eigen::Matrix3f covariance_matrix = Eigen::Matrix3f::Random();
+  Eigen::Vector4f centroid = Eigen::Vector4f::Random();
+  const Eigen::Matrix3f old_covariance_matrix = covariance_matrix;
+  const Eigen::Vector4f old_centroid = centroid;
 
   // test empty cloud which is dense
   cloud.is_dense = true;
   EXPECT_EQ (computeMeanAndCovarianceMatrix (cloud, covariance_matrix, centroid), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
+  EXPECT_EQ (old_centroid, centroid); // centroid remains unchanged
 
   // test empty cloud non_dense
   cloud.is_dense = false;
   EXPECT_EQ (computeMeanAndCovarianceMatrix (cloud, covariance_matrix, centroid), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
+  EXPECT_EQ (old_centroid, centroid); // centroid remains unchanged
 
   // test non-empty cloud non_dense
   point.x = point.y = point.z = std::numeric_limits<float>::quiet_NaN ();
   cloud.push_back (point);
   EXPECT_EQ (computeMeanAndCovarianceMatrix (cloud, covariance_matrix, centroid), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
+  EXPECT_EQ (old_centroid, centroid); // centroid remains unchanged
 
   // test non-empty cloud non_dense
   point.x = point.y = point.z = std::numeric_limits<float>::quiet_NaN ();
   cloud.push_back (point);
   indices.push_back (1);
   EXPECT_EQ (computeMeanAndCovarianceMatrix (cloud, indices, covariance_matrix, centroid), 0);
+  EXPECT_EQ (old_covariance_matrix, covariance_matrix); // cov. matrix remains unchanged
+  EXPECT_EQ (old_centroid, centroid); // centroid remains unchanged
 
   cloud.clear ();
   indices.clear ();


### PR DESCRIPTION
Make sure that output centroid/covariance matrix are unchanged if cloud doesn't contain any valid points (as the documentation says)
The changes are taken from https://github.com/PointCloudLibrary/pcl/pull/4106 . Thanks to @sthoduka for writing them. The other changes from that PR are not needed any more since a fix was merged in https://github.com/PointCloudLibrary/pcl/pull/5181 
Closes #4106