### PR TITLE
[CI] Use jammy instead of focal as fallback for installing latest version of CMake

### DIFF
--- a/.dev/docker/env/Dockerfile
+++ b/.dev/docker/env/Dockerfile
@@ -52,7 +52,14 @@ RUN apt-get update \
  && if [ "$USE_LATEST_CMAKE" = true ] ; then \
       cmake_ubuntu_version=$(lsb_release -cs) ; \
       if ! wget -q --method=HEAD "https://apt.kitware.com/ubuntu/dists/$cmake_ubuntu_version/Release"; then \
-        cmake_ubuntu_version="focal" ; \
+        ubuntu_version=$(lsb_release -sr) ; \
+        if dpkg --compare-versions ${ubuntu_version} ge 22.04; then \
+          cmake_ubuntu_version="jammy" ; \
+        elif dpkg --compare-versions ${ubuntu_version} ge 20.04; then \
+          cmake_ubuntu_version="focal" ; \
+        else \
+          cmake_ubuntu_version="bionic" ; \
+        fi ; \
       fi ; \
       wget -qO - https://apt.kitware.com/kitware-archive.sh | bash -s -- --release $cmake_ubuntu_version ; \
       apt-get update ; \


### PR DESCRIPTION
When installing CMake 3.25.0 from focal repo, `libssl1.1 (>= 1.1.1)` is requested, which [doesn't exists anymore](https://packages.ubuntu.com/search?suite=all&keywords=libssl1.1) as package since 22.04 (seems 3.24.2 didn't had this dependency). Therefore update the fallback ubuntu version.

//EDIT: Seems they didnt' have Jammy support until now, as we get now `Only Ubuntu Xenial (16.04), Bionic (18.04), and Focal (20.04) are supported. Aborting.`. So the 22.10 image will be built now with the default CMake version, until they are adding support of Jammy.

//EDIT2: Further research showed: They already have Jammy support, but missed to update the script `kitware-archive.sh`. I will [ping the CMake devs](https://gitlab.kitware.com/cmake/cmake/-/issues/24177).

//EDIT3: They have now support of Jammy and I could successfully test this PR on our CI.