### PR TITLE
Fix usage of dangling pointer in PCLVisualizer::getUniqueCameraFile

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -4579,8 +4579,8 @@ pcl::visualization::PCLVisualizer::getUniqueCameraFile (int argc, char **argv)
       if (boost::filesystem::exists (path))
       {
         path = boost::filesystem::canonical (path);
-        const char *str = path.string ().c_str ();
-        sha1.process_bytes (str, std::strlen (str));
+        const auto pathStr = path.string ();
+        sha1.process_bytes (pathStr.c_str(), pathStr.size());
         valid = true;
       }
     }


### PR DESCRIPTION
This was detected by MSVC warning [C26815](https://learn.microsoft.com/en-us/cpp/code-quality/c26815) (sadly the warnings of MSVC appears really randomly, adding `/we26815` didn't showed this).