### PR TITLE
[windows] Fix compile issues when compiling OpenNIDriver

### DIFF
--- a/io/src/openni_camera/openni_driver.cpp
+++ b/io/src/openni_camera/openni_driver.cpp
@@ -48,6 +48,9 @@
 #include <pcl/io/openni_camera/openni_device_primesense.h>
 #include <pcl/io/openni_camera/openni_device_xtion.h>
 #include <pcl/io/openni_camera/openni_device_oni.h>
+
+#include <boost/tokenizer.hpp>
+
 #include <sstream>
 #include <iostream>
 #include <algorithm>
@@ -193,8 +196,8 @@ openni_wrapper::OpenNIDriver::updateDeviceList ()
 #ifdef _WIN32
     if (vendor_id == 0x45e)
     {
-      strcpy (const_cast<char*> (device_context_[device].device_node.GetDescription ().strVendor), "Microsoft");
-      strcpy (const_cast<char*> (device_context_[device].device_node.GetDescription ().strName), "Xbox NUI Camera");
+      strcpy (const_cast<char*> (device.device_node.GetDescription ().strVendor), "Microsoft");
+      strcpy (const_cast<char*> (device.device_node.GetDescription ().strName), "Xbox NUI Camera");
     }
     else
 #endif


### PR DESCRIPTION
Installed OpenNI(1) on my system to get a full build of PCL and got two compile issues:
- `error C2039: 'tokenizer': is not a member of 'boost'`
- ` error C2679: binary '[': no operator found which takes a right-hand operand of type 'const openni_wrapper::OpenNIDriver::DeviceContext' (or there is no acceptable conversion)`

Last issue was introduced by myself in #2845 3 years ago. As no one mentioned it: Maybe we could also deprecate the OpenNI code (at least of version 1)?