### PR TITLE
Add empty point cloud support at pcd file.

### DIFF
--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -113,8 +113,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
 {
   if (cloud.empty ())
   {
-    throw pcl::IOException ("[pcl::PCDWriter::writeBinary] Input point cloud has no data!");
-    return (-1);
+    PCL_WARN ("[pcl::PCDWriter::writeBinary] Input point cloud has no data!");
   }
   int data_idx = 0;
   std::ostringstream oss;
@@ -246,8 +245,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
 {
   if (cloud.empty ())
   {
-    throw pcl::IOException ("[pcl::PCDWriter::writeBinaryCompressed] Input point cloud has no data!");
-    return (-1);
+    PCL_WARN ("[pcl::PCDWriter::writeBinaryCompressed] Input point cloud has no data!");
   }
   int data_idx = 0;
   std::ostringstream oss;
@@ -341,29 +339,35 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
   }
 
   char* temp_buf = static_cast<char*> (malloc (static_cast<std::size_t> (static_cast<float> (data_size) * 1.5f + 8.0f)));
+  unsigned int compressed_final_size = 0;
+  if (data_size != 0) {
   // Compress the valid data
   unsigned int compressed_size = pcl::lzfCompress (only_valid_data, 
                                                    static_cast<std::uint32_t> (data_size), 
                                                    &temp_buf[8], 
                                                    static_cast<std::uint32_t> (static_cast<float>(data_size) * 1.5f));
-  unsigned int compressed_final_size = 0;
-  // Was the compression successful?
-  if (compressed_size)
-  {
-    char *header = &temp_buf[0];
-    memcpy (&header[0], &compressed_size, sizeof (unsigned int));
-    memcpy (&header[4], &data_size, sizeof (unsigned int));
-    data_size = compressed_size + 8;
-    compressed_final_size = static_cast<std::uint32_t> (data_size) + data_idx;
+    // Was the compression successful?
+    if (compressed_size)
+    {
+      char *header = &temp_buf[0];
+      memcpy (&header[0], &compressed_size, sizeof (unsigned int));
+      memcpy (&header[4], &data_size, sizeof (unsigned int));
+      data_size = compressed_size + 8;
+      compressed_final_size = static_cast<std::uint32_t> (data_size) + data_idx;
+    }
+    else
+    {
+  #ifndef _WIN32
+      io::raw_close (fd);
+  #endif
+      resetLockingPermissions (file_name, file_lock);
+      return (-1);
+    }
   }
   else
   {
-#ifndef _WIN32
-    io::raw_close (fd);
-#endif
-    resetLockingPermissions (file_name, file_lock);
-    throw pcl::IOException ("[pcl::PCDWriter::writeBinaryCompressed] Error during compression!");
-    return (-1);
+    // empty cloud case
+    compressed_final_size = 8 + data_idx;
   }
 
   // Prepare the map
@@ -440,8 +444,7 @@ pcl::PCDWriter::writeASCII (const std::string &file_name, const pcl::PointCloud<
 {
   if (cloud.empty ())
   {
-    throw pcl::IOException ("[pcl::PCDWriter::writeASCII] Input point cloud has no data!");
-    return (-1);
+    PCL_WARN ("[pcl::PCDWriter::writeASCII] Input point cloud has no data!");
   }
 
   if (cloud.width * cloud.height != cloud.size ())
@@ -594,8 +597,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
 {
   if (cloud.empty () || indices.empty ())
   {
-    throw pcl::IOException ("[pcl::PCDWriter::writeBinary] Input point cloud has no data or empty indices given!");
-    return (-1);
+    PCL_WARN ("[pcl::PCDWriter::writeBinary] Input point cloud has no data or empty indices given!");
   }
   int data_idx = 0;
   std::ostringstream oss;
@@ -725,8 +727,7 @@ pcl::PCDWriter::writeASCII (const std::string &file_name,
 {
   if (cloud.empty () || indices.empty ())
   {
-    throw pcl::IOException ("[pcl::PCDWriter::writeASCII] Input point cloud has no data or empty indices given!");
-    return (-1);
+    PCL_WARN ("[pcl::PCDWriter::writeASCII] Input point cloud has no data or empty indices given!");
   }
 
   if (cloud.width * cloud.height != cloud.size ())

--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -369,6 +369,10 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
   {
     // empty cloud case
     compressed_final_size = 8 + data_idx;
+    std::uint32_t *header = reinterpret_cast<std::uint32_t*>(&temp_buf[0]);
+    header[0] = 0; // compressed_size is 0
+    header[1] = 0; // data_size is 0
+    data_size = 8; // correct data_size to header size
   }
 
   // Prepare the map

--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -347,7 +347,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
                                                    &temp_buf[8], 
                                                    static_cast<std::uint32_t> (static_cast<float>(data_size) * 1.5f));
     // Was the compression successful?
-    if (compressed_size)
+    if (compressed_size > 0)
     {
       char *header = &temp_buf[0];
       memcpy (&header[0], &compressed_size, sizeof (unsigned int));

--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -369,7 +369,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
   {
     // empty cloud case
     compressed_final_size = 8 + data_idx;
-    std::uint32_t *header = reinterpret_cast<std::uint32_t*>(&temp_buf[0]);
+    auto *header = reinterpret_cast<std::uint32_t*>(&temp_buf[0]);
     header[0] = 0; // compressed_size is 0
     header[1] = 0; // data_size is 0
     data_size = 8; // correct data_size to header size

--- a/io/include/pcl/io/impl/pcd_io.hpp
+++ b/io/include/pcl/io/impl/pcd_io.hpp
@@ -113,7 +113,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
 {
   if (cloud.empty ())
   {
-    PCL_WARN ("[pcl::PCDWriter::writeBinary] Input point cloud has no data!");
+    PCL_WARN ("[pcl::PCDWriter::writeBinary] Input point cloud has no data!\n");
   }
   int data_idx = 0;
   std::ostringstream oss;
@@ -245,7 +245,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
 {
   if (cloud.empty ())
   {
-    PCL_WARN ("[pcl::PCDWriter::writeBinaryCompressed] Input point cloud has no data!");
+    PCL_WARN ("[pcl::PCDWriter::writeBinaryCompressed] Input point cloud has no data!\n");
   }
   int data_idx = 0;
   std::ostringstream oss;
@@ -361,6 +361,7 @@ pcl::PCDWriter::writeBinaryCompressed (const std::string &file_name,
       io::raw_close (fd);
   #endif
       resetLockingPermissions (file_name, file_lock);
+      PCL_WARN("[pcl::PCDWriter::writeBinaryCompressed] Error during compression!\n");
       return (-1);
     }
   }
@@ -444,7 +445,7 @@ pcl::PCDWriter::writeASCII (const std::string &file_name, const pcl::PointCloud<
 {
   if (cloud.empty ())
   {
-    PCL_WARN ("[pcl::PCDWriter::writeASCII] Input point cloud has no data!");
+    PCL_WARN ("[pcl::PCDWriter::writeASCII] Input point cloud has no data!\n");
   }
 
   if (cloud.width * cloud.height != cloud.size ())
@@ -597,7 +598,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name,
 {
   if (cloud.empty () || indices.empty ())
   {
-    PCL_WARN ("[pcl::PCDWriter::writeBinary] Input point cloud has no data or empty indices given!");
+    PCL_WARN ("[pcl::PCDWriter::writeBinary] Input point cloud has no data or empty indices given!\n");
   }
   int data_idx = 0;
   std::ostringstream oss;
@@ -727,7 +728,7 @@ pcl::PCDWriter::writeASCII (const std::string &file_name,
 {
   if (cloud.empty () || indices.empty ())
   {
-    PCL_WARN ("[pcl::PCDWriter::writeASCII] Input point cloud has no data or empty indices given!");
+    PCL_WARN ("[pcl::PCDWriter::writeASCII] Input point cloud has no data or empty indices given!\n");
   }
 
   if (cloud.width * cloud.height != cloud.size ())

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -634,10 +634,7 @@ pcl::PCDReader::readBodyBinary (const unsigned char *map, pcl::PCLPointCloud2 &c
     memcpy (&cloud.data[0], &map[0] + data_idx, cloud.data.size ());
 
   // Extra checks (not needed for ASCII)
-  int point_size = 0;
-  if (cloud.width * cloud.height != 0) {
-    point_size = static_cast<int> (cloud.data.size () / (cloud.height * cloud.width));
-  }
+  int point_size = (cloud.width * cloud.height == 0) ? 0 : static_cast<int> (cloud.data.size () / (cloud.height * cloud.width));
   // Once copied, we need to go over each field and check if it has NaN/Inf values and assign cloud.is_dense to true or false
   for (uindex_t i = 0; i < cloud.width * cloud.height; ++i)
   {
@@ -1153,13 +1150,7 @@ pcl::PCDWriter::writeASCII (const std::string &file_name, const pcl::PCLPointClo
   setLockingPermissions (file_name, file_lock);
 
   int nr_points  = cloud.width * cloud.height;
-  int point_size = 0;
-  if (nr_points != 0) {
-    point_size = static_cast<int> (cloud.data.size () / nr_points);
-  } else {
-    // Do nothing
-    // If nr_points is equal to 0, there is no need to set point_size correctly
-  }
+  int point_size = (nr_points == 0) ? 0 : static_cast<int> (cloud.data.size () / nr_points);
 
   // Write the header information
   fs << generateHeaderASCII (cloud, origin, orientation) << "DATA ascii\n";

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -1461,6 +1461,10 @@ pcl::PCDWriter::writeBinaryCompressed (std::ostream &os, const pcl::PCLPointClou
     memcpy (&temp_buf[0], &compressed_size, 4);
     memcpy (&temp_buf[4], &data_size, 4);
     temp_buf.resize (compressed_size + 8);
+  } else {
+    std::uint32_t *header = reinterpret_cast<std::uint32_t*>(&temp_buf[0]);
+    header[0] = 0; // compressed_size is 0
+    header[1] = 0; // data_size is 0
   }
 
   os.imbue (std::locale::classic ());

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -284,6 +284,8 @@ pcl::PCDReader::readHeader (std::istream &fs, pcl::PCLPointCloud2 &cloud,
       if (line_type.substr (0, 6) == "HEIGHT")
       {
         sstream >> cloud.height;
+        if (sstream.fail ())
+          throw "Invalid HEIGHT value specified.";
         height_read = true;
         continue;
       }

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -122,6 +122,10 @@ pcl::PCDReader::readHeader (std::istream &fs, pcl::PCLPointCloud2 &cloud,
   // By default, assume that there are _no_ invalid (e.g., NaN) points
   //cloud.is_dense = true;
 
+  // Used to determine if a value has been read
+  bool width_read = false;
+  bool height_read = false;
+
   std::size_t nr_points = 0;
   std::string line;
 
@@ -270,6 +274,7 @@ pcl::PCDReader::readHeader (std::istream &fs, pcl::PCLPointCloud2 &cloud,
         sstream >> cloud.width;
         if (sstream.fail ())
           throw "Invalid WIDTH value specified.";
+        width_read = true;
         if (cloud.point_step != 0)
           cloud.row_step = cloud.point_step * cloud.width;      // row_step only makes sense for organized datasets
         continue;
@@ -279,6 +284,7 @@ pcl::PCDReader::readHeader (std::istream &fs, pcl::PCLPointCloud2 &cloud,
       if (line_type.substr (0, 6) == "HEIGHT")
       {
         sstream >> cloud.height;
+        height_read = true;
         continue;
       }
 
@@ -328,15 +334,13 @@ pcl::PCDReader::readHeader (std::istream &fs, pcl::PCLPointCloud2 &cloud,
     return (-1);
   }
 
-  // Exit early: if no points have been given, there's no sense to read or check anything anymore
   if (nr_points == 0)
   {
-    PCL_ERROR ("[pcl::PCDReader::readHeader] No points to read\n");
-    return (-1);
+    PCL_WARN ("[pcl::PCDReader::readHeader] No points to read\n");
   }
   
   // Compatibility with older PCD file versions
-  if (cloud.width == 0 && cloud.height == 0)
+  if (!width_read && !height_read)
   {
     cloud.width  = nr_points;
     cloud.height = 1;
@@ -345,7 +349,7 @@ pcl::PCDReader::readHeader (std::istream &fs, pcl::PCLPointCloud2 &cloud,
   //assert (cloud.row_step != 0);       // If row_step = 0, either point_step was not set or width is 0
 
   // if both height/width are not given, assume an unorganized dataset
-  if (cloud.height == 0)
+  if (!height_read)
   {
     cloud.height = 1;
     PCL_WARN ("[pcl::PCDReader::readHeader] no HEIGHT given, setting to 1 (unorganized).\n");
@@ -628,7 +632,10 @@ pcl::PCDReader::readBodyBinary (const unsigned char *map, pcl::PCLPointCloud2 &c
     memcpy (&cloud.data[0], &map[0] + data_idx, cloud.data.size ());
 
   // Extra checks (not needed for ASCII)
-  int point_size = static_cast<int> (cloud.data.size () / (cloud.height * cloud.width));
+  int point_size = 0;
+  if (cloud.width * cloud.height != 0) {
+    point_size = static_cast<int> (cloud.data.size () / (cloud.height * cloud.width));
+  }
   // Once copied, we need to go over each field and check if it has NaN/Inf values and assign cloud.is_dense to true or false
   for (uindex_t i = 0; i < cloud.width * cloud.height; ++i)
   {
@@ -1122,7 +1129,11 @@ pcl::PCDWriter::writeASCII (const std::string &file_name, const pcl::PCLPointClo
 {
   if (cloud.data.empty ())
   {
-    PCL_ERROR ("[pcl::PCDWriter::writeASCII] Input point cloud has no data!\n");
+    PCL_WARN ("[pcl::PCDWriter::writeASCII] Input point cloud has no data!\n");
+  }
+  if (cloud.fields.empty())
+  {
+    PCL_ERROR ("[pcl::PCDWriter::writeASCII] Input point cloud has no field data!\n");
     return (-1);
   }
 
@@ -1140,7 +1151,13 @@ pcl::PCDWriter::writeASCII (const std::string &file_name, const pcl::PCLPointClo
   setLockingPermissions (file_name, file_lock);
 
   int nr_points  = cloud.width * cloud.height;
-  int point_size = static_cast<int> (cloud.data.size () / nr_points);
+  int point_size = 0;
+  if (nr_points != 0) {
+    point_size = static_cast<int> (cloud.data.size () / nr_points);
+  } else {
+    // Do nothing
+    // If nr_points is equal to 0, there is no need to set point_size correctly
+  }
 
   // Write the header information
   fs << generateHeaderASCII (cloud, origin, orientation) << "DATA ascii\n";
@@ -1241,9 +1258,14 @@ pcl::PCDWriter::writeBinary (const std::string &file_name, const pcl::PCLPointCl
 {
   if (cloud.data.empty ())
   {
-    PCL_ERROR ("[pcl::PCDWriter::writeBinary] Input point cloud has no data!\n");
+    PCL_WARN ("[pcl::PCDWriter::writeBinary] Input point cloud has no data!\n");
+  }
+  if (cloud.fields.empty())
+  {
+    PCL_ERROR ("[pcl::PCDWriter::writeBinary] Input point cloud has no field data!\n");
     return (-1);
   }
+
   std::streamoff data_idx = 0;
   std::ostringstream oss;
   oss.imbue (std::locale::classic ());
@@ -1352,9 +1374,14 @@ pcl::PCDWriter::writeBinaryCompressed (std::ostream &os, const pcl::PCLPointClou
 {
   if (cloud.data.empty ())
   {
-    PCL_ERROR ("[pcl::PCDWriter::writeBinaryCompressed] Input point cloud has no data!\n");
+    PCL_WARN ("[pcl::PCDWriter::writeBinaryCompressed] Input point cloud has no data!\n");
+  }
+  if (cloud.fields.empty())
+  {
+    PCL_ERROR ("[pcl::PCDWriter::writeBinaryCompressed] Input point cloud has no field data!\n");
     return (-1);
   }
+
 
   if (generateHeaderBinaryCompressed (os, cloud, origin, orientation))
   {
@@ -1427,20 +1454,21 @@ pcl::PCDWriter::writeBinaryCompressed (std::ostream &os, const pcl::PCLPointClou
   }
 
   std::vector<char> temp_buf (data_size * 3 / 2 + 8);
-  // Compress the valid data
-  unsigned int compressed_size = pcl::lzfCompress (&only_valid_data.front (), 
-                                                   static_cast<unsigned int> (data_size), 
-                                                   &temp_buf[8], 
-                                                   data_size * 3 / 2);
-  // Was the compression successful?
-  if (compressed_size == 0)
-  {
-    return (-1);
+  if (data_size != 0) {
+    // Compress the valid data
+    unsigned int compressed_size = pcl::lzfCompress (&only_valid_data.front (),
+                                                    static_cast<unsigned int> (data_size),
+                                                    &temp_buf[8],
+                                                    data_size * 3 / 2);
+    // Was the compression successful?
+    if (compressed_size == 0)
+    {
+      return (-1);
+    }
+    memcpy (&temp_buf[0], &compressed_size, 4);
+    memcpy (&temp_buf[4], &data_size, 4);
+    temp_buf.resize (compressed_size + 8);
   }
-
-  memcpy (&temp_buf[0], &compressed_size, 4);
-  memcpy (&temp_buf[4], &data_size, 4);
-  temp_buf.resize (compressed_size + 8);
 
   os.imbue (std::locale::classic ());
   os << "DATA binary_compressed\n";

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -1462,7 +1462,7 @@ pcl::PCDWriter::writeBinaryCompressed (std::ostream &os, const pcl::PCLPointClou
     memcpy (&temp_buf[4], &data_size, 4);
     temp_buf.resize (compressed_size + 8);
   } else {
-    std::uint32_t *header = reinterpret_cast<std::uint32_t*>(&temp_buf[0]);
+    auto *header = reinterpret_cast<std::uint32_t*>(&temp_buf[0]);
     header[0] = 0; // compressed_size is 0
     header[1] = 0; // data_size is 0
   }

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -670,40 +670,44 @@ TEST (PCL, EmptyCloudToPCD)
   pcl::PointCloud<pcl::PointXYZ> cloud_in_ascii;
   cloud_in_ascii.width = 10; // Make sure loadPCDFile overwrites this
   cloud_in_ascii.height = 10; // Make sure loadPCDFile overwrites this
-  pcl::io::loadPCDFile("ascii.pcd", cloud_in_ascii);
-  remove("ascii.pcd");
+  res = pcl::io::loadPCDFile("ascii.pcd", cloud_in_ascii);
+  EXPECT_EQ (0, res);
   EXPECT_EQ(cloud.width, cloud_in_ascii.width);
   EXPECT_EQ(cloud.height, cloud_in_ascii.height);
+  remove ("ascii.pcd");
   
   pcl::Indices indices;
   res = pcl::io::savePCDFile("ascii_indices.pcd", cloud, indices);
   EXPECT_EQ (0, res);
   pcl::PointCloud<pcl::PointXYZ> cloud_in_indices;
   cloud_in_indices.width = 10; // Make sure loadPCDFile overwrites this
-  pcl::io::loadPCDFile("ascii_indices.pcd", cloud_in_indices);
-  remove("ascii_indices.pcd");
+  res = pcl::io::loadPCDFile("ascii_indices.pcd", cloud_in_indices);
+  EXPECT_EQ (0, res);
   EXPECT_EQ(cloud.width, cloud_in_indices.width);
   EXPECT_EQ(1, cloud_in_indices.height); // if we specify indices height must be 1
+  remove ("ascii_indices.pcd");
   
   res = pcl::io::savePCDFileBinary("binary.pcd", cloud);
   EXPECT_EQ (0, res);
   pcl::PointCloud<pcl::PointXYZ> cloud_in_binary;
   cloud_in_binary.width = 10; // Make sure loadPCDFile overwrites this
   cloud_in_binary.height = 10; // Make sure loadPCDFile overwrites this
-  pcl::io::loadPCDFile("binary.pcd", cloud_in_binary);
-  remove("binary.pcd");
+  res = pcl::io::loadPCDFile("binary.pcd", cloud_in_binary);
+  EXPECT_EQ (0, res);
   EXPECT_EQ(cloud.width, cloud_in_binary.width);
   EXPECT_EQ(cloud.height, cloud_in_binary.height);
+  remove ("binary.pcd");
 
   res = pcl::io::savePCDFileBinaryCompressed("binary_compressed.pcd", cloud);
   EXPECT_EQ (0, res);
   pcl::PointCloud<pcl::PointXYZ> cloud_in_compressed;
   cloud_in_compressed.width = 10; // Make sure loadPCDFile overwrites this
   cloud_in_compressed.height = 10; // Make sure loadPCDFile overwrites this
-  pcl::io::loadPCDFile("binary_compressed.pcd", cloud_in_compressed);
-  remove("binary_compressed.pcd");
+  res = pcl::io::loadPCDFile("binary_compressed.pcd", cloud_in_compressed);
+  EXPECT_EQ (0, res);
   EXPECT_EQ(cloud.width, cloud_in_compressed.width);
   EXPECT_EQ(cloud.height, cloud_in_compressed.height);
+  remove ("binary_compressed.pcd");
 
   // Data initialization for pcl::PCLPointCloud2 interface
   pcl::PCLPointCloud2 cloud2;
@@ -727,10 +731,10 @@ TEST (PCL, EmptyCloudToPCD)
   cloud2_in_ascii.width = 10;
   cloud2_in_ascii.height = 10;
   res = loadPCDFile ("ascii_pc2.pcd", cloud2_in_ascii);
-  remove("ascii_pc2.pcd");
-  EXPECT_NE (-1, res);
+  EXPECT_EQ (0, res);
   EXPECT_EQ (cloud2.width, cloud2_in_ascii.width);
   EXPECT_EQ (cloud2.height, cloud2_in_ascii.height);
+  remove ("ascii_pc2.pcd");
 
   res = pcl::io::savePCDFile ("binary_pc2.pcd", cloud2,
                               Eigen::Vector4f::Zero (),
@@ -742,10 +746,10 @@ TEST (PCL, EmptyCloudToPCD)
   cloud2_in_binary.width = 10;
   cloud2_in_binary.height = 10;
   res = loadPCDFile ("binary_pc2.pcd", cloud2_in_binary);
-  remove("binary_pc2.pcd");
-  EXPECT_NE (-1, res);
+  EXPECT_EQ (0, res);
   EXPECT_EQ (cloud2.width, cloud2_in_binary.width);
   EXPECT_EQ (cloud2.height, cloud2_in_binary.height);
+  remove ("binary_pc2.pcd");
 
   PCDWriter w;
   res = w.writeBinaryCompressed ("compressed_pc2.pcd", cloud2);
@@ -754,10 +758,10 @@ TEST (PCL, EmptyCloudToPCD)
   cloud2_in_compressed.width = 10;
   cloud2_in_compressed.height = 10;
   res = loadPCDFile ("compressed_pc2.pcd", cloud2_in_compressed);
-  remove("compressed_pc2.pcd");
-  EXPECT_NE (-1, res);
+  EXPECT_EQ (0, res);
   EXPECT_EQ (cloud2.width, cloud2_in_compressed.width);
   EXPECT_EQ (cloud2.height, cloud2_in_compressed.height);
+  remove ("compressed_pc2.pcd");
 
   // Test when WIDTH and HEIGHT are not defined
   std::ofstream fs;
@@ -775,12 +779,12 @@ TEST (PCL, EmptyCloudToPCD)
   fs.close ();
   pcl::PCLPointCloud2 incomplete_cloud2_in;
   res = loadPCDFile ("incomplete_ascii.pcd", incomplete_cloud2_in);
-  remove("incomplete_ascii.pcd");
-  EXPECT_NE (-1, res);
+  EXPECT_EQ (0, res);
   EXPECT_EQ (2, incomplete_cloud2_in.width);
   EXPECT_EQ (1, incomplete_cloud2_in.height);
   EXPECT_EQ (true, bool (incomplete_cloud2_in.is_dense));
   EXPECT_EQ (2 * 4 * 4, std::size_t (incomplete_cloud2_in.data.size ()));
+  remove ("incomplete_ascii.pcd");
 
   // Test when HEIGHT are not defined
   fs.open ("incomplete_height_ascii.pcd");
@@ -798,12 +802,12 @@ TEST (PCL, EmptyCloudToPCD)
   fs.close ();
   pcl::PCLPointCloud2 incomplete_height_cloud2_in;
   res = loadPCDFile ("incomplete_height_ascii.pcd", incomplete_height_cloud2_in);
-  remove("incomplete_height_ascii.pcd");
-  EXPECT_NE (-1, res);
+  EXPECT_EQ (0, res);
   EXPECT_EQ (2, incomplete_height_cloud2_in.width);
   EXPECT_EQ (1, incomplete_height_cloud2_in.height);
   EXPECT_EQ (true, bool (incomplete_height_cloud2_in.is_dense));
   EXPECT_EQ (2 * 4 * 4, std::size_t (incomplete_height_cloud2_in.data.size ()));
+  remove ("incomplete_height_ascii.pcd");
 
   // Test invalid height
   fs.open ("invalid_height_ascii.pcd");
@@ -822,27 +826,27 @@ TEST (PCL, EmptyCloudToPCD)
   fs.close ();
   pcl::PCLPointCloud2 invalid_height_cloud2_in;
   res = loadPCDFile ("invalid_height_ascii.pcd", invalid_height_cloud2_in);
-  remove("invalid_height_ascii.pcd");
   EXPECT_EQ (-1, res);
+  remove ("invalid_height_ascii.pcd");
 
   // Test for no field data
   pcl::PCLPointCloud2 empty_cloud;
   res = pcl::io::savePCDFile ("empty_cloud_ascii.pcd", empty_cloud,
                               Eigen::Vector4f::Zero (),
                               Eigen::Quaternionf::Identity ());
-  remove("empty_cloud_ascii.pcd");
   EXPECT_EQ (-1, res);
+  remove ("empty_cloud_ascii.pcd");
 
   res = pcl::io::savePCDFile ("empty_cloud_binary.pcd", empty_cloud,
                               Eigen::Vector4f::Zero (),
                               Eigen::Quaternionf::Identity (),
                               true);
-  remove("empty_cloud_binary.pcd");
   EXPECT_EQ (-1, res);
+  remove ("empty_cloud_binary.pcd");
 
   EXPECT_THROW(w.writeBinaryCompressed ("empty_cloud_compressed.pcd", empty_cloud),
                pcl::IOException);
-  remove("empty_cloud_compressed.pcd");
+  remove ("empty_cloud_compressed.pcd");
 }
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, PCDReaderWriter)

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -805,6 +805,26 @@ TEST (PCL, EmptyCloudToPCD)
   EXPECT_EQ (true, bool (incomplete_height_cloud2_in.is_dense));
   EXPECT_EQ (2 * 4 * 4, std::size_t (incomplete_height_cloud2_in.data.size ()));
 
+  // Test invalid height
+  fs.open ("invalid_height_ascii.pcd");
+  fs << "# .PCD v0.7 - Point Cloud Data file format\n"
+        "VERSION 0.7\n"
+        "FIELDS x y z intensity\n"
+        "SIZE 4 4 4 4\n"
+        "TYPE F F F F\n"
+        "COUNT 1 1 1 1\n"
+        "WIDTH 2\n"
+        "HEIGHT a\n"
+        "POINTS 2\n"
+        "DATA ascii\n"
+        "1 2 3 4\n"
+        "5 6 7 8";
+  fs.close ();
+  pcl::PCLPointCloud2 invalid_height_cloud2_in;
+  res = loadPCDFile ("invalid_height_ascii.pcd", invalid_height_cloud2_in);
+  remove("invalid_height_ascii.pcd");
+  EXPECT_EQ (-1, res);
+
   // Test for no field data
   pcl::PCLPointCloud2 empty_cloud;
   res = pcl::io::savePCDFile ("empty_cloud_ascii.pcd", empty_cloud,


### PR DESCRIPTION
write methods
* Return warning instead of error when size is 0
* Handling of 0 div
* Return an error when given a PointCloud2 class with field size of 0

PCDReder::readHeader
* Modified to use bool variable instead of value
  to determine unread value of width and height
* Not to return an error when the size is 0
* Handling of 0 div