### PR TITLE
Fix pcd_video_player crash on OSX

### DIFF
--- a/apps/src/pcd_video_player/pcd_video_player.cpp
+++ b/apps/src/pcd_video_player/pcd_video_player.cpp
@@ -314,7 +314,7 @@ print_usage()
 int
 main(int argc, char** argv)
 {
-#ifdef HAS_VTK_82
+#ifdef HAS_QVTKOPENGLWINDOW_H
   QSurfaceFormat::setDefaultFormat(QVTKOpenGLWindow::defaultFormat());
 #endif
   QApplication app(argc, argv);

--- a/apps/src/pcd_video_player/pcd_video_player.cpp
+++ b/apps/src/pcd_video_player/pcd_video_player.cpp
@@ -47,6 +47,7 @@
 #include <QMutexLocker>
 #include <QObject>
 #include <QRadioButton>
+#include <QVTKOpenGLWindow.h>
 #include <ui_pcd_video_player.h>
 
 #include <vtkCamera.h>
@@ -310,6 +311,7 @@ print_usage()
 int
 main(int argc, char** argv)
 {
+  QSurfaceFormat::setDefaultFormat(QVTKOpenGLWindow::defaultFormat());
   QApplication app(argc, argv);
 
   PCDVideoPlayer VideoPlayer;

--- a/apps/src/pcd_video_player/pcd_video_player.cpp
+++ b/apps/src/pcd_video_player/pcd_video_player.cpp
@@ -47,7 +47,10 @@
 #include <QMutexLocker>
 #include <QObject>
 #include <QRadioButton>
+#if VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 2
+#define HAS_VTK_82
 #include <QVTKOpenGLWindow.h>
+#endif
 #include <ui_pcd_video_player.h>
 
 #include <vtkCamera.h>
@@ -311,7 +314,9 @@ print_usage()
 int
 main(int argc, char** argv)
 {
+#ifdef HAS_VTK_82
   QSurfaceFormat::setDefaultFormat(QVTKOpenGLWindow::defaultFormat());
+#endif
   QApplication app(argc, argv);
 
   PCDVideoPlayer VideoPlayer;

--- a/apps/src/pcd_video_player/pcd_video_player.cpp
+++ b/apps/src/pcd_video_player/pcd_video_player.cpp
@@ -47,7 +47,7 @@
 #include <QMutexLocker>
 #include <QObject>
 #include <QRadioButton>
-#if VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 2
+#if VTK_MAJOR_VERSION >= 9 || (VTK_MAJOR_VERSION == 8 && VTK_MINOR_VERSION >= 2)
 #define HAS_QVTKOPENGLWINDOW_H
 #include <QVTKOpenGLWindow.h>
 #endif

--- a/apps/src/pcd_video_player/pcd_video_player.cpp
+++ b/apps/src/pcd_video_player/pcd_video_player.cpp
@@ -48,7 +48,7 @@
 #include <QObject>
 #include <QRadioButton>
 #if VTK_MAJOR_VERSION >= 8 && VTK_MINOR_VERSION >= 2
-#define HAS_VTK_82
+#define HAS_QVTKOPENGLWINDOW_H
 #include <QVTKOpenGLWindow.h>
 #endif
 #include <ui_pcd_video_player.h>


### PR DESCRIPTION
On macos big sur, you can't execute the pcd video player
```
pcl_pcd_video_player.app/Contents/MacOS/pcl_pcd_video_player
2022-09-09 16:11:20.621 (   0.522s) [          15E0E6]vtkOpenGLRenderWindow.c:506    ERR| vtkGenericOpenGLRenderWindow (0x7ff1d8f3a840): Unable to find a valid OpenGL 3.2 or later implementation. Please update your video card driver to the latest version. If you are using Mesa please make sure you have version 11.2 or later and make sure your driver in Mesa supports OpenGL 3.2 such as llvmpipe or openswr. If you are on windows and using Microsoft remote desktop note that it only supports OpenGL 3.2 with nvidia quadro cards. You can use other remoting software such as nomachine to avoid this issue.
```

The fix is to set the Qt surface format.