### PR TITLE
[visualization] Access to a potential null pointer in interactor_style (#5503)

### DIFF
--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -1050,11 +1050,14 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
       {
         FindPokedRenderer(Interactor->GetEventPosition ()[0], Interactor->GetEventPosition ()[1]);
         if(CurrentRenderer)
+        {
           CurrentRenderer->ResetCamera ();
+          CurrentRenderer->Render ();
+        }
         else
+        {
           PCL_WARN ("no current renderer on the interactor style.\n");
-
-        CurrentRenderer->Render ();
+        }
         break;
       }
 


### PR DESCRIPTION
Within the OnKeyDown method of PCLVisualizerInteractorStyle, the pointer to the currentRenderer is tested for null then it is used to render outside the scope of the test. The rendering is now done only if the pointer is not null.