### PR TITLE
Solve an internal compiler issue on MSVC 2022 within openNURBS

### DIFF
--- a/surface/src/3rdparty/opennurbs/opennurbs_lookup.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_lookup.cpp
@@ -666,6 +666,11 @@ std::size_t ON_SerialNumberMap::ActiveIdCount() const
   return m_active_id_count;
 }
 
+#if (_MSC_VER >= 1930 && _MSC_VER <= 1939)
+// Solves internal compiler error on MSVC 2022
+// (see https://github.com/microsoft/vcpkg/issues/19561)
+#pragma optimize("", off)
+#endif
 struct ON_SerialNumberMap::SN_ELEMENT* ON_SerialNumberMap::FirstElement() const
 {
   struct SN_ELEMENT* e=0;
@@ -717,6 +722,9 @@ struct ON_SerialNumberMap::SN_ELEMENT* ON_SerialNumberMap::FirstElement() const
   }
   return e;
 }
+#if (_MSC_VER >= 1930 && _MSC_VER <= 1939)
+#pragma optimize("", on)
+#endif
 
 struct ON_SerialNumberMap::SN_ELEMENT* ON_SerialNumberMap::LastElement() const
 {


### PR DESCRIPTION
Found finally a solution to the internal compiler error within the openNURBS code, so I don't have to comment out the code always.

Solution comes from here: https://github.com/microsoft/vcpkg/issues/19561
And it seems there is no official fix for this available until now: https://discourse.mcneel.com/t/building-opennurbs-public-with-visualstudio2022-results-in-compiler-error/137817