### PR TITLE
Fix missing virtual destructors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ if(CMAKE_COMPILER_IS_MSVC)
   add_definitions("-DBOOST_ALL_NO_LIB -D_SCL_SECURE_NO_WARNINGS -D_CRT_SECURE_NO_WARNINGS -DNOMINMAX -DPCL_ONLY_CORE_POINT_TYPES ${SSE_DEFINITIONS}")
   
   if("${CMAKE_CXX_FLAGS}" STREQUAL "${CMAKE_CXX_FLAGS_DEFAULT}")
-    string(APPEND CMAKE_CXX_FLAGS " /fp:precise /wd4800 /wd4521 /wd4251 /wd4275 /wd4305 /wd4355 ${SSE_FLAGS} ${AVX_FLAGS} /bigobj")
+    string(APPEND CMAKE_CXX_FLAGS " /fp:precise ${SSE_FLAGS} ${AVX_FLAGS} /bigobj")
 
     # Add extra code generation/link optimizations
     if(CMAKE_MSVC_CODE_LINK_OPTIMIZATION AND (NOT BUILD_CUDA) AND (NOT BUILD_GPU))
@@ -156,6 +156,12 @@ if(CMAKE_COMPILER_IS_MSVC)
       message("Global optimizations /GL has been turned off, as it doesn't work with nvcc/thrust")
     endif()
     # /MANIFEST:NO") # please, don't disable manifest generation, otherwise crash at start for vs2008
+
+    # Disable some warnings
+    string(APPEND CMAKE_CXX_FLAGS " /wd4800 /wd4521 /wd4251 /wd4275 /wd4305 /wd4355")
+
+    # Enable warnings, which are disabled by default (see https://learn.microsoft.com/de-de/cpp/preprocessor/compiler-warnings-that-are-off-by-default)
+    string(APPEND CMAKE_CXX_FLAGS " /w34265")
 
     if(PCL_WARNINGS_ARE_ERRORS)
       # MSVC supports external includes only since Visual Studio 2019 version 16.10.0.

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_classifier.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/global_nn_classifier.h
@@ -20,6 +20,8 @@ class PCL_EXPORTS GlobalClassifier {
 public:
   using PointInTPtr = typename pcl::PointCloud<PointInT>::Ptr;
 
+  virtual ~GlobalClassifier() = default;
+
   virtual void
   setNN(int nn) = 0;
 
@@ -130,8 +132,6 @@ protected:
 
 public:
   GlobalNNPipeline() { NN_ = 1; }
-
-  ~GlobalNNPipeline() = default;
 
   void
   setNN(int nn) override

--- a/features/include/pcl/features/feature.h
+++ b/features/include/pcl/features/feature.h
@@ -446,6 +446,10 @@ namespace pcl
       /** \brief Empty constructor. */
       FeatureWithLocalReferenceFrames () : frames_ (), frames_never_defined_ (true) {}
 
+      /** \brief Default virtual destructor. */
+      virtual
+      ~FeatureWithLocalReferenceFrames() = default;
+
       /** \brief Provide a pointer to the input dataset that contains the local
         * reference frames of the XYZ dataset.
         * In case of search surface is set to be different from the input cloud,

--- a/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_clusters.h
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_clusters.h
@@ -81,6 +81,9 @@ public:
   /** \brief Empty constructor. */
   EuclideanClusterExtraction() = default;
 
+  /** \brief Default virtual destructor. */
+  virtual ~EuclideanClusterExtraction() = default;
+
   /** \brief the destructor */
   /*        ~EuclideanClusterExtraction ()
           {

--- a/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_labeled_clusters.h
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/gpu_extract_labeled_clusters.h
@@ -82,6 +82,9 @@ public:
   /** \brief Empty constructor. */
   EuclideanLabeledClusterExtraction() = default;
 
+  /** \brief Default virtual destructor. */
+  virtual ~EuclideanLabeledClusterExtraction() = default;
+
   /** \brief Provide a pointer to the search object.
    * \param tree a pointer to the spatial search object.
    */

--- a/ml/include/pcl/ml/dt/decision_tree_data_provider.h
+++ b/ml/include/pcl/ml/dt/decision_tree_data_provider.h
@@ -70,7 +70,7 @@ public:
   DecisionTreeTrainerDataProvider() = default;
 
   /** Destructor. */
-  ~DecisionTreeTrainerDataProvider() = default;
+  virtual ~DecisionTreeTrainerDataProvider() = default;
 
   /** Virtual function called to obtain training examples and labels before
    *  training a specific tree */

--- a/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
+++ b/recognition/include/pcl/recognition/face_detection/face_detector_data_provider.h
@@ -122,8 +122,6 @@ namespace pcl
           min_images_per_bin_ = -1;
         }
 
-        virtual ~FaceDetectorDataProvider() = default;
-
         void setPatchesPerImage(int n)
         {
           patches_per_image_ = n;

--- a/surface/include/pcl/surface/3rdparty/poisson4/bspline_data.h
+++ b/surface/include/pcl/surface/3rdparty/poisson4/bspline_data.h
@@ -72,7 +72,7 @@ namespace pcl
         BSplineComponents* baseBSplines;
 
         BSplineData();
-        ~BSplineData();
+        virtual ~BSplineData();
 
         virtual void   setDotTables( int flags );
         virtual void clearDotTables( int flags );

--- a/surface/include/pcl/surface/3rdparty/poisson4/geometry.h
+++ b/surface/include/pcl/surface/3rdparty/poisson4/geometry.h
@@ -200,6 +200,8 @@ namespace pcl
     {
       public:
         std::vector<Point3D<float> > inCorePoints;
+
+        virtual ~CoredMeshData() = default;
         virtual void resetIterator( void ) = 0;
 
         virtual int addOutOfCorePoint( const Point3D<float>& p ) = 0;
@@ -231,6 +233,9 @@ namespace pcl
               value = ( p1[0] * p2[0] + p1[1] * p2[1] + p1[2] * p2[2] ) / ( p2[0] * p2[0] + p2[1] * p2[1] + p2[2] * p2[2] );
             }
         };
+
+        virtual ~CoredMeshData2() = default;
+
         std::vector< Vertex > inCorePoints;
         virtual void resetIterator( void ) = 0;
 

--- a/surface/include/pcl/surface/on_nurbs/fitting_curve_2d.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_curve_2d.h
@@ -93,6 +93,10 @@ namespace pcl
           */
         FittingCurve2d (NurbsDataCurve2d *data, const ON_NurbsCurve &nc);
 
+        /** \brief Default virtual destructor. */
+        virtual
+        ~FittingCurve2d() = default;
+
         /** \brief Find the element in which the parameter xi lies.
           * \param[in] xi value in parameter domain of the B-Spline curve.
           * \param[in] elements the vector of elements of the curve.

--- a/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_apdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_apdm.h
@@ -97,6 +97,10 @@ namespace pcl
          * \param[in] nc B-Spline curve used for fitting.        */
         FittingCurve2dAPDM (NurbsDataCurve2d *data, const ON_NurbsCurve &nc);
 
+        /** \brief Default virtual destructor. */
+        virtual
+        ~FittingCurve2dAPDM() = default;
+
         /** \brief Find the element in which the parameter xi lies.
          * \param[in] xi value in parameter domain of the B-Spline curve.
          * \param[in] elements the vector of elements of the curve.

--- a/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_pdm.h
+++ b/surface/include/pcl/surface/on_nurbs/fitting_curve_2d_pdm.h
@@ -93,6 +93,10 @@ namespace pcl
           */
         FittingCurve2dPDM (NurbsDataCurve2d *data, const ON_NurbsCurve &nc);
 
+        /** \brief Default virtual destructor. */
+        virtual
+        ~FittingCurve2dPDM() = default;
+
         /** \brief Find the element in which the parameter xi lies.
           * \param[in] xi value in parameter domain of the B-Spline curve.
           * \param[in] elements the vector of elements of the curve.

--- a/surface/include/pcl/surface/on_nurbs/global_optimization_pdm.h
+++ b/surface/include/pcl/surface/on_nurbs/global_optimization_pdm.h
@@ -83,6 +83,10 @@ namespace pcl
        * \param[in] nurbs set of B-Spline surface used for fitting.        */
       GlobalOptimization (const std::vector<NurbsDataSurface*> &data, const std::vector<ON_NurbsSurface*> &nurbs);
 
+      /** \brief Default virtual destructor. */
+      virtual
+      ~GlobalOptimization() = default;
+
       /** \brief Set common boundary points two NURBS should lie on
        *  \param[in] boundary vector of boundary points.
        *  \param[in] nurbs_indices vector of 2 NURBS indices sharing the boundary point. */

--- a/visualization/include/pcl/visualization/pcl_painter2D.h
+++ b/visualization/include/pcl/visualization/pcl_painter2D.h
@@ -95,6 +95,13 @@ namespace pcl
         this->brush_->DeepCopy (b);
         this->transform_->SetMatrix (t->GetMatrix());
       }
+
+      virtual ~Figure2D()
+      {
+        pen_->Delete();
+        brush_->Delete();
+        transform_->Delete();
+      }
       
       void applyInternals (vtkContext2D *painter) const
       {


### PR DESCRIPTION
Fix MSVC warning [C4265](https://learn.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-3-c4265): `class has virtual functions, but destructor is not virtual`

Usually I prefer to not touch 3rd party code, but as this could fix memory leaks I think we should fix it there also.

Not sure if I catched all issues, as a few dependencies I don't have installed on Windows.