### PR TITLE
Remove unnecessary member in SHOTEstimationBase

### DIFF
--- a/features/include/pcl/features/impl/shot.hpp
+++ b/features/include/pcl/features/impl/shot.hpp
@@ -751,7 +751,8 @@ pcl::SHOTEstimation<PointInT, PointNT, PointOutT, PointRFT>::computeFeature (pcl
 
   assert(descLength_ == 352);
 
-  shot_.setZero (descLength_);
+  Eigen::VectorXf shot;
+  shot.setZero (descLength_);
 
   // Allocate enough space to hold the results
   // \note This resize is irrelevant for a radiusSearch ().
@@ -788,11 +789,11 @@ pcl::SHOTEstimation<PointInT, PointNT, PointOutT, PointRFT>::computeFeature (pcl
     }
 
     // Estimate the SHOT descriptor at each patch
-    computePointSHOT (static_cast<int> (idx), nn_indices, nn_dists, shot_);
+    computePointSHOT (static_cast<int> (idx), nn_indices, nn_dists, shot);
 
     // Copy into the resultant cloud
     for (int d = 0; d < descLength_; ++d)
-      output[idx].descriptor[d] = shot_[d];
+      output[idx].descriptor[d] = shot[d];
     for (int d = 0; d < 3; ++d)
     {
       output[idx].rf[d + 0] = (*frames_)[idx].x_axis[d];
@@ -823,7 +824,8 @@ pcl::SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::computeFeature
   radius1_4_ = search_radius_ / 4;
   radius1_2_ = search_radius_ / 2;
 
-  shot_.setZero (descLength_);
+  Eigen::VectorXf shot;
+  shot.setZero (descLength_);
 
   // Allocate enough space to hold the results
   // \note This resize is irrelevant for a radiusSearch ().
@@ -860,11 +862,11 @@ pcl::SHOTColorEstimation<PointInT, PointNT, PointOutT, PointRFT>::computeFeature
     }
 
     // Compute the SHOT descriptor for the current 3D feature
-    computePointSHOT (static_cast<int> (idx), nn_indices, nn_dists, shot_);
+    computePointSHOT (static_cast<int> (idx), nn_indices, nn_dists, shot);
 
     // Copy into the resultant cloud
     for (int d = 0; d < descLength_; ++d)
-      output[idx].descriptor[d] = shot_[d];
+      output[idx].descriptor[d] = shot[d];
     for (int d = 0; d < 3; ++d)
     {
       output[idx].rf[d + 0] = (*frames_)[idx].x_axis[d];

--- a/features/include/pcl/features/shot.h
+++ b/features/include/pcl/features/shot.h
@@ -169,9 +169,6 @@ namespace pcl
       /** \brief The number of bins in each shape histogram. */
       int nr_shape_bins_;
 
-      /** \brief Placeholder for a point's SHOT. */
-      Eigen::VectorXf shot_;
-
       /** \brief The radius used for the LRF computation */
       float lrf_radius_;
 
@@ -240,7 +237,6 @@ namespace pcl
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::radius1_2_;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::maxAngularSectors_;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::interpolateSingleChannel;
-      using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::shot_;
       using FeatureWithLocalReferenceFrames<PointInT, PointRFT>::frames_;
 
       using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;
@@ -318,7 +314,6 @@ namespace pcl
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::radius1_2_;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::maxAngularSectors_;
       using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::interpolateSingleChannel;
-      using SHOTEstimationBase<PointInT, PointNT, PointOutT, PointRFT>::shot_;
       using FeatureWithLocalReferenceFrames<PointInT, PointRFT>::frames_;
 
       using PointCloudIn = typename Feature<PointInT, PointOutT>::PointCloudIn;


### PR DESCRIPTION
Can also cause problems with alignment. See https://github.com/PointCloudLibrary/pcl/issues/5425