### PR TITLE
Fix OpenMP compile issue under MSVC

### DIFF
--- a/keypoints/include/pcl/keypoints/impl/trajkovic_2d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/trajkovic_2d.hpp
@@ -246,7 +246,7 @@ TrajkovicKeypoint2D<PointInT, PointOutT, IntensityT>::detectKeypoints (PointClou
   shared(height, indices, occupency_map, output, width) \
   num_threads(threads_)
 #endif
-  for (std::size_t i = 0; i < indices.size (); ++i)
+  for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t> (indices.size ()); ++i)
   {
     int idx = indices[i];
     if (((*response_)[idx] < second_threshold_) || occupency_map[idx])


### PR DESCRIPTION
Fix `error C3016: 'i': index variable in OpenMP 'for' statement must have signed integral type`

Issue occurs, as MSVC doesn't support `size_t` as OpenMP loop variable (see [here](https://developercommunity.visualstudio.com/t/openmp-unsigned-typed-induction-variables-in-paral/539086)).