### PR TITLE
Fix segfault of NDT for sparse clouds

### DIFF
--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -223,7 +223,7 @@ namespace pcl
         }
         else
         {
-          PCL_WARN ("%s: Covariance calculation requires at least 3 points, setting Min Point per Voxel to 3 ", this->getClassName ().c_str ());
+          PCL_WARN ("[%s::setMinPointPerVoxel] Covariance calculation requires at least 3 points, setting Min Point per Voxel to 3\n", this->getClassName ().c_str ());
           min_points_per_voxel_ = 3;
         }
       }
@@ -267,10 +267,15 @@ namespace pcl
 
         voxel_centroids_ = PointCloudPtr (new PointCloud (output));
 
-        if (searchable_ && !voxel_centroids_->empty ())
+        if (searchable_)
         {
-          // Initiates kdtree of the centroids of voxels containing a sufficient number of points
-          kdtree_.setInputCloud (voxel_centroids_);
+          if (voxel_centroids_->empty ()) {
+            PCL_WARN ("[%s::filter] No voxels with a sufficient number of points. Grid will not be searchable. You can try reducing the min number of points required per voxel or increasing the voxel/leaf size.\n", this->getClassName ().c_str ());
+            searchable_ = false;
+          } else {
+            // Initiates kdtree of the centroids of voxels containing a sufficient number of points
+            kdtree_.setInputCloud (voxel_centroids_);
+          }
         }
       }
 
@@ -284,10 +289,15 @@ namespace pcl
         voxel_centroids_ = PointCloudPtr (new PointCloud);
         applyFilter (*voxel_centroids_);
 
-        if (searchable_ && !voxel_centroids_->empty ())
+        if (searchable_)
         {
-          // Initiates kdtree of the centroids of voxels containing a sufficient number of points
-          kdtree_.setInputCloud (voxel_centroids_);
+          if (voxel_centroids_->empty ()) {
+            PCL_WARN ("[%s::filter] No voxels with a sufficient number of points. Grid will not be searchable. You can try reducing the min number of points required per voxel or increasing the voxel/leaf size\n", this->getClassName ().c_str ());
+            searchable_ = false;
+          } else {
+            // Initiates kdtree of the centroids of voxels containing a sufficient number of points
+            kdtree_.setInputCloud (voxel_centroids_);
+          }
         }
       }
 
@@ -449,7 +459,7 @@ namespace pcl
         // Check if kdtree has been built
         if (!searchable_)
         {
-          PCL_WARN ("%s: Not Searchable", this->getClassName ().c_str ());
+          PCL_WARN ("[%s::nearestKSearch] Not Searchable\n", this->getClassName ().c_str ());
           return 0;
         }
 
@@ -508,7 +518,7 @@ namespace pcl
         // Check if kdtree has been built
         if (!searchable_)
         {
-          PCL_WARN ("%s: Not Searchable", this->getClassName ().c_str ());
+          PCL_WARN ("[%s::radiusSearch] Not Searchable\n", this->getClassName ().c_str ());
           return 0;
         }
 

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -76,6 +76,11 @@ NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeTransform
 {
   nr_iterations_ = 0;
   converged_ = false;
+  if (target_cells_.getCentroids()->empty()) {
+    PCL_ERROR("[%s::computeTransformation] Voxel grid is not searchable!\n",
+              getClassName().c_str());
+    return;
+  }
 
   // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
   const double gauss_c1 = 10 * (1 - outlier_ratio_);

--- a/registration/include/pcl/registration/ndt.h
+++ b/registration/include/pcl/registration/ndt.h
@@ -131,6 +131,18 @@ public:
     }
   }
 
+  /** \brief Set the minimum number of points required for a cell to be used (must be 3
+   * or greater for covariance calculation). Calls the function of the underlying
+   * VoxelGridCovariance. This function must be called before `setInputTarget` and
+   * `setResolution`. \param[in] min_points_per_voxel the minimum number of points
+   * required for a voxel to be used
+   */
+  inline void
+  setMinPointPerVoxel(unsigned int min_points_per_voxel)
+  {
+    target_cells_.setMinPointPerVoxel(min_points_per_voxel);
+  }
+
   /** \brief Get voxel grid resolution.
    * \return side length of voxels
    */


### PR DESCRIPTION
- VoxelGridCovariance: if searchable requested but no valid voxel centers, print warning and set searchable to false
- in NDT, check if VoxelGridCovariance is searchable, and do not start registration if not searchable
- add function to NDT to change MinPointPerVoxel of VoxelGridCovariance

Fixes https://github.com/PointCloudLibrary/pcl/issues/5392
Fixes https://github.com/PointCloudLibrary/pcl/issues/2333