### PR TITLE
Add OpenCV to preinstalled components

### DIFF
--- a/.dev/docker/env/Dockerfile
+++ b/.dev/docker/env/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update \
       libflann-dev \
       libglew-dev \
       libgtest-dev \
+      libopencv-dev \
       libopenni-dev \
       libopenni2-dev \
       libproj-dev \

--- a/.dev/docker/windows/Dockerfile
+++ b/.dev/docker/windows/Dockerfile
@@ -48,4 +48,4 @@ COPY $PLATFORM'-windows-rel.cmake' 'c:\vcpkg\triplets\'$PLATFORM'-windows-rel.cm
 
 RUN cd .\vcpkg;                                                `
     .\bootstrap-vcpkg.bat;                                            `
-    .\vcpkg install boost flann eigen3 qhull vtk[qt,opengl] gtest benchmark openni2 --triplet $Env:PLATFORM-windows-rel --clean-after-build;
+    .\vcpkg install boost flann eigen3 qhull vtk[qt,opengl] gtest benchmark opencv openni2 --triplet $Env:PLATFORM-windows-rel --clean-after-build;


### PR DESCRIPTION
OpenCV is required for some components:
- GPU Kinfu (optional)
- Tutorials davidSDK & Ensenso Cameras (required)
