### PR TITLE
fix linemod binindex wrong range bug in surface normal modality

### DIFF
--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -1371,7 +1371,7 @@ pcl::SurfaceNormalModality<PointInT>::quantizeSurfaceNormals ()
       const float normal_y = surface_normals_ (col_index, row_index).normal_y;
       const float normal_z = surface_normals_ (col_index, row_index).normal_z;
 
-      if (std::isnan(normal_x) || std::isnan(normal_y) || std::isnan(normal_z) || normal_z > 0)
+      if (std::isnan(normal_x) || std::isnan(normal_y) || std::isnan(normal_z) || normal_z > 0 || (normal_x == 0 && normal_y == 0))
       {
         quantized_surface_normals_ (col_index, row_index) = 0;
         continue;
@@ -1385,7 +1385,7 @@ pcl::SurfaceNormalModality<PointInT>::quantizeSurfaceNormals ()
       if (angle < 0.0f) angle += 360.0f;
       if (angle >= 360.0f) angle -= 360.0f;
 
-      int bin_index = static_cast<int> (angle*8.0f/360.0f);
+      int bin_index = std::clamp(static_cast<int> (angle*8.0f/360.0f+1), 1, 8);
 
       //quantized_surface_normals_.data[row_index*width+col_index] = 0x1 << bin_index;
       quantized_surface_normals_ (col_index, row_index) = static_cast<unsigned char> (bin_index);

--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -1385,7 +1385,7 @@ pcl::SurfaceNormalModality<PointInT>::quantizeSurfaceNormals ()
       if (angle < 0.0f) angle += 360.0f;
       if (angle >= 360.0f) angle -= 360.0f;
 
-      int bin_index = static_cast<int> (angle*8.0f/360.0f);
+      int bin_index = static_cast<int> (angle*8.0f/360.0f + 1);
       bin_index = (bin_index < 1) ? 1 : (8 < bin_index) ? 8 : bin_index;
 
       //quantized_surface_normals_.data[row_index*width+col_index] = 0x1 << bin_index;

--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -1385,7 +1385,8 @@ pcl::SurfaceNormalModality<PointInT>::quantizeSurfaceNormals ()
       if (angle < 0.0f) angle += 360.0f;
       if (angle >= 360.0f) angle -= 360.0f;
 
-      int bin_index = std::clamp(static_cast<int> (angle*8.0f/360.0f+1), 1, 8);
+      int bin_index = static_cast<int> (angle*8.0f/360.0f);
+      bin_index = (bin_index < 1) ? 1 : (8 < bin_index) ? 8 : bin_index;
 
       //quantized_surface_normals_.data[row_index*width+col_index] = 0x1 << bin_index;
       quantized_surface_normals_ (col_index, row_index) = static_cast<unsigned char> (bin_index);

--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -683,7 +683,8 @@ pcl::SurfaceNormalModality<PointInT>::computeAndQuantizeSurfaceNormals ()
         if (angle < 0.0f) angle += 360.0f;
         if (angle >= 360.0f) angle -= 360.0f;
 
-        int bin_index = static_cast<int> (angle*8.0f/360.0f) & 7;
+        int bin_index = static_cast<int> (angle*8.0f/360.0f + 1);
+        bin_index = (bin_index < 1) ? 1 : (8 < bin_index) ? 8 : bin_index;
 
         quantized_surface_normals_ (x, y) = static_cast<unsigned char> (bin_index);
       }
@@ -902,7 +903,7 @@ pcl::SurfaceNormalModality<PointInT>::computeAndQuantizeSurfaceNormals2 ()
           if (angle < 0.0f) angle += 360.0f;
           if (angle >= 360.0f) angle -= 360.0f;
 
-          int bin_index = static_cast<int> (angle*8.0f/360.0f) & 7;
+          int bin_index = static_cast<int> (angle*8.0f/360.0f);
 
           surface_normal_orientations_ (l_x, l_y) = angle;
 
@@ -932,14 +933,14 @@ pcl::SurfaceNormalModality<PointInT>::computeAndQuantizeSurfaceNormals2 ()
 
   unsigned char map[255]{};
 
-  map[0x1<<0] = 0;
-  map[0x1<<1] = 1;
-  map[0x1<<2] = 2;
-  map[0x1<<3] = 3;
-  map[0x1<<4] = 4;
-  map[0x1<<5] = 5;
-  map[0x1<<6] = 6;
-  map[0x1<<7] = 7;
+  map[0x1<<0] = 1;
+  map[0x1<<1] = 2;
+  map[0x1<<2] = 3;
+  map[0x1<<3] = 4;
+  map[0x1<<4] = 5;
+  map[0x1<<5] = 6;
+  map[0x1<<6] = 7;
+  map[0x1<<7] = 8;
 
   quantized_surface_normals_.resize (width, height);
   for (int row_index = 0; row_index < height; ++row_index)


### PR DESCRIPTION
In linemod, binindex in surface normal modality should be within [1, 8] (0 represents invalid points), but in current master it is [0, 7] ( only one angle 360deg gives binindex 8).