### PR TITLE
Modernized memset via uniform init or modern constructs

### DIFF
--- a/octree/include/pcl/octree/octree2buf_base.h
+++ b/octree/include/pcl/octree/octree2buf_base.h
@@ -44,10 +44,14 @@
 #include <pcl/octree/octree_nodes.h>
 #include <pcl/pcl_macros.h>
 
+#include <array>
 #include <vector>
 
 namespace pcl {
 namespace octree {
+
+using OctreeNodePair = std::array<OctreeNode*, 2>;
+using OctreeNodeArray = std::array<OctreeNodePair, 8>;
 
 template <typename ContainerT>
 class BufferedBranchNode : public OctreeNode {
@@ -66,12 +70,13 @@ public:
   inline BufferedBranchNode&
   operator=(const BufferedBranchNode& source_arg)
   {
-    memset(child_node_array_, 0, sizeof(child_node_array_));
-
-    for (unsigned char b = 0; b < 2; ++b)
+    child_node_array_ = {};
+    for (unsigned char b = 0; b < 2; ++b) {
       for (unsigned char i = 0; i < 8; ++i)
-        if (source_arg.child_node_array_[b][i])
+        if (source_arg.child_node_array_[b][i]) {
           child_node_array_[b][i] = source_arg.child_node_array_[b][i]->deepCopy();
+        }
+    }
 
     return (*this);
   }
@@ -135,7 +140,7 @@ public:
   inline void
   reset()
   {
-    memset(&child_node_array_[0][0], 0, sizeof(OctreeNode*) * 8 * 2);
+    child_node_array_ = {};
   }
 
   /** \brief Get const pointer to container */
@@ -197,7 +202,7 @@ public:
 protected:
   ContainerT container_;
 
-  OctreeNode* child_node_array_[2][8];
+  OctreeNodeArray child_node_array_{};
 };
 
 /** \brief @b Octree double buffer class

--- a/octree/include/pcl/octree/octree_nodes.h
+++ b/octree/include/pcl/octree/octree_nodes.h
@@ -42,6 +42,7 @@
 #include <pcl/memory.h>
 #include <pcl/pcl_macros.h>
 
+#include <array>
 #include <cassert>
 
 namespace pcl {
@@ -182,28 +183,31 @@ public:
   OctreeBranchNode() : OctreeNode()
   {
     // reset pointer to child node vectors
-    memset(child_node_array_, 0, sizeof(child_node_array_));
+    child_node_array_ = {};
   }
 
   /** \brief Empty constructor. */
   OctreeBranchNode(const OctreeBranchNode& source) : OctreeNode()
   {
-    memset(child_node_array_, 0, sizeof(child_node_array_));
+    child_node_array_ = {};
 
     for (unsigned char i = 0; i < 8; ++i)
-      if (source.child_node_array_[i])
+      if (source.child_node_array_[i]) {
         child_node_array_[i] = source.child_node_array_[i]->deepCopy();
+      }
   }
 
   /** \brief Copy operator. */
   inline OctreeBranchNode&
   operator=(const OctreeBranchNode& source)
   {
-    memset(child_node_array_, 0, sizeof(child_node_array_));
+    child_node_array_ = {};
 
-    for (unsigned char i = 0; i < 8; ++i)
-      if (source.child_node_array_[i])
+    for (unsigned char i = 0; i < 8; ++i) {
+      if (source.child_node_array_[i]) {
         child_node_array_[i] = source.child_node_array_[i]->deepCopy();
+      }
+    }
     return (*this);
   }
 
@@ -295,7 +299,7 @@ public:
   void
   reset()
   {
-    memset(child_node_array_, 0, sizeof(child_node_array_));
+    child_node_array_ = {};
     container_.reset();
   }
 
@@ -356,7 +360,7 @@ public:
   }
 
 protected:
-  OctreeNode* child_node_array_[8];
+  std::array<OctreeNode*, 8> child_node_array_{};
 
   ContainerT container_;
 };

--- a/surface/include/pcl/surface/3rdparty/poisson4/bspline_data.h
+++ b/surface/include/pcl/surface/3rdparty/poisson4/bspline_data.h
@@ -102,8 +102,8 @@ namespace pcl
     template< int Degree >
     struct BSplineElementCoefficients
     {
-        int coeffs[Degree+1];
-        BSplineElementCoefficients( ) { memset( coeffs , 0 , sizeof( int ) * ( Degree+1 ) ); }
+        int coeffs[Degree+1] = {};
+        BSplineElementCoefficients( ) = default;
         int& operator[]( int idx ){ return coeffs[idx]; }
         const int& operator[]( int idx ) const { return coeffs[idx]; }
     };

--- a/surface/include/pcl/surface/3rdparty/poisson4/multi_grid_octree_data.h
+++ b/surface/include/pcl/surface/3rdparty/poisson4/multi_grid_octree_data.h
@@ -122,8 +122,8 @@ namespace pcl
         void set( TreeOctNode& root );
         struct CornerIndices
         {
-            int idx[pcl::poisson::Cube::CORNERS];
-            CornerIndices( void ) { memset( idx , -1 , sizeof( int ) * pcl::poisson::Cube::CORNERS ); }
+            int idx[pcl::poisson::Cube::CORNERS] = {};
+            CornerIndices( void ) = default;
             int& operator[] ( int i ) { return idx[i]; }
             const int& operator[] ( int i ) const { return idx[i]; }
         };
@@ -146,8 +146,8 @@ namespace pcl
         int getMaxCornerCount( const TreeOctNode* rootNode , int depth , int maxDepth , int threads ) const ;
         struct EdgeIndices
         {
-            int idx[pcl::poisson::Cube::EDGES];
-            EdgeIndices( void ) { memset( idx , -1 , sizeof( int ) * pcl::poisson::Cube::EDGES ); }
+            int idx[pcl::poisson::Cube::EDGES] = {};
+            EdgeIndices( void ) = default;
             int& operator[] ( int i ) { return idx[i]; }
             const int& operator[] ( int i ) const { return idx[i]; }
         };


### PR DESCRIPTION
As a follow-up to #4299, modernized more `memset` usages by either employing uniform initialization or modern constructs