### PR TITLE
Remove leftover define of Intel Threading Building Blocks

### DIFF
--- a/pcl_config.h.in
+++ b/pcl_config.h.in
@@ -34,8 +34,6 @@
   #endif //PCL_MINOR_VERSION
 #endif 
 
-#cmakedefine HAVE_TBB 1
-
 #cmakedefine HAVE_OPENNI 1
 
 #cmakedefine HAVE_OPENNI2 1


### PR DESCRIPTION
TBB was removed some years ago: 4ee6b45efe83ab2074712e5c062b4a1484316c59 (before the release of PCL-1.0.0 🤣 )