### PR TITLE
[filters] FrustumCulling: allowing infinite far plane distance

### DIFF
--- a/filters/include/pcl/filters/frustum_culling.h
+++ b/filters/include/pcl/filters/frustum_culling.h
@@ -166,7 +166,7 @@ namespace pcl
       }
 
       /** \brief Set the near plane distance
-        * \param[in] np_dist the near plane distance. Setting it to 0 to extract a square cone.
+        * \param[in] np_dist the near plane distance. You can set this to 0 to disable near-plane filtering and extract a pyramid instead of a frustum.
         */
       void 
       setNearPlaneDistance (float np_dist)

--- a/filters/include/pcl/filters/frustum_culling.h
+++ b/filters/include/pcl/filters/frustum_culling.h
@@ -171,6 +171,11 @@ namespace pcl
       void 
       setNearPlaneDistance (float np_dist)
       {
+        if (np_dist < 0.0f)
+        {
+          throw PCLException ("Near plane distance should be greater than or equal to 0.",
+            "frustum_culling.h", "setNearPlaneDistance");
+        }
         np_dist_ = np_dist;
       }
 
@@ -187,6 +192,11 @@ namespace pcl
       void 
       setFarPlaneDistance (float fp_dist)
       {
+        if (fp_dist <= 0.0f)
+        {
+          throw PCLException ("Far plane distance should be greater than 0.",
+            "frustum_culling.h", "setFarPlaneDistance");
+        }
         fp_dist_ = fp_dist;
       }
 

--- a/filters/include/pcl/filters/frustum_culling.h
+++ b/filters/include/pcl/filters/frustum_culling.h
@@ -166,7 +166,7 @@ namespace pcl
       }
 
       /** \brief Set the near plane distance
-        * \param[in] np_dist the near plane distance
+        * \param[in] np_dist the near plane distance. Setting it to 0 to extract a square cone.
         */
       void 
       setNearPlaneDistance (float np_dist)
@@ -187,7 +187,8 @@ namespace pcl
       }
 
       /** \brief Set the far plane distance
-        * \param[in] fp_dist the far plane distance
+        * \param[in] fp_dist the far plane distance.
+        * Setting it to std::numeric_limits<float>::max() so points will not be filtered by far plane.
         */
       void 
       setFarPlaneDistance (float fp_dist)

--- a/filters/include/pcl/filters/frustum_culling.h
+++ b/filters/include/pcl/filters/frustum_culling.h
@@ -166,7 +166,7 @@ namespace pcl
       }
 
       /** \brief Set the near plane distance
-        * \param[in] np_dist the near plane distance. You can set this to 0 to disable near-plane filtering and extract a pyramid instead of a frustum.
+        * \param[in] np_dist the near plane distance. You can set this to 0 to disable near-plane filtering and extract a rectangular pyramid instead of a frustum.
         */
       void 
       setNearPlaneDistance (float np_dist)

--- a/filters/include/pcl/filters/frustum_culling.h
+++ b/filters/include/pcl/filters/frustum_culling.h
@@ -188,7 +188,7 @@ namespace pcl
 
       /** \brief Set the far plane distance
         * \param[in] fp_dist the far plane distance.
-        * Setting it to std::numeric_limits<float>::max() so points will not be filtered by far plane.
+        * You can set this to std::numeric_limits<float>::max(), then points will not be filtered by the far plane.
         */
       void 
       setFarPlaneDistance (float fp_dist)

--- a/filters/include/pcl/filters/impl/frustum_culling.hpp
+++ b/filters/include/pcl/filters/impl/frustum_culling.hpp
@@ -45,6 +45,11 @@
 template <typename PointT> void
 pcl::FrustumCulling<PointT>::applyFilter (Indices &indices)
 {
+    bool is_far_plane_infinite = (fp_dist_ == std::numeric_limits<float>::max());
+    if(is_far_plane_infinite) {
+        fp_dist_ = (np_dist_ != 0) ? np_dist_ : 1.0f;
+    }
+
   Eigen::Vector4f pl_n; // near plane 
   Eigen::Vector4f pl_f; // far plane
   Eigen::Vector4f pl_t; // top plane
@@ -90,6 +95,11 @@ pcl::FrustumCulling<PointT>::applyFilter (Indices &indices)
 
   pl_f.head<3> () = (fp_bl - fp_br).cross (fp_tr - fp_br);  // Far plane equation - cross product of the 
   pl_f (3) = -fp_c.dot (pl_f.head<3> ());                   // perpendicular edges of the far plane
+
+  if(is_far_plane_infinite) {
+      pl_f.setZero();
+      fp_dist_ = std::numeric_limits<float>::max();
+  }
 
   pl_n.head<3> () = (np_tr - np_br).cross (np_bl - np_br);  // Near plane equation - cross product of the 
   pl_n (3) = -np_c.dot (pl_n.head<3> ());                   // perpendicular edges of the far plane

--- a/filters/include/pcl/filters/impl/frustum_culling.hpp
+++ b/filters/include/pcl/filters/impl/frustum_culling.hpp
@@ -47,7 +47,7 @@ pcl::FrustumCulling<PointT>::applyFilter (Indices &indices)
 {
     bool is_far_plane_infinite = (fp_dist_ == std::numeric_limits<float>::max());
     if(is_far_plane_infinite) {
-        fp_dist_ = (np_dist_ != 0) ? np_dist_ : 1.0f;
+        fp_dist_ = np_dist_ + 1.0f;
     }
 
   Eigen::Vector4f pl_n; // near plane 


### PR DESCRIPTION
1. check for np_dist and fp_dist
2. allow infinite fp_dist

Ref: https://github.com/PointCloudLibrary/pcl/issues/5423

top, bottom, right, left planes are dependent on far plane's corners, so when `fp_dist_` is max value, it should be first set to a valid value and then set back.