### PR TITLE
Fix can't compile getMeanPointDensity

### DIFF
--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -55,7 +55,7 @@ pcl::getMeanPointDensity(const typename pcl::PointCloud<PointT>::ConstPtr& cloud
                          int nr_threads)
 {
   const float max_dist_sqr = max_dist * max_dist;
-  const std::size_t s = cloud.size();
+  const std::size_t s = cloud->size();
 
   pcl::search::KdTree<PointT> tree;
   tree.setInputCloud(cloud);


### PR DESCRIPTION
`cloud` is a smart pointer, need to use Arrow(->) operator to access the members

```c++
 // const std::size_t s = cloud.size();
 const std::size_t s = cloud->size();
```

Resolves #5446