### PR TITLE
[octree] fix definition of ConstLeafNodeIterator

### DIFF
--- a/octree/include/pcl/octree/octree_base.h
+++ b/octree/include/pcl/octree/octree_base.h
@@ -155,7 +155,7 @@ public:
   // LeafNodeIterator and ConstLeafNodeIterator are deprecated.
   // Please use LeafNodeDepthFirstIterator and ConstLeafNodeDepthFirstIterator instead.
   using LeafNodeIterator = OctreeLeafNodeDepthFirstIterator<OctreeT>;
-  using ConstLeafNodeIterator = const OctreeLeafNodeDepthFirstIterator<OctreeT>;
+  using ConstLeafNodeIterator = OctreeLeafNodeDepthFirstIterator<const OctreeT>;
 
   // The currently valide names
   using LeafNodeDepthFirstIterator = OctreeLeafNodeDepthFirstIterator<OctreeT>;


### PR DESCRIPTION
Missing `ConstLeafNodeIterator` in #5359.