### PR TITLE
fix quantized normals' bin boundaries not consistent in different places in linemod

### DIFF
--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -898,7 +898,7 @@ pcl::SurfaceNormalModality<PointInT>::computeAndQuantizeSurfaceNormals2 ()
           l_ny *= l_norminv;
           l_nz *= l_norminv;
 
-          float angle = 22.5f + std::atan2 (l_ny, l_nx) * 180.0f / 3.14f;
+          float angle = 11.25f + std::atan2 (l_ny, l_nx) * 180.0f / 3.14f;
 
           if (angle < 0.0f) angle += 360.0f;
           if (angle >= 360.0f) angle -= 360.0f;


### PR DESCRIPTION
As @mvieth requested in [pull/5444](https://github.com/PointCloudLibrary/pcl/pull/5444).