### PR TITLE
Add ::Ptr and ::ConstPtr member typedefs to ConditionalRemoval

### DIFF
--- a/filters/include/pcl/filters/conditional_removal.h
+++ b/filters/include/pcl/filters/conditional_removal.h
@@ -605,6 +605,10 @@ namespace pcl
       using ConditionBase = pcl::ConditionBase<PointT>;
       using ConditionBasePtr = typename ConditionBase::Ptr;
       using ConditionBaseConstPtr = typename ConditionBase::ConstPtr;
+      
+      using Ptr = shared_ptr<ConditionalRemoval<PointT> >;    
+      using ConstPtr = shared_ptr<const ConditionalRemoval<PointT> >;
+
 
       /** \brief the default constructor.  
         *


### PR DESCRIPTION
I was used to these being available for other filters, but to my surprise, a `ConditionalRemoval<PointT>::Ptr` is actually a pointer to the `Filter<PointT>` base class.