### PR TITLE
Add check in pcd_viewer.cpp for padding fields

### DIFF
--- a/tools/pcd_viewer.cpp
+++ b/tools/pcd_viewer.cpp
@@ -83,9 +83,7 @@ isValidFieldName (const std::string &field)
 bool
 isMultiDimensionalFeatureField (const pcl::PCLPointField &field)
 {
-  if (field.count > 1)
-    return (true);
-  return (false);
+  return (field.count > 1 && field.name != "_"); // check for padding fields "_"
 }
 
 bool


### PR DESCRIPTION
Padding fields should not be considered as multi-dimensional feature fields and should not be shown in histograms
Fixes https://github.com/PointCloudLibrary/pcl/issues/5441