### PR TITLE
Return empty handler if rgb doesn't exist when trying to add alpha value

### DIFF
--- a/common/src/PCLPointCloud2.cpp
+++ b/common/src/PCLPointCloud2.cpp
@@ -39,7 +39,6 @@
  */
 
 #include <vector>
-#include <iterator>
 
 #include <pcl/common/io.h>
 #include <pcl/pcl_macros.h>

--- a/common/src/PCLPointCloud2.cpp
+++ b/common/src/PCLPointCloud2.cpp
@@ -39,6 +39,7 @@
  */
 
 #include <vector>
+#include <iterator>
 
 #include <pcl/common/io.h>
 #include <pcl/pcl_macros.h>

--- a/io/include/pcl/io/ply_io.h
+++ b/io/include/pcl/io/ply_io.h
@@ -448,10 +448,13 @@ namespace pcl
 
       /** Amend property from cloud fields identified by \a old_name renaming
         * it \a new_name.
+        *  * Returns:
+        *  * false on error
+        *  * true success
         * param[in] old_name property old name
         * param[in] new_name property new name
         */
-      void
+      bool
       amendProperty (const std::string& old_name, const std::string& new_name, std::uint8_t datatype = 0);
 
       /** Callback function for the begin of vertex line */

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -118,20 +118,21 @@ pcl::PLYReader::appendScalarProperty (const std::string& name, const std::size_t
 void
 pcl::PLYReader::amendProperty (const std::string& old_name, const std::string& new_name, std::uint8_t new_datatype)
 {
-  auto finder = cloud_->fields.rbegin ();
-  for (; finder != cloud_->fields.rend (); ++finder)
-    if (finder->name == old_name)
-      break;
-  if (finder == cloud_->fields.rend ())
+  const auto fieldIndex = pcl::getFieldIndex(*cloud_,old_name);
+  if (fieldIndex == -1)
   {
       PCL_ERROR("[pcl::PLYReader::amendProperty] old_name '%s' was not found in cloud_->fields!\n",
           old_name.c_str());
       assert (false);
       return;
   }
-  finder->name = new_name;
-  if (new_datatype > 0 && new_datatype != finder->datatype)
-    finder->datatype = new_datatype;
+
+  auto& field = cloud_->fields[fieldIndex];
+
+  field.name = new_name;
+  
+  if (new_datatype > 0 && new_datatype != field.datatype)
+    field.datatype = new_datatype;
 }
 
 namespace pcl
@@ -213,6 +214,12 @@ namespace pcl
       }
       if (property_name == "alpha")
       {
+        if(pcl::getFieldIndex(*cloud_,"rgb") == -1)
+        {
+          PCL_ERROR("No RGB field to append aplha channel to.\n");
+          return {};
+        }
+
         amendProperty ("rgb", "rgba", pcl::PCLPointField::UINT32);
         return [this] (pcl::io::ply::uint8 alpha) { vertexAlphaCallback (alpha); };
       }


### PR DESCRIPTION
Print error and return empty callback if only alpha channel is listed in the header.

Should fix:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=50652