### PR TITLE
Use constexpr variables if possible

### DIFF
--- a/apps/in_hand_scanner/src/icp.cpp
+++ b/apps/in_hand_scanner/src/icp.cpp
@@ -161,7 +161,7 @@ pcl::ihs::ICP::findTransformation(const MeshConstPtr& mesh_model,
 {
   // Check the input
   // TODO: Double check the minimum number of points necessary for icp
-  const std::size_t n_min = 4;
+  constexpr std::size_t n_min = 4;
 
   if (mesh_model->sizeVertices() < n_min || cloud_data->size() < n_min) {
     std::cerr << "ERROR in icp.cpp: Not enough input points!\n";

--- a/apps/in_hand_scanner/src/integration.cpp
+++ b/apps/in_hand_scanner/src/integration.cpp
@@ -124,7 +124,7 @@ pcl::ihs::Integration::reconstructMesh(const CloudXYZRGBNormalConstPtr& cloud_da
   // *   3 - 0  //
   const int offset_1 = -width;
   const int offset_2 = -width - 1;
-  const int offset_3 = -1;
+  constexpr int offset_3 = -1;
   const int offset_4 = -width - 2;
 
   for (int r = 1; r < height; ++r) {
@@ -262,7 +262,7 @@ pcl::ihs::Integration::merge(const CloudXYZRGBNormalConstPtr& cloud_data,
   // *   3 - 0  //
   const int offset_1 = -width;
   const int offset_2 = -width - 1;
-  const int offset_3 = -1;
+  constexpr int offset_3 = -1;
   const int offset_4 = -width - 2;
 
   const float dot_min = std::cos(max_angle_ * 17.45329252e-3); // deg to rad

--- a/apps/in_hand_scanner/src/main_window.cpp
+++ b/apps/in_hand_scanner/src/main_window.cpp
@@ -70,7 +70,7 @@ pcl::ihs::MainWindow::MainWindow(QWidget* parent)
   spacer->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
   ui_->toolBar->insertWidget(ui_->actionHelp, spacer);
 
-  const double max = std::numeric_limits<double>::max();
+  constexpr double max = std::numeric_limits<double>::max();
 
   // In hand scanner
   QHBoxLayout* layout = new QHBoxLayout(ui_->placeholder_in_hand_scanner);

--- a/apps/in_hand_scanner/src/opengl_viewer.cpp
+++ b/apps/in_hand_scanner/src/opengl_viewer.cpp
@@ -484,7 +484,7 @@ pcl::ihs::OpenGLViewer::addMesh(const CloudXYZRGBNormalConstPtr& cloud,
   const int h = cloud->height;
   const int offset_1 = -w;
   const int offset_2 = -w - 1;
-  const int offset_3 = -1;
+  constexpr int offset_3 = -1;
 
   FaceVertexMeshPtr mesh(new FaceVertexMesh());
   mesh->transformation = T;
@@ -1083,7 +1083,7 @@ pcl::ihs::OpenGLViewer::initializeGL()
 void
 pcl::ihs::OpenGLViewer::setupViewport(const int w, const int h)
 {
-  const float aspect_ratio = 4. / 3.;
+  constexpr float aspect_ratio = 4. / 3.;
 
   // Use the biggest possible area of the window to draw to
   //    case 1 (w < w_scaled):        case 2 (w >= w_scaled):

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/localTypes.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/localTypes.h
@@ -167,25 +167,25 @@ struct IncIndex
 /// A helpful const representing the number of elements in our vectors.
 /// This is used for all operations that require the copying of the vector.
 /// Although this is used in a fairly generic way, the display requires 3D.
-const unsigned int XYZ_SIZE = 3;
+constexpr unsigned int XYZ_SIZE = 3;
 
 /// A helpful const representing the number of elements in each row/col in
 /// our matrices. This is used for all operations that require the copying of
 /// the matrix.
-const unsigned int MATRIX_SIZE_DIM = 4;
+constexpr unsigned int MATRIX_SIZE_DIM = 4;
 
 /// A helpful const representing the number of elements in our matrices.
 /// This is used for all operations that require the copying of the matrix.
-const unsigned int MATRIX_SIZE = MATRIX_SIZE_DIM * MATRIX_SIZE_DIM;
+constexpr unsigned int MATRIX_SIZE = MATRIX_SIZE_DIM * MATRIX_SIZE_DIM;
 
 /// The default window width
-const unsigned int WINDOW_WIDTH = 1200;
+constexpr unsigned int WINDOW_WIDTH = 1200;
 /// The default window height
-const unsigned int WINDOW_HEIGHT = 1000;
+constexpr unsigned int WINDOW_HEIGHT = 1000;
 
 /// The default z translation used to push the world origin in front of the
 /// display
-const float DISPLAY_Z_TRANSLATION = -2.0f;
+constexpr float DISPLAY_Z_TRANSLATION = -2.0f;
 
 /// The radius of the trackball given as a percentage of the screen width
-const float TRACKBALL_RADIUS_SCALE = 0.4f;
+constexpr float TRACKBALL_RADIUS_SCALE = 0.4f;

--- a/apps/src/feature_matching.cpp
+++ b/apps/src/feature_matching.cpp
@@ -324,7 +324,7 @@ ICCVTutorial<FeatureType>::findCorrespondences(
 
   // Find the index of the best match for each keypoint, and store it in
   // "correspondences_out"
-  const int k = 1;
+  constexpr int k = 1;
   pcl::Indices k_indices(k);
   std::vector<float> k_squared_distances(k);
   for (int i = 0; i < static_cast<int>(source->size()); ++i) {

--- a/apps/src/multiscale_feature_persistence_example.cpp
+++ b/apps/src/multiscale_feature_persistence_example.cpp
@@ -47,7 +47,7 @@
 using namespace pcl;
 
 const Eigen::Vector4f subsampling_leaf_size(0.01f, 0.01f, 0.01f, 0.0f);
-const float normal_estimation_search_radius = 0.05f;
+constexpr float normal_estimation_search_radius = 0.05f;
 
 void
 subsampleAndCalculateNormals(PointCloud<PointXYZ>::Ptr& cloud,

--- a/apps/src/openni_feature_persistence.cpp
+++ b/apps/src/openni_feature_persistence.cpp
@@ -69,11 +69,11 @@ using namespace std::chrono_literals;
   } while (false)
 // clang-format on
 
-const float default_subsampling_leaf_size = 0.02f;
-const float default_normal_search_radius = 0.041f;
+constexpr float default_subsampling_leaf_size = 0.02f;
+constexpr float default_normal_search_radius = 0.041f;
 const double aux[] = {0.21, 0.32};
 const std::vector<double> default_scales_vector(aux, aux + 2);
-const float default_alpha = 1.2f;
+constexpr float default_alpha = 1.2f;
 
 template <typename PointType>
 class OpenNIFeaturePersistence {

--- a/apps/src/openni_mobile_server.cpp
+++ b/apps/src/openni_mobile_server.cpp
@@ -79,7 +79,7 @@ CopyPointCloudToBuffers(const pcl::PointCloud<pcl::PointXYZRGBA>::ConstPtr& clou
         point.x > bounds_max.x || point.y > bounds_max.y || point.z > bounds_max.z)
       continue;
 
-    const int conversion_factor = 500;
+    constexpr int conversion_factor = 500;
 
     cloud_buffers.points[j * 3 + 0] = static_cast<short>(point.x * conversion_factor);
     cloud_buffers.points[j * 3 + 1] = static_cast<short>(point.y * conversion_factor);

--- a/apps/src/openni_organized_edge_detection.cpp
+++ b/apps/src/openni_organized_edge_detection.cpp
@@ -68,7 +68,7 @@ public:
                                      *this);
     viewer->resetCameraViewpoint("cloud");
 
-    const int point_size = 2;
+    constexpr int point_size = 2;
     viewer->addPointCloud<PointT>(cloud, "nan boundary edges");
     viewer->setPointCloudRenderingProperties(
         pcl::visualization::PCL_VISUALIZER_POINT_SIZE,

--- a/apps/src/openni_shift_to_depth_conversion.cpp
+++ b/apps/src/openni_shift_to_depth_conversion.cpp
@@ -164,7 +164,7 @@ protected:
     int centerY = static_cast<int>(height_arg / 2);
 
     const float fl_const = 1.0f / focalLength_arg;
-    static const float bad_point = std::numeric_limits<float>::quiet_NaN();
+    constexpr float bad_point = std::numeric_limits<float>::quiet_NaN();
 
     std::size_t i = 0;
     for (int y = -centerY; y < +centerY; ++y)

--- a/apps/src/pcd_organized_edge_detection.cpp
+++ b/apps/src/pcd_organized_edge_detection.cpp
@@ -227,7 +227,7 @@ compute(const pcl::PCLPointCloud2::ConstPtr& input,
   pcl::copyPointCloud(*cloud, label_indices[3].indices, *high_curvature_edges);
   pcl::copyPointCloud(*cloud, label_indices[4].indices, *rgb_edges);
 
-  const int point_size = 2;
+  constexpr int point_size = 2;
   viewer.addPointCloud<pcl::PointXYZRGBA>(nan_boundary_edges, "nan boundary edges");
   viewer.setPointCloudRenderingProperties(
       pcl::visualization::PCL_VISUALIZER_POINT_SIZE, point_size, "nan boundary edges");

--- a/apps/src/ppf_object_recognition.cpp
+++ b/apps/src/ppf_object_recognition.cpp
@@ -15,7 +15,7 @@ using namespace pcl;
 using namespace std::chrono_literals;
 
 const Eigen::Vector4f subsampling_leaf_size(0.02f, 0.02f, 0.02f, 0.0f);
-const float normal_estimation_search_radius = 0.05f;
+constexpr float normal_estimation_search_radius = 0.05f;
 
 PointCloud<PointNormal>::Ptr
 subsampleAndCalculateNormals(const PointCloud<PointXYZ>::Ptr& cloud)

--- a/apps/src/pyramid_surface_matching.cpp
+++ b/apps/src/pyramid_surface_matching.cpp
@@ -9,7 +9,7 @@ using namespace pcl;
 #include <iostream>
 
 const Eigen::Vector4f subsampling_leaf_size(0.02f, 0.02f, 0.02f, 0.0f);
-const float normal_estimation_search_radius = 0.05f;
+constexpr float normal_estimation_search_radius = 0.05f;
 
 void
 subsampleAndCalculateNormals(PointCloud<PointXYZ>::Ptr& cloud,

--- a/apps/src/statistical_multiscale_interest_region_extraction_example.cpp
+++ b/apps/src/statistical_multiscale_interest_region_extraction_example.cpp
@@ -42,8 +42,8 @@
 
 using namespace pcl;
 
-const float subsampling_leaf_size = 0.003f;
-const float base_scale = 0.005f;
+constexpr float subsampling_leaf_size = 0.003f;
+constexpr float base_scale = 0.005f;
 
 int
 main(int, char** argv)

--- a/common/include/pcl/common/impl/copy_point.hpp
+++ b/common/include/pcl/common/impl/copy_point.hpp
@@ -118,10 +118,10 @@ struct CopyPointHelper<PointInT, PointOutT,
     using FieldListInT = typename pcl::traits::fieldList<PointInT>::type;
     using FieldListOutT = typename pcl::traits::fieldList<PointOutT>::type;
     using FieldList = typename pcl::intersect<FieldListInT, FieldListOutT>::type;
-    const std::uint32_t offset_in  = boost::mpl::if_<pcl::traits::has_field<PointInT, pcl::fields::rgb>,
+    constexpr std::uint32_t offset_in  = boost::mpl::if_<pcl::traits::has_field<PointInT, pcl::fields::rgb>,
                                                 pcl::traits::offset<PointInT, pcl::fields::rgb>,
                                                 pcl::traits::offset<PointInT, pcl::fields::rgba> >::type::value;
-    const std::uint32_t offset_out = boost::mpl::if_<pcl::traits::has_field<PointOutT, pcl::fields::rgb>,
+    constexpr std::uint32_t offset_out = boost::mpl::if_<pcl::traits::has_field<PointOutT, pcl::fields::rgb>,
                                                 pcl::traits::offset<PointOutT, pcl::fields::rgb>,
                                                 pcl::traits::offset<PointOutT, pcl::fields::rgba> >::type::value;
     pcl::for_each_type <FieldList> (pcl::NdConcatenateFunctor <PointInT, PointOutT> (point_in, point_out));

--- a/common/include/pcl/common/impl/eigen.hpp
+++ b/common/include/pcl/common/impl/eigen.hpp
@@ -89,7 +89,7 @@ computeRoots (const Matrix& m, Roots& roots)
     computeRoots2 (c2, c1, roots);
   else
   {
-    const Scalar s_inv3 = Scalar (1.0 / 3.0);
+    constexpr Scalar s_inv3 = Scalar(1.0 / 3.0);
     const Scalar s_sqrt3 = std::sqrt (Scalar (3.0));
     // Construct the parameters used in classifying the roots of the equation
     // and in solving the equation for the roots in closed form.

--- a/common/include/pcl/point_representation.h
+++ b/common/include/pcl/point_representation.h
@@ -250,7 +250,7 @@ namespace pcl
       template<typename Key> inline void operator() ()
       {
         using FieldT = typename pcl::traits::datatype<PointDefault, Key>::type;
-        const int NrDims = pcl::traits::datatype<PointDefault, Key>::size;
+        constexpr int NrDims = pcl::traits::datatype<PointDefault, Key>::size;
         Helper<Key, FieldT, NrDims>::copyPoint (p1_, p2_, f_idx_);
       }
 

--- a/common/include/pcl/register_point_struct.h
+++ b/common/include/pcl/register_point_struct.h
@@ -100,7 +100,7 @@ namespace pcl
     plus (std::remove_const_t<T> &l, const T &r)
     {
       using type = std::remove_all_extents_t<T>;
-      static const std::uint32_t count = sizeof (T) / sizeof (type);
+      constexpr std::uint32_t count = sizeof(T) / sizeof(type);
       for (std::uint32_t i = 0; i < count; ++i)
         l[i] += r[i];
     }
@@ -117,7 +117,7 @@ namespace pcl
     plusscalar (T1 &p, const T2 &scalar)
     {
       using type = std::remove_all_extents_t<T1>;
-      static const std::uint32_t count = sizeof (T1) / sizeof (type);
+      constexpr std::uint32_t count = sizeof(T1) / sizeof(type);
       for (std::uint32_t i = 0; i < count; ++i)
         p[i] += scalar;
     }
@@ -134,7 +134,7 @@ namespace pcl
     minus (std::remove_const_t<T> &l, const T &r)
     {
       using type = std::remove_all_extents_t<T>;
-      static const std::uint32_t count = sizeof (T) / sizeof (type);
+      constexpr std::uint32_t count = sizeof(T) / sizeof(type);
       for (std::uint32_t i = 0; i < count; ++i)
         l[i] -= r[i];
     }
@@ -151,7 +151,7 @@ namespace pcl
     minusscalar (T1 &p, const T2 &scalar)
     {
       using type = std::remove_all_extents_t<T1>;
-      static const std::uint32_t count = sizeof (T1) / sizeof (type);
+      constexpr std::uint32_t count = sizeof(T1) / sizeof(type);
       for (std::uint32_t i = 0; i < count; ++i)
         p[i] -= scalar;
     }
@@ -168,7 +168,7 @@ namespace pcl
     mulscalar (T1 &p, const T2 &scalar)
     {
       using type = std::remove_all_extents_t<T1>;
-      static const std::uint32_t count = sizeof (T1) / sizeof (type);
+      constexpr std::uint32_t count = sizeof(T1) / sizeof(type);
       for (std::uint32_t i = 0; i < count; ++i)
         p[i] *= scalar;
     }
@@ -185,7 +185,7 @@ namespace pcl
     divscalar (T1 &p, const T2 &scalar)
     {
       using type = std::remove_all_extents_t<T1>;
-      static const std::uint32_t count = sizeof (T1) / sizeof (type);
+      constexpr std::uint32_t count = sizeof (T1) / sizeof (type);
       for (std::uint32_t i = 0; i < count; ++i)
         p[i] /= scalar;
     }
@@ -202,7 +202,7 @@ namespace pcl
     divscalar2 (ArrayT &p, const ScalarT &scalar)
     {
       using type = std::remove_all_extents_t<ArrayT>;
-      static const std::uint32_t count = sizeof (ArrayT) / sizeof (type);
+      constexpr std::uint32_t count = sizeof (ArrayT) / sizeof (type);
       for (std::uint32_t i = 0; i < count; ++i)
         p[i] = scalar / p[i];
     }

--- a/examples/features/example_difference_of_normals.cpp
+++ b/examples/features/example_difference_of_normals.cpp
@@ -99,7 +99,7 @@ int main (int argc, char *argv[])
 
     // Create downsampled point cloud for DoN NN search with large scale
     large_cloud_downsampled = PointCloud<PointT>::Ptr(new pcl::PointCloud<PointT>);
-    const float largedownsample = float (scale2/decimation);
+    constexpr float largedownsample = float(scale2 / decimation);
     sor.setLeafSize (largedownsample, largedownsample, largedownsample);
     sor.filter (*large_cloud_downsampled);
     std::cout << "Using leaf size of " << largedownsample << " for large scale, " << large_cloud_downsampled->size() << " points" << std::endl;

--- a/examples/keypoints/example_sift_keypoint_estimation.cpp
+++ b/examples/keypoints/example_sift_keypoint_estimation.cpp
@@ -57,10 +57,10 @@ main(int, char** argv)
   std::cout << "points: " << cloud->size () <<std::endl;
   
   // Parameters for sift computation
-  const float min_scale = 0.1f;
-  const int n_octaves = 6;
-  const int n_scales_per_octave = 10;
-  const float min_contrast = 0.5f;
+  constexpr float min_scale = 0.1f;
+  constexpr int n_octaves = 6;
+  constexpr int n_scales_per_octave = 10;
+  constexpr float min_contrast = 0.5f;
   
   
   // Estimate the sift interest points using Intensity values from RGB values

--- a/examples/keypoints/example_sift_normal_keypoint_estimation.cpp
+++ b/examples/keypoints/example_sift_normal_keypoint_estimation.cpp
@@ -63,10 +63,10 @@ main(int, char** argv)
   std::cout << "points: " << cloud_xyz->size () <<std::endl;
   
   // Parameters for sift computation
-  const float min_scale = 0.01f;
-  const int n_octaves = 3;
-  const int n_scales_per_octave = 4;
-  const float min_contrast = 0.001f;
+  constexpr float min_scale = 0.01f;
+  constexpr int n_octaves = 3;
+  constexpr int n_scales_per_octave = 4;
+  constexpr float min_contrast = 0.001f;
   
   // Estimate the normals of the cloud_xyz
   pcl::NormalEstimation<pcl::PointXYZ, pcl::PointNormal> ne;

--- a/examples/keypoints/example_sift_z_keypoint_estimation.cpp
+++ b/examples/keypoints/example_sift_z_keypoint_estimation.cpp
@@ -75,10 +75,10 @@ main(int, char** argv)
   std::cout << "points: " << cloud_xyz->size () <<std::endl;
   
   // Parameters for sift computation
-  const float min_scale = 0.005f;
-  const int n_octaves = 6;
-  const int n_scales_per_octave = 4;
-  const float min_contrast = 0.005f;
+  constexpr float min_scale = 0.005f;
+  constexpr int n_octaves = 6;
+  constexpr int n_scales_per_octave = 4;
+  constexpr float min_contrast = 0.005f;
   
   // Estimate the sift interest points using z values from xyz as the Intensity variants
   pcl::SIFTKeypoint<pcl::PointXYZ, pcl::PointWithScale> sift;

--- a/examples/segmentation/example_extract_clusters_normals.cpp
+++ b/examples/segmentation/example_extract_clusters_normals.cpp
@@ -79,9 +79,9 @@ main (int argc, char **argv)
   
   // Extracting Euclidean clusters using cloud and its normals
   std::vector<pcl::PointIndices> cluster_indices;
-  const float tolerance = 0.5f; // 50cm tolerance in (x, y, z) coordinate system
-  const double eps_angle = 5 * (M_PI / 180.0); // 5degree tolerance in normals
-  const unsigned int min_cluster_size = 50;
+  constexpr float tolerance = 0.5f; // 50cm tolerance in (x, y, z) coordinate system
+  constexpr double eps_angle = 5 * (M_PI / 180.0); // 5degree tolerance in normals
+  constexpr unsigned int min_cluster_size = 50;
  
   pcl::extractEuclideanClusters (*cloud_ptr, *cloud_normals, tolerance, tree_ec, cluster_indices, eps_angle, min_cluster_size);
 

--- a/features/include/pcl/features/impl/brisk_2d.hpp
+++ b/features/include/pcl/features/impl/brisk_2d.hpp
@@ -124,7 +124,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::generateKernel (
   scale_list_ = new float[scales_];
   size_list_  = new unsigned int[scales_];
 
-  const float sigma_scale = 1.3f;
+  constexpr float sigma_scale = 1.3f;
 
   for (unsigned int scale = 0; scale < scales_; ++scale)
   {

--- a/gpu/kinfu/tools/kinfu_app.cpp
+++ b/gpu/kinfu/tools/kinfu_app.cpp
@@ -732,7 +732,7 @@ struct KinFuApp
   {
     if(registration_)
     {
-      const int max_color_integration_weight = 2;
+      constexpr int max_color_integration_weight = 2;
       kinfu_.initColorIntegration(max_color_integration_weight);
       integrate_colors_ = true;      
     }    

--- a/gpu/kinfu/tools/record_tsdfvolume.cpp
+++ b/gpu/kinfu/tools/record_tsdfvolume.cpp
@@ -138,8 +138,8 @@ DeviceVolume::createFromDepth (const pcl::device::PtrStepSz<const unsigned short
 
   using Matrix3frm = Eigen::Matrix<float, 3, 3, Eigen::RowMajor>;
 
-  const int rows = 480;
-  const int cols = 640;
+  constexpr int rows = 480;
+  constexpr int cols = 640;
 
   // scale depth values
   gpu::DeviceArray2D<float> device_depth_scaled;
@@ -197,7 +197,7 @@ DeviceVolume::getVolume (pcl::TSDFVolume<VoxelT, WeightT>::Ptr &volume)
 bool
 DeviceVolume::getCloud (pcl::PointCloud<pcl::PointXYZ>::Ptr &cloud)
 {
-  const int DEFAULT_VOLUME_CLOUD_BUFFER_SIZE = 10 * 1000 * 1000;
+  constexpr int DEFAULT_VOLUME_CLOUD_BUFFER_SIZE = 10 * 1000 * 1000;
 
   // point buffer on the device
   pcl::gpu::DeviceArray<pcl::PointXYZ> device_cloud_buffer (DEFAULT_VOLUME_CLOUD_BUFFER_SIZE);

--- a/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
+++ b/gpu/kinfu_large_scale/tools/kinfuLS_app.cpp
@@ -790,7 +790,7 @@ struct KinFuLSApp
   {
     if(registration_)
     {
-      const int max_color_integration_weight = 2;
+      constexpr int max_color_integration_weight = 2;
       kinfu_->initColorIntegration(max_color_integration_weight);
       integrate_colors_ = true;      
     }    

--- a/gpu/kinfu_large_scale/tools/record_maps_rgb.cpp
+++ b/gpu/kinfu_large_scale/tools/record_maps_rgb.cpp
@@ -71,7 +71,7 @@ do \
 bool is_done = false;
 std::mutex io_mutex;
 
-const int BUFFER_SIZE = 1000;
+constexpr int BUFFER_SIZE = 1000;
 static int counter = 1;
 //////////////////////////////////////////////////////////////////////////////////////////
 class MapsBuffer

--- a/gpu/people/include/pcl/gpu/people/tree.h
+++ b/gpu/people/include/pcl/gpu/people/tree.h
@@ -53,7 +53,7 @@ namespace pcl
       namespace trees
       {
         // this has nothing to do here...
-        static const double focal = 1000.;
+        constexpr double focal = 1000.;
 
         // ###############################################
         // compile type values

--- a/gpu/people/src/cuda/nvidia/NCV.hpp
+++ b/gpu/people/src/cuda/nvidia/NCV.hpp
@@ -212,8 +212,8 @@ NCV_CT_ASSERT(sizeof(NcvPoint2D32u) == 2 * sizeof(Ncv32u));
 //
 //==============================================================================
 
-const Ncv32u K_WARP_SIZE = 32;
-const Ncv32u K_LOG2_WARP_SIZE = 5;
+constexpr Ncv32u K_WARP_SIZE = 32;
+constexpr Ncv32u K_LOG2_WARP_SIZE = 5;
 
 //==============================================================================
 //

--- a/io/include/pcl/compression/impl/entropy_range_coder.hpp
+++ b/io/include/pcl/compression/impl/entropy_range_coder.hpp
@@ -54,9 +54,9 @@ pcl::AdaptiveRangeCoder::encodeCharVectorToStream (const std::vector<char>& inpu
   DWord freq[257];
 
   // define limits
-  const DWord top = static_cast<DWord> (1) << 24;
-  const DWord bottom = static_cast<DWord> (1) << 16;
-  const DWord maxRange = static_cast<DWord> (1) << 16;
+  constexpr DWord top = static_cast<DWord>(1) << 24;
+  constexpr DWord bottom = static_cast<DWord>(1) << 16;
+  constexpr DWord maxRange = static_cast<DWord>(1) << 16;
 
   auto input_size = static_cast<unsigned> (inputByteVector_arg.size ());
 
@@ -132,9 +132,9 @@ pcl::AdaptiveRangeCoder::decodeStreamToCharVector (std::istream& inputByteStream
   DWord freq[257];
 
   // define limits
-  const DWord top = static_cast<DWord> (1) << 24;
-  const DWord bottom = static_cast<DWord> (1) << 16;
-  const DWord maxRange = static_cast<DWord> (1) << 16;
+  constexpr DWord top = static_cast<DWord>(1) << 24;
+  constexpr DWord bottom = static_cast<DWord>(1) << 16;
+  constexpr DWord maxRange = static_cast<DWord>(1) << 16;
 
   auto output_size = static_cast<unsigned> (outputByteVector_arg.size ());
 
@@ -222,9 +222,9 @@ pcl::StaticRangeCoder::encodeIntVectorToStream (std::vector<unsigned int>& input
                                                 std::ostream& outputByteStream_arg)
 {
   // define numerical limits
-  const std::uint64_t top = static_cast<std::uint64_t> (1) << 56;
-  const std::uint64_t bottom = static_cast<std::uint64_t> (1) << 48;
-  const std::uint64_t maxRange = static_cast<std::uint64_t> (1) << 48;
+  constexpr std::uint64_t top = static_cast<std::uint64_t>(1) << 56;
+  constexpr std::uint64_t bottom = static_cast<std::uint64_t>(1) << 48;
+  constexpr std::uint64_t maxRange = static_cast<std::uint64_t>(1) << 48;
 
   auto input_size = static_cast<unsigned long> (inputIntVector_arg.size ());
 
@@ -353,8 +353,8 @@ pcl::StaticRangeCoder::decodeStreamToIntVector (std::istream& inputByteStream_ar
                                                 std::vector<unsigned int>& outputIntVector_arg)
 {
   // define range limits
-  const std::uint64_t top = static_cast<std::uint64_t> (1) << 56;
-  const std::uint64_t bottom = static_cast<std::uint64_t> (1) << 48;
+  constexpr std::uint64_t top = static_cast<std::uint64_t>(1) << 56;
+  constexpr std::uint64_t bottom = static_cast<std::uint64_t>(1) << 48;
 
   std::uint64_t frequencyTableSize;
   unsigned char frequencyTableByteSize;
@@ -445,9 +445,9 @@ pcl::StaticRangeCoder::encodeCharVectorToStream (const std::vector<char>& inputB
   DWord freq[257];
 
   // define numerical limits
-  const DWord top = static_cast<DWord> (1) << 24;
-  const DWord bottom = static_cast<DWord> (1) << 16;
-  const DWord maxRange = static_cast<DWord> (1) << 16;
+  constexpr DWord top = static_cast<DWord>(1) << 24;
+  constexpr DWord bottom = static_cast<DWord>(1) << 16;
+  constexpr DWord maxRange = static_cast<DWord>(1) << 16;
 
   DWord low, range;
 
@@ -543,8 +543,8 @@ pcl::StaticRangeCoder::decodeStreamToCharVector (std::istream& inputByteStream_a
   DWord freq[257];
 
   // define range limits
-  const DWord top = static_cast<DWord> (1) << 24;
-  const DWord bottom = static_cast<DWord> (1) << 16;
+  constexpr DWord top = static_cast<DWord>(1) << 24;
+  constexpr DWord bottom = static_cast<DWord>(1) << 16;
 
   DWord low, range;
   DWord code;

--- a/io/tools/openni_pcd_recorder.cpp
+++ b/io/tools/openni_pcd_recorder.cpp
@@ -94,7 +94,7 @@ getTotalSystemMemory ()
 const std::size_t BUFFER_SIZE = std::size_t (getTotalSystemMemory () / (640 * 480 * sizeof (pcl::PointXYZRGBA)));
 #else
 
-const std::size_t BUFFER_SIZE = 200;
+constexpr std::size_t BUFFER_SIZE = 200;
 #endif
 
 //////////////////////////////////////////////////////////////////////////////////////////

--- a/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
@@ -504,7 +504,7 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::refineCorners (PointCloudOu
   Eigen::Matrix3f nnT;
   Eigen::Matrix3f NNT;
   Eigen::Vector3f NNTp;
-  const unsigned max_iterations = 10;
+  constexpr unsigned max_iterations = 10;
 #pragma omp parallel for \
   default(none) \
   shared(corners) \

--- a/keypoints/include/pcl/keypoints/impl/sift_keypoint.hpp
+++ b/keypoints/include/pcl/keypoints/impl/sift_keypoint.hpp
@@ -128,7 +128,7 @@ pcl::SIFTKeypoint<PointInT, PointOutT>::detectKeypoints (PointCloudOut &output)
     cloud = temp;
 
     // Make sure the downsampled cloud still has enough points
-    const std::size_t min_nr_points = 25;
+    constexpr std::size_t min_nr_points = 25;
     if (cloud->size () < min_nr_points)
       break;
 
@@ -261,7 +261,7 @@ pcl::SIFTKeypoint<PointInT, PointOutT>::findScaleSpaceExtrema (
     const PointCloudIn &input, KdTree &tree, const Eigen::MatrixXf &diff_of_gauss, 
     pcl::Indices &extrema_indices, std::vector<int> &extrema_scales)
 {
-  const int k = 25;
+  constexpr int k = 25;
   pcl::Indices nn_indices (k);
   std::vector<float> nn_dist (k);
 

--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -475,7 +475,7 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
     adoptBoundingBoxToPoint(const PointT& point_arg)
 {
 
-  const float minValue = std::numeric_limits<float>::epsilon();
+  constexpr float minValue = std::numeric_limits<float>::epsilon();
 
   // increase octree size until point fits into bounding box
   while (true) {
@@ -679,7 +679,7 @@ void
 pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>::
     getKeyBitSize()
 {
-  const float minValue = std::numeric_limits<float>::epsilon();
+  constexpr float minValue = std::numeric_limits<float>::epsilon();
 
   // find maximum key values for x, y, z
   const auto max_key_x =

--- a/octree/include/pcl/octree/octree_search.h
+++ b/octree/include/pcl/octree/octree_search.h
@@ -534,7 +534,7 @@ protected:
                        unsigned char& a) const
   {
     // Account for division by zero when direction vector is 0.0
-    const float epsilon = 1e-10f;
+    constexpr float epsilon = 1e-10f;
     if (direction.x() == 0.0)
       direction.x() = epsilon;
     if (direction.y() == 0.0)

--- a/outofcore/include/pcl/outofcore/impl/octree_base.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base.hpp
@@ -209,7 +209,7 @@ namespace pcl
     {
       std::unique_lock < std::shared_timed_mutex > lock (read_write_mutex_);
 
-      const bool _FORCE_BB_CHECK = true;
+      constexpr bool _FORCE_BB_CHECK = true;
       
       std::uint64_t pt_added = root_node_->addDataToLeaf (p, _FORCE_BB_CHECK);
 
@@ -569,7 +569,7 @@ namespace pcl
 
       std::unique_lock < std::shared_timed_mutex > lock (read_write_mutex_);
 
-      const int number_of_nodes = 1;
+      constexpr int number_of_nodes = 1;
 
       std::vector<BranchNode*> current_branch (number_of_nodes, static_cast<BranchNode*>(nullptr));
       current_branch[0] = root_node_;

--- a/outofcore/tools/outofcore_process.cpp
+++ b/outofcore/tools/outofcore_process.cpp
@@ -70,8 +70,8 @@ using pcl::console::print_info;
 
 using octree_disk = OutofcoreOctreeBase<>;
 
-const int OCTREE_DEPTH (0);
-const int OCTREE_RESOLUTION (1);
+constexpr int OCTREE_DEPTH (0);
+constexpr int OCTREE_RESOLUTION(1);
 
 PCLPointCloud2::Ptr
 getCloudFromFile (boost::filesystem::path pcd_path)

--- a/recognition/include/pcl/recognition/color_gradient_modality.h
+++ b/recognition/include/pcl/recognition/color_gradient_modality.h
@@ -295,7 +295,7 @@ computeGaussianKernel (const std::size_t kernel_size, const float sigma, std::ve
 {
   // code taken from OpenCV
   const int n = int (kernel_size);
-  const int SMALL_GAUSSIAN_SIZE = 7;
+  constexpr int SMALL_GAUSSIAN_SIZE = 7;
   static const float small_gaussian_tab[][SMALL_GAUSSIAN_SIZE] =
   {
       {1.f},
@@ -340,7 +340,7 @@ pcl::ColorGradientModality<PointInT>::
 processInputData ()
 {
   // compute gaussian kernel values
-  const std::size_t kernel_size = 7;
+  constexpr std::size_t kernel_size = 7;
   std::vector<float> kernel_values;
   computeGaussianKernel (kernel_size, 0.0f, kernel_values);
 
@@ -971,7 +971,7 @@ quantizeColorGradients ()
 
   quantized_color_gradients_.resize (width, height);
 
-  const float angleScale = 16.0f/360.0f;
+  constexpr float angleScale = 16.0f / 360.0f;
 
   //float min_angle = std::numeric_limits<float>::max ();
   //float max_angle = -std::numeric_limits<float>::max ();

--- a/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
+++ b/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
@@ -140,7 +140,7 @@ pcl::features::ISMVoteList<PointT>::findStrongestPeaks (
 
   // heuristic: start from NUM_INIT_PTS different locations selected uniformly
   // on the votes. Intuitively, it is likely to get a good location in dense regions.
-  const int NUM_INIT_PTS = 100;
+  constexpr int NUM_INIT_PTS = 100;
   double SIGMA_DIST = in_sigma;// rule of thumb: 10% of the object radius
   const double FINAL_EPS = SIGMA_DIST / 100;// another heuristic
 
@@ -1128,7 +1128,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::simplifyCl
   grid.filter (temp_cloud);
 
   //extract indices of points from source cloud which are closest to grid points
-  const float max_value = std::numeric_limits<float>::max ();
+  constexpr float max_value = std::numeric_limits<float>::max ();
 
   const auto num_source_points = in_point_cloud->size ();
   const auto num_sample_points = temp_cloud.size ();
@@ -1262,7 +1262,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::computeKMe
   int flags,
   Eigen::MatrixXf& cluster_centers)
 {
-  const int spp_trials = 3;
+  constexpr int spp_trials = 3;
   std::size_t number_of_points = points_to_cluster.rows () > 1 ? points_to_cluster.rows () : points_to_cluster.cols ();
   int feature_dimension = points_to_cluster.rows () > 1 ? FeatureSize : 1;
 

--- a/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
+++ b/recognition/include/pcl/recognition/impl/linemod/line_rgbd.hpp
@@ -676,7 +676,7 @@ LineRGBD<PointXYZT, PointRGBT>::refineDetectionsAlongDepth ()
       }
     }
 
-    const std::size_t nr_bins = 1000;
+    constexpr std::size_t nr_bins = 1000;
     const float step_size = (max_depth - min_depth) / static_cast<float> (nr_bins-1);
     std::vector<std::size_t> depth_bins (nr_bins, 0);
     for (std::size_t row_index = start_y; row_index < end_y; ++row_index)

--- a/recognition/include/pcl/recognition/ransac_based/obj_rec_ransac.h
+++ b/recognition/include/pcl/recognition/ransac_based/obj_rec_ransac.h
@@ -329,9 +329,9 @@ namespace pcl
         {
           // 'p_obj' is the probability that given that the first sample point belongs to an object,
           // the second sample point will belong to the same object
-          const double p_obj = 0.25f;
+          constexpr double p_obj = 0.25f;
           // old version: p = p_obj*relative_obj_size_*fraction_of_pairs_in_hash_table_;
-          const double p = p_obj*relative_obj_size_;
+          const double p = p_obj * relative_obj_size_;
 
           if ( 1.0 - p <= 0.0 )
             return 1;

--- a/recognition/include/pcl/recognition/surface_normal_modality.h
+++ b/recognition/include/pcl/recognition/surface_normal_modality.h
@@ -192,15 +192,15 @@ namespace pcl
       delete[] lut;
       lut = new unsigned char[size_x*size_y*size_z];
 
-      const int nr_normals = 8;
+      constexpr int nr_normals = 8;
 	    pcl::PointCloud<PointXYZ>::VectorType ref_normals (nr_normals);
       
-      const float normal0_angle = 40.0f * 3.14f / 180.0f;
+      constexpr float normal0_angle = 40.0f * 3.14f / 180.0f;
       ref_normals[0].x = std::cos (normal0_angle);
       ref_normals[0].y = 0.0f;
       ref_normals[0].z = -sinf (normal0_angle);
 
-      const float inv_nr_normals = 1.0f / static_cast<float> (nr_normals);
+      constexpr float inv_nr_normals = 1.0f / static_cast<float>(nr_normals);
       for (int normal_index = 1; normal_index < nr_normals; ++normal_index)
       {
         const float angle = 2.0f * static_cast<float> (M_PI * normal_index * inv_nr_normals);
@@ -749,7 +749,7 @@ pcl::SurfaceNormalModality<PointInT>::computeAndQuantizeSurfaceNormals2 ()
   const int l_W = width;
   const int l_H = height;
 
-  const int l_r = 5; // used to be 7
+  constexpr int l_r = 5; // used to be 7
   //const int l_offset0 = -l_r - l_r * l_W;
   //const int l_offset1 =    0 - l_r * l_W;
   //const int l_offset2 = +l_r - l_r * l_W;
@@ -774,8 +774,8 @@ pcl::SurfaceNormalModality<PointInT>::computeAndQuantizeSurfaceNormals2 ()
   //const int l_offsetx = GRANULARITY / 2;
   //const int l_offsety = GRANULARITY / 2;
 
-  const int difference_threshold = 50;
-  const int distance_threshold = 2000;
+  constexpr int difference_threshold = 50;
+  constexpr int distance_threshold = 2000;
 
   //const double scale = 1000.0;
   //const double difference_threshold = 0.05 * scale;
@@ -1027,7 +1027,7 @@ pcl::SurfaceNormalModality<PointInT>::extractFeatures (const MaskMap & mask,
 
   float weights[8] = {0,0,0,0,0,0,0,0};
 
-  const std::size_t off = 4;
+  constexpr std::size_t off = 4;
   for (std::size_t row_index = off; row_index < height-off; ++row_index)
   {
     for (std::size_t col_index = off; col_index < width-off; ++col_index)
@@ -1297,7 +1297,7 @@ pcl::SurfaceNormalModality<PointInT>::extractAllFeatures (
 
   float weights[8] = {0,0,0,0,0,0,0,0};
 
-  const std::size_t off = 4;
+  constexpr std::size_t off = 4;
   for (std::size_t row_index = off; row_index < height-off; ++row_index)
   {
     for (std::size_t col_index = off; col_index < width-off; ++col_index)

--- a/registration/include/pcl/registration/bfgs.h
+++ b/registration/include/pcl/registration/bfgs.h
@@ -28,7 +28,7 @@ public:
   void
   compute(const OtherPolynomial& poly, bool& hasRealRoot)
   {
-    const Scalar ZERO(0);
+    constexpr Scalar ZERO(0);
     Scalar a2(2 * poly[2]);
     assert(ZERO != poly[poly.size() - 1]);
     Scalar discriminant((poly[1] * poly[1]) - (4 * poly[0] * poly[2]));

--- a/registration/include/pcl/registration/impl/correspondence_rejection_poly.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_poly.hpp
@@ -178,7 +178,7 @@ CorrespondenceRejectorPoly<SourceT, TargetT>::findThresholdOtsu(
     const std::vector<int>& histogram)
 {
   // Precision
-  const double eps = std::numeric_limits<double>::epsilon();
+  constexpr double eps = std::numeric_limits<double>::epsilon();
 
   // Histogram dimension
   const int nbins = static_cast<int>(histogram.size());

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -290,8 +290,8 @@ pcl::registration::FPCSInitialAlignment<PointSource, PointTarget, NormalT, Scala
   }
 
   // set predefined variables
-  const int min_iterations = 4;
-  const float diameter_fraction = 0.3f;
+  constexpr int min_iterations = 4;
+  constexpr float diameter_fraction = 0.3f;
 
   // get diameter of input cloud (distance between farthest points)
   Eigen::Vector4f pt_min, pt_max;

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -681,13 +681,13 @@ NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeStepLengt
 
   // The Search Algorithm for T(mu) [More, Thuente 1994]
 
-  const int max_step_iterations = 10;
+  constexpr int max_step_iterations = 10;
   int step_iterations = 0;
 
   // Sufficient decrease constant, Equation 1.1 [More, Thuete 1994]
-  const double mu = 1.e-4;
+  constexpr double mu = 1.e-4;
   // Curvature condition constant, Equation 1.2 [More, Thuete 1994]
-  const double nu = 0.9;
+  constexpr double nu = 0.9;
 
   // Initial endpoints of Interval I,
   double a_l = 0, a_u = 0;

--- a/sample_consensus/include/pcl/sample_consensus/method_types.h
+++ b/sample_consensus/include/pcl/sample_consensus/method_types.h
@@ -42,11 +42,11 @@
 
 namespace pcl
 {
-  const static int SAC_RANSAC  = 0;
-  const static int SAC_LMEDS   = 1;
-  const static int SAC_MSAC    = 2;
-  const static int SAC_RRANSAC = 3;
-  const static int SAC_RMSAC   = 4;
-  const static int SAC_MLESAC  = 5;
-  const static int SAC_PROSAC  = 6;
+  constexpr int SAC_RANSAC  = 0;
+  constexpr int SAC_LMEDS   = 1;
+  constexpr int SAC_MSAC    = 2;
+  constexpr int SAC_RRANSAC = 3;
+  constexpr int SAC_RMSAC   = 4;
+  constexpr int SAC_MLESAC  = 5;
+  constexpr int SAC_PROSAC  = 6;
 }

--- a/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_array_defs.h
+++ b/surface/include/pcl/surface/3rdparty/opennurbs/opennurbs_array_defs.h
@@ -842,7 +842,7 @@ int ON_ClassArray<T>::NewCapacity() const
   // Reserve() size and then wasting gigabytes of memory.
 
   // cap_size = 128 MB on 32-bit os, 256 MB on 64 bit os
-  const std::size_t cap_size = 32*sizeof(void*)*1024*1024;
+  constexpr std::size_t cap_size = 32*sizeof(void*)*1024*1024;
   if (m_count*sizeof(T) <= cap_size || m_count < 8)
     return ((m_count <= 2) ? 4 : 2*m_count);
 

--- a/surface/include/pcl/surface/3rdparty/poisson4/multi_grid_octree_data.hpp
+++ b/surface/include/pcl/surface/3rdparty/poisson4/multi_grid_octree_data.hpp
@@ -48,9 +48,9 @@ namespace pcl
   namespace poisson
   {
 
-    const Real MATRIX_ENTRY_EPSILON = Real(0);
-    const Real EPSILON=Real(1e-6);
-    const Real ROUND_EPS=Real(1e-5);
+    constexpr Real MATRIX_ENTRY_EPSILON = Real(0);
+    constexpr Real EPSILON=Real(1e-6);
+    constexpr Real ROUND_EPS = Real(1e-5);
 
     void atomicOr(volatile int& dest, int value)
     {
@@ -736,7 +736,7 @@ namespace pcl
       Real w;
       node->centerAndWidth( center , w );
       width=w;
-      const double SAMPLE_SCALE = 1. / ( 0.125 * 0.125 + 0.75 * 0.75 + 0.125 * 0.125 );
+      constexpr double SAMPLE_SCALE = 1. / ( 0.125 * 0.125 + 0.75 * 0.75 + 0.125 * 0.125 );
 
       for( int i=0 ; i<DIMENSION ; i++ )
       {

--- a/test/common/test_eigen.cpp
+++ b/test/common/test_eigen.cpp
@@ -65,8 +65,8 @@ TEST (PCL, InverseGeneral3x3f)
   CMatrix c_inverse = CMatrix::Zero ();
   Eigen::Matrix<Scalar, 3, 3> result = Eigen::Matrix<Scalar, 3, 3>::Zero ();
   Eigen::Matrix<Scalar, 3, 3> error = Eigen::Matrix<Scalar, 3, 3>::Zero ();
-  const Scalar epsilon = 1e-5f;
-  const unsigned iterations = 1000000;
+  constexpr Scalar epsilon = 1e-5f;
+  constexpr unsigned iterations = 1000000;
 
   // test floating point row-major : row-major
   for (unsigned idx = 0; idx < iterations; ++idx)
@@ -124,8 +124,8 @@ TEST (PCL, InverseGeneral3x3d)
   CMatrix c_inverse = CMatrix::Zero ();
   Eigen::Matrix<Scalar, 3, 3> result = Eigen::Matrix<Scalar, 3, 3>::Zero ();
   Eigen::Matrix<Scalar, 3, 3> error = Eigen::Matrix<Scalar, 3, 3>::Zero ();
-  const Scalar epsilon = 1e-13;
-  const unsigned iterations = 1000000;
+  constexpr Scalar epsilon = 1e-13;
+  constexpr unsigned iterations = 1000000;
 
   // test floating point row-major : row-major
   for (unsigned idx = 0; idx < iterations; ++idx)
@@ -183,8 +183,8 @@ TEST (PCL, InverseSymmetric3x3f)
   CMatrix c_inverse = CMatrix::Zero ();
   Eigen::Matrix<Scalar, 3, 3> result = Eigen::Matrix<Scalar, 3, 3>::Zero ();
   Eigen::Matrix<Scalar, 3, 3> error = Eigen::Matrix<Scalar, 3, 3>::Zero ();
-  const Scalar epsilon = 1e-5f;
-  const unsigned iterations = 1000000;
+  constexpr Scalar epsilon = 1e-5f;
+  constexpr unsigned iterations = 1000000;
 
   // test floating point row-major : row-major
   for (unsigned idx = 0; idx < iterations; ++idx)
@@ -248,8 +248,8 @@ TEST (PCL, InverseSymmetric3x3d)
   CMatrix c_inverse = CMatrix::Zero ();
   Eigen::Matrix<Scalar, 3, 3> result = Eigen::Matrix<Scalar, 3, 3>::Zero ();
   Eigen::Matrix<Scalar, 3, 3> error = Eigen::Matrix<Scalar, 3, 3>::Zero ();
-  const Scalar epsilon = 1e-13;
-  const unsigned iterations = 1000000;
+  constexpr Scalar epsilon = 1e-13;
+  constexpr unsigned iterations = 1000000;
 
   // test floating point row-major : row-major
   for (unsigned idx = 0; idx < iterations; ++idx)
@@ -314,8 +314,8 @@ TEST (PCL, Inverse2x2f)
   CMatrix c_inverse = CMatrix::Zero ();
   Eigen::Matrix<Scalar, 2, 2> result = Eigen::Matrix<Scalar, 2, 2>::Zero ();
   Eigen::Matrix<Scalar, 2, 2> error = Eigen::Matrix<Scalar, 2, 2>::Zero ();
-  const Scalar epsilon = 1e-6f;
-  const unsigned iterations = 1000000;
+  constexpr Scalar epsilon = 1e-6f;
+  constexpr unsigned iterations = 1000000;
 
   // test floating point row-major : row-major
   for (unsigned idx = 0; idx < iterations; ++idx)
@@ -372,8 +372,8 @@ TEST (PCL, Inverse2x2d)
   CMatrix c_inverse = CMatrix::Zero ();
   Eigen::Matrix<Scalar, 2, 2> result;
   Eigen::Matrix<Scalar, 2, 2> error;
-  const Scalar epsilon = 1e-15;
-  const unsigned iterations = 1000000;
+  constexpr Scalar epsilon = 1e-15;
+  constexpr unsigned iterations = 1000000;
 
   // test floating point row-major : row-major
   for (unsigned idx = 0; idx < iterations; ++idx)
@@ -479,8 +479,8 @@ TEST (PCL, eigen22d)
   Eigen::Matrix<Scalar, 2, 2> c_result;
   Eigen::Matrix<Scalar, 2, 2> c_error;
 
-  const Scalar epsilon = 1.25e-14;
-  const unsigned iterations = 1000000;
+  constexpr Scalar epsilon = 1.25e-14;
+  constexpr unsigned iterations = 1000000;
 
   // test floating point row-major : row-major
   for (unsigned idx = 0; idx < iterations; ++idx)
@@ -537,8 +537,8 @@ TEST (PCL, eigen22f)
   Eigen::Matrix<Scalar, 2, 2> c_result;
   Eigen::Matrix<Scalar, 2, 2> c_error;
 
-  const Scalar epsilon = 3.1e-5f;
-  const unsigned iterations = 1000000;
+  constexpr Scalar epsilon = 3.1e-5f;
+  constexpr unsigned iterations = 1000000;
 
   // test floating point row-major : row-major
   for (unsigned idx = 0; idx < iterations; ++idx)
@@ -676,8 +676,8 @@ TEST (PCL, eigen33d)
   Eigen::Matrix<Scalar, 3, 3> c_result;
   Eigen::Matrix<Scalar, 3, 3> c_error;
 
-  const Scalar epsilon = 2e-5;
-  const unsigned iterations = 1000000;
+  constexpr Scalar epsilon = 2e-5;
+  constexpr unsigned iterations = 1000000;
 
   // special case
   r_matrix = Eigen::Matrix<Scalar, 3, 1>(3, 2, 1).asDiagonal();
@@ -751,7 +751,7 @@ TEST (PCL, eigen33f)
   Eigen::Matrix<Scalar, 3, 3> c_result;
   Eigen::Matrix<Scalar, 3, 3> c_error;
 
-  const Scalar epsilon = 1e-3f;
+  constexpr Scalar epsilon = 1e-3f;
   constexpr unsigned iterations = 1000000;
   unsigned r_fail_count = 0;
 
@@ -1128,9 +1128,9 @@ TEST (PCL, getTransFromUnitVectors)
 
 TEST (PCL, getTransformation)
 {
-  const float rot_x = 2.8827f;
-  const float rot_y = -0.31190f;
-  const float rot_z = -0.93058f;
+  constexpr float rot_x = 2.8827f;
+  constexpr float rot_y = -0.31190f;
+  constexpr float rot_z = -0.93058f;
 
   Eigen::Affine3f affine;
   pcl::getTransformation (0, 0, 0, rot_x, rot_y, rot_z, affine);
@@ -1142,12 +1142,12 @@ TEST (PCL, getTransformation)
 
 TEST (PCL, getTranslationAndEulerAngles)
 {
-  const float trans_x = 0.1f;
-  const float trans_y = 0.2f;
-  const float trans_z = 0.3f;
-  const float rot_x = 2.8827f;
-  const float rot_y = -0.31190f;
-  const float rot_z = -0.93058f;
+  constexpr float trans_x = 0.1f;
+  constexpr float trans_y = 0.2f;
+  constexpr float trans_z = 0.3f;
+  constexpr float rot_x = 2.8827f;
+  constexpr float rot_y = -0.31190f;
+  constexpr float rot_z = -0.93058f;
 
   Eigen::Affine3f affine;
   pcl::getTransformation (trans_x, trans_y, trans_z, rot_x, rot_y, rot_z, affine);

--- a/test/common/test_macros.cpp
+++ b/test/common/test_macros.cpp
@@ -67,7 +67,7 @@ TEST(MACROS, expect_near_vectors_macro)
 {
   v1.clear ();
   v2.clear ();
-  const static float epsilon = 1e-5f;
+  constexpr float epsilon = 1e-5f;
   for (std::size_t i = 0; i < 3; i++)
   {
     float val = static_cast<float> (i) * 1.5f;

--- a/test/common/test_parse.cpp
+++ b/test/common/test_parse.cpp
@@ -51,7 +51,7 @@ TEST (PCL, parse_double)
   const char* argv_1[] = { &arg0[0], &arg1[0], &arg2_1[0], nullptr};
   const char* argv_2[] = { &arg0[0], &arg1[0], &arg2_2[0], nullptr};
   const char* argv_3[] = { &arg0[0], &arg1[0], &arg2_3[0], nullptr};
-  const int argc = static_cast<int> (sizeof (argv_1)/sizeof (argv_1[0])) - 1;
+  constexpr int argc = static_cast<int> (sizeof (argv_1)/sizeof (argv_1[0])) - 1;
 
   int index = -1;
   double value = 0;
@@ -79,7 +79,7 @@ TEST (PCL, parse_float)
   const char* argv_1[] = { &arg0[0], &arg1[0], &arg2_1[0], nullptr};
   const char* argv_2[] = { &arg0[0], &arg1[0], &arg2_2[0], nullptr};
   const char* argv_3[] = { &arg0[0], &arg1[0], &arg2_3[0], nullptr};
-  const int argc = static_cast<int> (sizeof (argv_1)/sizeof (argv_1[0])) - 1;
+  constexpr int argc = static_cast<int>(sizeof(argv_1) / sizeof(argv_1[0])) - 1;
 
   int index = -1;
   float value = 0;
@@ -107,7 +107,7 @@ TEST (PCL, parse_longint)
   const char* argv_1[] = { &arg0[0], &arg1[0], &arg2_1[0], nullptr};
   const char* argv_2[] = { &arg0[0], &arg1[0], &arg2_2[0], nullptr};
   const char* argv_3[] = { &arg0[0], &arg1[0], &arg2_3[0], nullptr};
-  const int argc = static_cast<int> (sizeof (argv_1)/sizeof (argv_1[0])) - 1;
+  constexpr int argc = static_cast<int>(sizeof(argv_1) / sizeof(argv_1[0])) - 1;
 
   int index = -1;
   long int value = 0;
@@ -135,7 +135,7 @@ TEST (PCL, parse_unsignedint)
   const char* argv_1[] = { &arg0[0], &arg1[0], &arg2_1[0], nullptr};
   const char* argv_2[] = { &arg0[0], &arg1[0], &arg2_2[0], nullptr};
   const char* argv_3[] = { &arg0[0], &arg1[0], &arg2_3[0], nullptr};
-  const int argc = static_cast<int> (sizeof (argv_1)/sizeof (argv_1[0])) - 1;
+  constexpr int argc = static_cast<int>(sizeof(argv_1) / sizeof(argv_1[0])) - 1;
 
   int index = -1;
   unsigned int value = 53;
@@ -163,7 +163,7 @@ TEST (PCL, parse_int)
   const char* argv_1[] = { &arg0[0], &arg1[0], &arg2_1[0], nullptr};
   const char* argv_2[] = { &arg0[0], &arg1[0], &arg2_2[0], nullptr};
   const char* argv_3[] = { &arg0[0], &arg1[0], &arg2_3[0], nullptr};
-  const int argc = static_cast<int> (sizeof (argv_1)/sizeof (argv_1[0])) - 1;
+  constexpr int argc = static_cast<int>(sizeof(argv_1) / sizeof(argv_1[0])) - 1;
 
   int index = -1;
   int value = 0;

--- a/test/common/test_polygon_mesh.cpp
+++ b/test/common/test_polygon_mesh.cpp
@@ -66,7 +66,7 @@ TEST(PolygonMesh, concatenate_header)
 TEST(PolygonMesh, concatenate_cloud)
 {
     PointCloud<PointXYZ> cloud_template;
-    const std::size_t size = 10 * 480;
+    constexpr std::size_t size = 10 * 480;
 
     cloud_template.width = 10;
     cloud_template.height = 480;
@@ -91,7 +91,7 @@ TEST(PolygonMesh, concatenate_cloud)
 
 TEST(PolygonMesh, concatenate_vertices)
 {
-    const std::size_t size = 15;
+    constexpr std::size_t size = 15;
 
     PolygonMesh test, dummy;
     // The algorithm works regardless of the organization.

--- a/test/common/test_spring.cpp
+++ b/test/common/test_spring.cpp
@@ -44,8 +44,8 @@ using namespace pcl;
 using namespace pcl::test;
 
 PointCloud<PointXYZ>::Ptr cloud_ptr (new PointCloud<PointXYZ> (4, 5));
-const std::size_t size = 5 * 4;
-const int amount = 2;
+constexpr std::size_t size = 5 * 4;
+constexpr int amount = 2;
 
 // TEST (PointCloudSpring, vertical)
 // {

--- a/test/common/test_wrappers.cpp
+++ b/test/common/test_wrappers.cpp
@@ -46,7 +46,7 @@ using namespace pcl;
 using namespace pcl::test;
 
 PointCloud<PointXYZ> cloud;
-const std::size_t size = 10 * 480;
+constexpr std::size_t size = 10 * 480;
 
 TEST (PointCloud, size)
 {

--- a/test/features/test_flare_estimation.cpp
+++ b/test/features/test_flare_estimation.cpp
@@ -62,7 +62,7 @@ TEST (PCL, FLARELocalReferenceFrameEstimation)
   pcl::PointCloud<pcl::Normal>::Ptr normals (new pcl::PointCloud<pcl::Normal> ());
   pcl::PointCloud<pcl::ReferenceFrame> bunny_LRF;
 
-  const float mesh_res = 0.005f;
+  constexpr float mesh_res = 0.005f;
 
   // Compute normals
   pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> ne;
@@ -159,8 +159,8 @@ main (int argc, char** argv)
   tree->setInputCloud (cloud);
 
   //create and set sampled point cloud for computation of X axis
-  const float sampling_perc = 0.2f;
-  const float sampling_incr = 1.0f / sampling_perc;
+  constexpr float sampling_perc = 0.2f;
+  constexpr float sampling_incr = 1.0f / sampling_perc;
 
   sampled_cloud.reset (new pcl::PointCloud<pcl::PointXYZ> ());
 

--- a/test/features/test_gradient_estimation.cpp
+++ b/test/features/test_gradient_estimation.cpp
@@ -113,7 +113,7 @@ TEST (PCL, IntensityGradientEstimation)
     float gz = (-nz * nx) * tmpx + (-nz * ny) * tmpy + (1 - nz * nz) * tmpz;
 
     // Compare the estimates to the derived values.
-    const float tolerance = 0.11f;
+    constexpr float tolerance = 0.11f;
     EXPECT_NEAR (g_est[0], gx, tolerance);
     EXPECT_NEAR (g_est[1], gy, tolerance);
     EXPECT_NEAR (g_est[2], gz, tolerance);

--- a/test/features/test_ii_normals.cpp
+++ b/test/features/test_ii_normals.cpp
@@ -55,10 +55,10 @@ IntegralImageNormalEstimation<PointXYZ, Normal> ne;
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST(PCL, IntegralImage1D)
 {
-  const unsigned width = 640;
-  const unsigned height = 480;
-  const unsigned max_window_size = 5;
-  const unsigned min_window_size = 1;
+  constexpr unsigned width = 640;
+  constexpr unsigned height = 480;
+  constexpr unsigned max_window_size = 5;
+  constexpr unsigned min_window_size = 1;
   IntegralImage2D<float,1> integral_image1(true); // calculate second order
   IntegralImage2D<float,1> integral_image2(false);// calculate just first order (other if branch)
 
@@ -268,10 +268,10 @@ TEST(PCL, IntegralImage1D)
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST(PCL, IntegralImage3D)
 {
-  const unsigned width = 640;
-  const unsigned height = 480;
-  const unsigned max_window_size = 5;
-  const unsigned min_window_size = 1;
+  constexpr unsigned width = 640;
+  constexpr unsigned height = 480;
+  constexpr unsigned max_window_size = 5;
+  constexpr unsigned min_window_size = 1;
   IntegralImage2D<float, 3> integral_image3(true);
   unsigned element_stride = 4;
   unsigned row_stride = width * element_stride + 1;

--- a/test/features/test_pfh_estimation.cpp
+++ b/test/features/test_pfh_estimation.cpp
@@ -476,7 +476,7 @@ TEST (PCL, GFPFH)
 
   PointCloud<PointXYZL>::Ptr cloud (new PointCloud<PointXYZL>());
 
-  const unsigned num_classes = 3;
+  constexpr unsigned num_classes = 3;
 
   // Build a cubic shape with a hole and changing labels.
   for (int z = -10; z < 10; ++z)

--- a/test/filters/test_crop_hull.cpp
+++ b/test/filters/test_crop_hull.cpp
@@ -58,7 +58,7 @@ createTestDataSuite(
     std::function<pcl::PointXYZ()> outside_point_generator)
 {
   std::vector<TestData> test_data_suite;
-  size_t const chunk_size = 1000;
+  constexpr size_t chunk_size = 1000;
   pcl::PointCloud<pcl::PointXYZ>::Ptr inside_cloud(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZ>::Ptr outside_cloud(new pcl::PointCloud<pcl::PointXYZ>);
   pcl::PointCloud<pcl::PointXYZ>::Ptr mixed_cloud(new pcl::PointCloud<pcl::PointXYZ>);

--- a/test/filters/test_farthest_point_sampling.cpp
+++ b/test/filters/test_farthest_point_sampling.cpp
@@ -19,8 +19,8 @@
 
 using namespace pcl;
 PointCloud<PointXYZ>::Ptr cloud_in (new PointCloud<PointXYZ>);
-const static int CLOUD_SIZE = 10;
-const static int SAMPLE_SIZE = CLOUD_SIZE -1;
+constexpr int CLOUD_SIZE = 10;
+constexpr int SAMPLE_SIZE = CLOUD_SIZE - 1;
 std::vector<float> x_values;
 
 TEST (FarthestPointSampling, farthest_point_sampling)

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -2302,7 +2302,7 @@ TEST (NormalRefinement, Filters)
   const float vp_z = cloud_organized_nonan.sensor_origin_[2];
 
   // Search parameters
-  const int k = 5;
+  constexpr int k = 5;
   std::vector<pcl::Indices> k_indices;
   std::vector<std::vector<float> > k_sqr_distances;
 

--- a/test/filters/test_uniform_sampling.cpp
+++ b/test/filters/test_uniform_sampling.cpp
@@ -44,7 +44,7 @@
 TEST(UniformSampling, extractRemovedIndices)
 {
   using namespace pcl::common;
-  const int SEED = 1234;
+  constexpr int SEED = 1234;
   CloudGenerator<pcl::PointXYZ, UniformGenerator<float>> generator;
   UniformGenerator<float>::Parameters x_params(0, 1, SEED + 1);
   generator.setParametersForX(x_params);

--- a/test/geometry/test_iterator.cpp
+++ b/test/geometry/test_iterator.cpp
@@ -245,8 +245,8 @@ TEST (PCL, LineIterator8NeighborsGeneral)
   unsigned center_y = 50;
   unsigned length = 45;
   
-  const unsigned angular_resolution = 180;
-  float d_alpha = float(M_PI / angular_resolution);
+  constexpr unsigned angular_resolution = 180;
+  constexpr float d_alpha = float(M_PI / angular_resolution);
   for (unsigned idx = 0; idx < angular_resolution; ++idx)
   {
     auto x_end = unsigned (length * std::cos (float(idx) * d_alpha) + center_x + 0.5);
@@ -269,8 +269,8 @@ TEST (PCL, LineIterator4NeighborsGeneral)
   unsigned center_y = 50;
   unsigned length = 45;
   
-  const unsigned angular_resolution = 360;
-  float d_alpha = float(2.0 * M_PI / angular_resolution);
+  constexpr unsigned angular_resolution = 360;
+  constexpr float d_alpha = float(2.0 * M_PI / angular_resolution);
   for (unsigned idx = 0; idx < angular_resolution; ++idx)
   {
     auto x_end = unsigned (length * std::cos (float(idx) * d_alpha) + center_x + 0.5);

--- a/test/geometry/test_mesh_common_functions.h
+++ b/test/geometry/test_mesh_common_functions.h
@@ -46,8 +46,8 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 // Abort circulating if the number of evaluations is too damn high.
-const unsigned int max_number_polygon_vertices  = 100;
-const unsigned int max_number_boundary_vertices = 100;
+constexpr unsigned int max_number_polygon_vertices = 100;
+constexpr unsigned int max_number_boundary_vertices = 100;
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/test/geometry/test_quad_mesh.cpp
+++ b/test/geometry/test_quad_mesh.cpp
@@ -221,7 +221,7 @@ TYPED_TEST (TestQuadMesh, OneQuad)
 TYPED_TEST (TestQuadMesh, NineQuads)
 {
   using Mesh = typename TestFixture::Mesh;
-  const int int_max = std::numeric_limits <int>::max ();
+  constexpr int int_max = std::numeric_limits<int>::max();
 
   // Order
   //    -   -   -   //

--- a/test/gpu/octree/performance.cpp
+++ b/test/gpu/octree/performance.cpp
@@ -131,7 +131,7 @@ TEST(PCL_OctreeGPU, performance)
     // build opencv octree
 #ifdef HAVE_OPENCV
     cv::Octree octree_opencv;
-    const static int opencv_octree_points_per_leaf = 32;    
+    constexpr int opencv_octree_points_per_leaf = 32;    
     std::vector<cv::Point3f> opencv_points(data.size());
     std::transform(data.cbegin(), data.cend(), opencv_points.begin(), DataGenerator::ConvPoint<cv::Point3f>());
         
@@ -143,7 +143,7 @@ TEST(PCL_OctreeGPU, performance)
     
     //// Radius search performance ///
 
-    const int max_answers = 500;
+    constexpr int max_answers = 500;
     float dist;
 
     //host buffers

--- a/test/gpu/octree/test_host_radius_search.cpp
+++ b/test/gpu/octree/test_host_radius_search.cpp
@@ -136,7 +136,7 @@ TEST(PCL_OctreeGPU, hostRadiusSearch)
 
 int main (int argc, char** argv)
 {
-    const int device = 0;
+    constexpr int device = 0;
     pcl::gpu::setDevice(device);
     pcl::gpu::printShortCudaDeviceInfo(device);        
     testing::InitGoogleTest (&argc, argv);

--- a/test/gpu/octree/test_knn_search.cpp
+++ b/test/gpu/octree/test_knn_search.cpp
@@ -81,8 +81,8 @@ TEST(PCL_OctreeGPU, exactNeighbourSearch)
     data.shared_radius = data.cube_size/30.f;
     data.printParams();
 
-    const float host_octree_resolution = 25.f;
-    const int k = 1; // only this is supported
+    constexpr float host_octree_resolution = 25.f;
+    constexpr int k = 1; // only this is supported
 
     //generate
     data();

--- a/test/gpu/octree/test_radius_search.cpp
+++ b/test/gpu/octree/test_radius_search.cpp
@@ -68,7 +68,7 @@ TEST(PCL_OctreeGPU, batchRadiusSearch)
     data.shared_radius = data.cube_size/30.f;
     data.printParams();
 
-    const int max_answers = 333;
+    constexpr int max_answers = 333;
 
     //generate
     data();

--- a/test/io/test_octree_compression.cpp
+++ b/test/io/test_octree_compression.cpp
@@ -124,7 +124,7 @@ TEST (PCL, OctreeDeCompressionRandomPointXYZRGBASameCloud)
 {
   // Generate a random cloud. Put it into the encoder several times and make
   // sure that the decoded cloud has correct width and height each time.
-  const double MAX_XYZ = 1.0;
+  constexpr double MAX_XYZ = 1.0;
   srand(static_cast<unsigned int> (time(nullptr)));
   // iterate over all pre-defined compression profiles
   for (int compression_profile = pcl::io::LOW_RES_ONLINE_COMPRESSION_WITHOUT_COLOR;

--- a/test/io/test_ply_mesh_io.cpp
+++ b/test/io/test_ply_mesh_io.cpp
@@ -293,8 +293,8 @@ TEST (PCL, PLYPolygonMeshSpecificFieldOrder)
   add_field(mesh.cloud.fields, "rgba", 24, pcl::PCLPointField::PointFieldTypes::UINT32);
   mesh.cloud.height = mesh.cloud.width = 1;
   mesh.cloud.data.resize(28);
-  const float x = 0.0, y = 1.0, z = 2.0, normal_x = 1.0, normal_y = 0.0, normal_z = 0.0;
-  const std::uint32_t rgba = 0x326496;
+  constexpr float x = 0.0, y = 1.0, z = 2.0, normal_x = 1.0, normal_y = 0.0, normal_z = 0.0;
+  constexpr std::uint32_t rgba = 0x326496;
   memcpy(&mesh.cloud.data[0], &x, sizeof(float));
   memcpy(&mesh.cloud.data[4], &y, sizeof(float));
   memcpy(&mesh.cloud.data[8], &z, sizeof(float));

--- a/test/io/test_range_coder.cpp
+++ b/test/io/test_range_coder.cpp
@@ -58,7 +58,7 @@ TEST (PCL, Adaptive_Range_Coder_Test)
   unsigned long readByteLen;
 
   // vector size
-  const unsigned int vectorSize = 10000;
+  constexpr unsigned int vectorSize = 10000;
 
   inputData.resize(vectorSize);
   outputData.resize(vectorSize);

--- a/test/kdtree/test_kdtree.cpp
+++ b/test/kdtree/test_kdtree.cpp
@@ -242,7 +242,7 @@ TEST (PCL, KdTreeFLANN_setPointRepresentation)
   MyPoint p (50.0f, 50.0f, 50.0f);
   
   // Find k nearest neighbors
-  const int k = 10;
+  constexpr int k = 10;
   pcl::Indices k_indices (k);
   std::vector<float> k_distances (k);
   kdtree.nearestKSearch (p, k, k_indices, k_distances);

--- a/test/keypoints/test_iss_3d.cpp
+++ b/test/keypoints/test_iss_3d.cpp
@@ -74,7 +74,7 @@ TEST (PCL, ISSKeypoint3D_WBE)
   //
   // Compare to previously validated output
   //
-  const std::size_t correct_nr_keypoints = 6;
+  constexpr std::size_t correct_nr_keypoints = 6;
   const float correct_keypoints[correct_nr_keypoints][3] =
     {
       // { x,  y,  z}
@@ -130,7 +130,7 @@ TEST (PCL, ISSKeypoint3D_BE)
   //
   // Compare to previously validated output
   //
-  const std::size_t correct_nr_keypoints = 5;
+  constexpr std::size_t correct_nr_keypoints = 5;
   const float correct_keypoints[correct_nr_keypoints][3] =
     {
       // { x,  y,  z}

--- a/test/keypoints/test_keypoints.cpp
+++ b/test/keypoints/test_keypoints.cpp
@@ -99,7 +99,7 @@ TEST (PCL, SIFTKeypoint)
   ASSERT_EQ (keypoints.height, 1);
 
   // Compare to previously validated output
-  const std::size_t correct_nr_keypoints = 5;
+  constexpr std::size_t correct_nr_keypoints = 5;
   const float correct_keypoints[correct_nr_keypoints][4] = 
     { 
       // { x,  y,  z,  scale }
@@ -123,14 +123,14 @@ TEST (PCL, SIFTKeypoint)
 
 TEST (PCL, SIFTKeypoint_radiusSearch)
 {
-  const int nr_scales_per_octave = 3;
-  const float scale = 0.02f;
+  constexpr int nr_scales_per_octave = 3;
+  constexpr float scale = 0.02f;
 
   KdTreeFLANN<PointXYZI>::Ptr tree_ (new KdTreeFLANN<PointXYZI>);
   auto cloud = cloud_xyzi->makeShared ();
 
   ApproximateVoxelGrid<PointXYZI> voxel_grid;
-  const float s = 1.0 * scale;
+  constexpr float s = 1.0 * scale;
   voxel_grid.setLeafSize (s, s, s);
   voxel_grid.setInputCloud (cloud);
   voxel_grid.filter (*cloud);
@@ -138,12 +138,11 @@ TEST (PCL, SIFTKeypoint_radiusSearch)
   
   const PointCloud<PointXYZI> & input = *cloud;
   KdTreeFLANN<PointXYZI> & tree = *tree_;
-  const float base_scale = scale;
 
   std::vector<float> scales (nr_scales_per_octave + 3);
   for (int i_scale = 0; i_scale <= nr_scales_per_octave + 2; ++i_scale)
   {
-    scales[i_scale] = base_scale * std::pow (2.0f, static_cast<float> (i_scale-1) / nr_scales_per_octave);
+    scales[i_scale] = scale * std::pow (2.0f, static_cast<float> (i_scale-1) / nr_scales_per_octave);
   }
   Eigen::MatrixXf diff_of_gauss;
 
@@ -151,9 +150,9 @@ TEST (PCL, SIFTKeypoint_radiusSearch)
   std::vector<float> nn_dist;
   diff_of_gauss.resize (input.size (), scales.size () - 1);
 
-  const float max_radius = 0.10f;
+  constexpr float max_radius = 0.10f;
 
-  const std::size_t i_point = 500;
+  constexpr std::size_t i_point = 500;
   tree.radiusSearch (i_point, max_radius, nn_indices, nn_dist);
 
   // Are they all unique?

--- a/test/octree/test_octree.cpp
+++ b/test/octree/test_octree.cpp
@@ -555,7 +555,7 @@ TEST (PCL, Octree2Buf_Base_Double_Buffering_Test)
 
   srand (static_cast<unsigned int> (time (nullptr)));
 
-  const unsigned int test_runs = 20;
+  constexpr unsigned int test_runs = 20;
 
   for (unsigned int j = 0; j < test_runs; j++)
   {
@@ -636,7 +636,7 @@ TEST (PCL, Octree2Buf_Base_Double_Buffering_XOR_Test)
 
   srand (static_cast<unsigned int> (time (nullptr)));
 
-  const unsigned int test_runs = 15;
+  constexpr unsigned int test_runs = 15;
 
   for (unsigned int j = 0; j < test_runs; j++)
   {
@@ -1616,10 +1616,10 @@ TEST (PCL, Octree_Pointcloud_Adjacency)
 
 TEST (PCL, Octree_Pointcloud_Bounds)
 {
-    const double SOME_RESOLUTION (10 + 1/3.0);
-    const int SOME_DEPTH (4);
-    const double DESIRED_MAX = ((1<<SOME_DEPTH) + 0.5)*SOME_RESOLUTION;
-    const double DESIRED_MIN = 0;
+    constexpr double SOME_RESOLUTION (10 + 1/3.0);
+    constexpr int SOME_DEPTH (4);
+    constexpr double DESIRED_MAX = ((1 << SOME_DEPTH) + 0.5) * SOME_RESOLUTION;
+    constexpr double DESIRED_MIN = 0;
 
     OctreePointCloud<PointXYZ> tree (SOME_RESOLUTION);
     tree.defineBoundingBox (DESIRED_MIN, DESIRED_MIN, DESIRED_MIN, DESIRED_MAX, DESIRED_MAX, DESIRED_MAX);
@@ -1630,8 +1630,8 @@ TEST (PCL, Octree_Pointcloud_Bounds)
     ASSERT_GE (max_x, DESIRED_MAX);
     ASSERT_GE (DESIRED_MIN, min_x);
 
-    const double LARGE_MIN = 1e7-45*SOME_RESOLUTION;
-    const double LARGE_MAX = 1e7-5*SOME_RESOLUTION;
+    constexpr double LARGE_MIN = 1e7 - 45 * SOME_RESOLUTION;
+    constexpr double LARGE_MAX = 1e7 - 5 * SOME_RESOLUTION;
     tree.defineBoundingBox (LARGE_MIN, LARGE_MIN, LARGE_MIN, LARGE_MAX, LARGE_MAX, LARGE_MAX);
     tree.getBoundingBox (min_x, min_y, min_z, max_x, max_y, max_z);
     const auto depth = tree.getTreeDepth ();

--- a/test/octree/test_octree_iterator.cpp
+++ b/test/octree/test_octree_iterator.cpp
@@ -1259,7 +1259,7 @@ struct OctreePointCloudAdjacencyBeginEndIteratorsTest
 
     // Generate Point Cloud
     typename PointCloudT::Ptr cloud (new PointCloudT (100, 1));
-    const float max_inv = 1.f / float (RAND_MAX);
+    constexpr float max_inv = 1.f / float (RAND_MAX);
     for (std::size_t i = 0; i < 100; ++i)
     {
       const PointT pt (10.f * (float (std::rand ()) * max_inv - .5f),
@@ -1484,7 +1484,7 @@ struct OctreePointCloudSierpinskiTest
     std::vector<std::pair<Eigen::Vector3f, Eigen::Vector3f> > voxels (generateSierpinskiVoxelExtremities (v_min, v_max, depth_));
 
     // The number of points in each voxel
-    unsigned int total_nb_pt = 100000;
+    constexpr unsigned int total_nb_pt = 100000;
     unsigned int nb_pt_in_voxel = total_nb_pt / pow (4, depth_);
 
     // Replicable results
@@ -1493,7 +1493,7 @@ struct OctreePointCloudSierpinskiTest
     // Fill the point cloud
     for (const auto& voxel : voxels)
     {
-      const static float eps = std::numeric_limits<float>::epsilon ();
+      constexpr float eps = std::numeric_limits<float>::epsilon ();
       double x_min = voxel.first.x () + eps;
       double y_min = voxel.first.y () + eps;
       double z_min = voxel.first.z () + eps;

--- a/test/outofcore/test_outofcore.cpp
+++ b/test/outofcore/test_outofcore.cpp
@@ -67,7 +67,7 @@ using namespace pcl::outofcore;
 
 // For doing exhaustive checks this is set low remove those, and this can be
 // set much higher
-const static std::uint64_t numPts (10000);
+constexpr std::uint64_t numPts (10000);
 
 constexpr std::uint32_t rngseed = 0xAAFF33DD;
 
@@ -702,7 +702,7 @@ TEST_F (OutofcoreTest, PointCloud2_Constructors)
   const Eigen::Vector3d min (-100.1, -100.1, -100.1);
   const Eigen::Vector3d max (100.1, 100.1, 100.1);
   
-  const std::uint64_t depth = 2;
+  constexpr std::uint64_t depth = 2;
   
   //create a point cloud
   pcl::PointCloud<PointT>::Ptr test_cloud (new pcl::PointCloud<PointT> ());
@@ -833,7 +833,7 @@ TEST_F (OutofcoreTest, PointCloud2_QueryBoundingBox)
   const Eigen::Vector3d min (-100.1, -100.1, -100.1);
   const Eigen::Vector3d max (100.1, 100.1, 100.1);
   
-  const std::uint64_t depth = 2;
+  constexpr std::uint64_t depth = 2;
 
   //create a point cloud
   pcl::PointCloud<PointT>::Ptr test_cloud (new pcl::PointCloud<PointT> ());
@@ -885,7 +885,7 @@ TEST_F (OutofcoreTest, PointCloud2_Query)
   const Eigen::Vector3d min (-100.1, -100.1, -100.1);
   const Eigen::Vector3d max (100.1, 100.1, 100.1);
   
-  const std::uint64_t depth = 2;
+  constexpr std::uint64_t depth = 2;
   
   //create a point cloud
   pcl::PointCloud<PointT>::Ptr test_cloud (new pcl::PointCloud<PointT> ());

--- a/test/registration/test_fpcs_ia_data.h
+++ b/test/registration/test_fpcs_ia_data.h
@@ -1,9 +1,9 @@
 #pragma once
 
-const int nr_threads = 1;
-const float approx_overlap = 0.9f;
-const float delta = 1.f;
-const int nr_samples = 100;
+constexpr int nr_threads = 1;
+constexpr float approx_overlap = 0.9f;
+constexpr float delta = 1.f;
+constexpr int nr_samples = 100;
 
 const float transform_from_fpcs [4][4] = {
   { -0.0019f, 0.8266f, -0.5628f, -0.0378f },

--- a/test/registration/test_kfpcs_ia.cpp
+++ b/test/registration/test_kfpcs_ia.cpp
@@ -73,7 +73,7 @@ TEST (PCL, KFPCSInitialAlignment)
   kfpcs_ia.setScoreThreshold (abort_score);
 
   // repeat alignment 2 times to increase probability to ~99.99%
-  const float max_angle3d = 0.1745f, max_translation3d = 1.f;
+  constexpr float max_angle3d = 0.1745f, max_translation3d = 1.f;
   float angle3d = std::numeric_limits<float>::max(), translation3d = std::numeric_limits<float>::max();
   for (int i = 0; i < 2; i++)
   {

--- a/test/registration/test_kfpcs_ia_data.h
+++ b/test/registration/test_kfpcs_ia_data.h
@@ -1,9 +1,9 @@
 #pragma once
 
-const int nr_threads = 1;
-const float voxel_size = 0.1f;
-const float approx_overlap = 0.9f;
-const float abort_score = 0.0f;
+constexpr int nr_threads = 1;
+constexpr float voxel_size = 0.1f;
+constexpr float approx_overlap = 0.9f;
+constexpr float abort_score = 0.0f;
 
 const float transformation_office1_office2 [4][4] = {
   { -0.6946f, -0.7194f, -0.0051f, -3.6352f },

--- a/test/registration/test_registration_api_data.h
+++ b/test/registration/test_registration_api_data.h
@@ -1,6 +1,6 @@
 #pragma once
 
-const int nr_original_correspondences = 397;
+constexpr int nr_original_correspondences = 397;
 const int correspondences_original[397][2] = {
   { 0, 61 },
   { 1, 50 },
@@ -401,7 +401,7 @@ const int correspondences_original[397][2] = {
   { 396, 353 },
 };
 
-const int nr_reciprocal_correspondences = 53;
+constexpr int nr_reciprocal_correspondences = 53;
 const int correspondences_reciprocal[53][2] = {
   { 1, 50 },
   { 2, 51 },
@@ -458,8 +458,8 @@ const int correspondences_reciprocal[53][2] = {
   { 366, 334 },
 };
 
-const int nr_correspondences_result_rej_dist = 97;
-const float rej_dist_max_dist = 0.01f;
+constexpr int nr_correspondences_result_rej_dist = 97;
+constexpr float rej_dist_max_dist = 0.01f;
 const int correspondences_dist[97][2] = {
   { 1, 50 },
   { 2, 51 },
@@ -560,9 +560,9 @@ const int correspondences_dist[97][2] = {
   { 367, 334 },
 };
 
-const int nr_correspondences_result_rej_median_dist = 139;
-const float rej_median_factor = 0.5f;
-const float rej_median_distance = 0.000465391f;
+constexpr int nr_correspondences_result_rej_median_dist = 139;
+constexpr float rej_median_factor = 0.5f;
+constexpr float rej_median_distance = 0.000465391f;
 const int correspondences_median_dist[139][2] = {
   { 0, 61 },
   { 1, 50 },
@@ -705,7 +705,7 @@ const int correspondences_median_dist[139][2] = {
   { 368, 335 },
 };
 
-const int nr_correspondences_result_rej_one_to_one = 103;
+constexpr int nr_correspondences_result_rej_one_to_one = 103;
 const int correspondences_one_to_one[103][2] = {
   { 177, 27 },
   { 180, 32 },
@@ -812,9 +812,9 @@ const int correspondences_one_to_one[103][2] = {
   { 327, 360 },
 };
 
-const int nr_correspondences_result_rej_sac = 97;
-const double rej_sac_max_dist = 0.01;
-const int rej_sac_max_iter = 1000;
+constexpr int nr_correspondences_result_rej_sac = 97;
+constexpr double rej_sac_max_dist = 0.01;
+constexpr int rej_sac_max_iter = 1000;
 const int correspondences_sac[97][2] = {
   { 1, 50 },
   { 2, 51 },
@@ -915,8 +915,8 @@ const int correspondences_sac[97][2] = {
   { 390, 334 },
 };
 
-const int nr_correspondences_result_rej_trimmed = 198;
-const float rej_trimmed_overlap = 0.5;
+constexpr int nr_correspondences_result_rej_trimmed = 198;
+constexpr float rej_trimmed_overlap = 0.5;
 const int correspondences_trimmed[198][2] = {
   { 260, 286 },
   { 271, 299 },

--- a/test/sample_consensus/test_sample_consensus.cpp
+++ b/test/sample_consensus/test_sample_consensus.cpp
@@ -97,7 +97,7 @@ TYPED_TEST(SacTest, InfiniteLoop)
 {
   using namespace std::chrono_literals;
 
-  const unsigned point_count = 100;
+  constexpr unsigned point_count = 100;
   PointCloud<PointXYZ> cloud;
   cloud.resize (point_count);
   for (unsigned idx = 0; idx < point_count; ++idx)

--- a/test/sample_consensus/test_sample_consensus_line_models.cpp
+++ b/test/sample_consensus/test_sample_consensus_line_models.cpp
@@ -159,9 +159,9 @@ TEST (SampleConsensusModelLine, SampleValidationPointsEqual)
   // being printed a 1000 times without any chance of success.
   // The order is chosen such that with a known, fixed rng-state/-seed all
   // validation steps are actually exercised.
-  const pcl::index_t firstKnownEqualPoint = 0;
-  const pcl::index_t secondKnownEqualPoint = 1;
-  const pcl::index_t cheatPointIndex = 2;
+  constexpr pcl::index_t firstKnownEqualPoint = 0;
+  constexpr pcl::index_t secondKnownEqualPoint = 1;
+  constexpr pcl::index_t cheatPointIndex = 2;
 
   cloud[firstKnownEqualPoint].getVector3fMap () <<  0.1f,  0.0f,  0.0f;
   cloud[secondKnownEqualPoint].getVector3fMap () <<  0.1f,  0.0f,  0.0f;
@@ -258,7 +258,7 @@ TEST (SampleConsensusModelParallelLine, RANSAC)
   cloud[15].getVector3fMap () << -1.05f,  5.01f,  5.0f;
 
   // Create a shared line model pointer directly
-  const double eps = 0.1; //angle eps in radians
+  constexpr double eps = 0.1; // angle eps in radians
   const Eigen::Vector3f axis (0, 0, 1);
   SampleConsensusModelParallelLinePtr model (new SampleConsensusModelParallelLine<PointXYZ> (cloud.makeShared ()));
   model->setAxis (axis);

--- a/test/sample_consensus/test_sample_consensus_plane_models.cpp
+++ b/test/sample_consensus/test_sample_consensus_plane_models.cpp
@@ -144,10 +144,10 @@ TEST (SampleConsensusModelPlane, SampleValidationPointsCollinear)
   // being printed a 1000 times without any chance of success.
   // The order is chosen such that with a known, fixed rng-state/-seed all
   // validation steps are actually exercised.
-  const pcl::index_t firstCollinearPointIndex = 0;
-  const pcl::index_t secondCollinearPointIndex = 1;
-  const pcl::index_t thirdCollinearPointIndex = 2;
-  const pcl::index_t cheatPointIndex = 3;
+  constexpr pcl::index_t firstCollinearPointIndex = 0;
+  constexpr pcl::index_t secondCollinearPointIndex = 1;
+  constexpr pcl::index_t thirdCollinearPointIndex = 2;
+  constexpr pcl::index_t cheatPointIndex = 3;
 
   cloud[firstCollinearPointIndex].getVector3fMap () <<  0.1f,  0.1f,  0.1f;
   cloud[secondCollinearPointIndex].getVector3fMap () <<  0.2f,  0.2f,  0.2f;
@@ -357,8 +357,8 @@ TEST (SampleConsensusModelNormalParallelPlane, RANSAC)
   SampleConsensusModelNormalParallelPlanePtr model (new SampleConsensusModelNormalParallelPlane<PointXYZ, Normal> (cloud.makeShared ()));
   model->setInputNormals (normals.makeShared ());
 
-  const float max_angle_rad = 0.01f;
-  const float angle_eps = 0.001f;
+  constexpr float max_angle_rad = 0.01f;
+  constexpr float angle_eps = 0.001f;
   model->setEpsAngle (max_angle_rad);
 
   // Test true axis

--- a/test/search/test_search.cpp
+++ b/test/search/test_search.cpp
@@ -69,16 +69,16 @@ using namespace pcl;
 
 #if EXCESSIVE_TESTING
 /** \brief number of points used for creating unordered point clouds */
-const unsigned int unorganized_point_count = 100000;
+constexpr unsigned int unorganized_point_count = 100000;
 
 /** \brief number of search operations on ordered point clouds*/
-const unsigned int query_count = 5000;
+constexpr unsigned int query_count = 5000;
 #else
 /** \brief number of points used for creating unordered point clouds */
-const unsigned int unorganized_point_count = 1200;
+constexpr unsigned int unorganized_point_count = 1200;
 
 /** \brief number of search operations on ordered point clouds*/
-const unsigned int query_count = 100;
+constexpr unsigned int query_count = 100;
 #endif
 
 /** \brief organized point cloud*/

--- a/test/surface/test_moving_least_squares.cpp
+++ b/test/surface/test_moving_least_squares.cpp
@@ -128,8 +128,8 @@ TEST (PCL, MovingLeastSquares)
 //  EXPECT_NEAR ((*mls_normals)[10].curvature, 0.019003, 1e-3);
 //  EXPECT_EQ (mls_normals->size (), 457);
 
-  const float voxel_size = 0.005f;
-  const int num_dilations = 5;
+  constexpr float voxel_size = 0.005f;
+  constexpr int num_dilations = 5;
   mls_upsampling.setUpsamplingMethod (MovingLeastSquares<PointXYZ, PointNormal>::VOXEL_GRID_DILATION);
   mls_upsampling.setDilationIterations (num_dilations);
   mls_upsampling.setDilationVoxelSize (voxel_size);

--- a/tools/crop_to_hull.cpp
+++ b/tools/crop_to_hull.cpp
@@ -52,7 +52,7 @@ using namespace pcl::console;
 using PointT = PointXYZ;
 using CloudT = PointCloud<PointT>;
 
-const static double default_alpha = 1e3f;
+constexpr double default_alpha = 1e3f;
 
 static void
 printHelp (int, char **argv)

--- a/tools/mesh_sampling.cpp
+++ b/tools/mesh_sampling.cpp
@@ -182,8 +182,8 @@ using namespace pcl;
 using namespace pcl::io;
 using namespace pcl::console;
 
-const int default_number_samples = 100000;
-const float default_leaf_size = 0.01f;
+constexpr int default_number_samples = 100000;
+constexpr float default_leaf_size = 0.01f;
 
 void
 printHelp (int, char **argv)

--- a/tools/obj_rec_ransac_accepted_hypotheses.cpp
+++ b/tools/obj_rec_ransac_accepted_hypotheses.cpp
@@ -469,7 +469,7 @@ main (int argc, char** argv)
 {
   printf ("\nUsage: ./obj_rec_ransac_accepted_hypotheses <pair_width> <voxel_size> <max_coplanarity_angle> <n_hypotheses_to_show> <show_hypotheses_as_coordinate_frames>\n\n");
 
-  const int num_params = 4;
+  constexpr int num_params = 4;
   float parameters[num_params] = {40.0f/*pair width*/, 5.0f/*voxel size*/, 15.0f/*max co-planarity angle*/, 1/*n_hypotheses_to_show*/};
   std::string parameter_names[num_params] = {"pair_width", "voxel_size", "max_coplanarity_angle", "n_hypotheses_to_show"};
 

--- a/tools/obj_rec_ransac_model_opps.cpp
+++ b/tools/obj_rec_ransac_model_opps.cpp
@@ -76,7 +76,7 @@ main (int argc, char** argv)
 {
   printf ("\nUsage: ./pcl_obj_rec_ransac_model_opps <pair_width> <voxel_size> <max_coplanarity_angle>\n\n");
 
-  const int num_params = 3;
+  constexpr int num_params = 3;
   float parameters[num_params] = {10.0f/*pair width*/, 5.0f/*voxel size*/, 5.0f/*max co-planarity angle*/};
   std::string parameter_names[num_params] = {"pair_width", "voxel_size", "max_coplanarity_angle"};
 

--- a/tools/obj_rec_ransac_result.cpp
+++ b/tools/obj_rec_ransac_result.cpp
@@ -106,7 +106,7 @@ main (int argc, char** argv)
 {
   printf ("\nUsage: ./pcl_obj_rec_ransac_scene_opps <pair_width> <voxel_size> <max_coplanarity_angle>\n\n");
 
-  const int num_params = 3;
+  constexpr int num_params = 3;
   float parameters[num_params] = {40.0f/*pair width*/, 5.0f/*voxel size*/, 15.0f/*max co-planarity angle*/};
   std::string parameter_names[num_params] = {"pair_width", "voxel_size", "max_coplanarity_angle"};
 

--- a/tools/obj_rec_ransac_scene_opps.cpp
+++ b/tools/obj_rec_ransac_scene_opps.cpp
@@ -96,7 +96,7 @@ main (int argc, char** argv)
 {
   printf ("\nUsage: ./pcl_obj_rec_ransac_scene_opps <pair_width> <voxel_size> <max_coplanarity_angle>\n\n");
 
-  const int num_params = 3;
+  constexpr int num_params = 3;
   float parameters[num_params] = {40.0f/*pair width*/, 5.0f/*voxel size*/, 15.0f/*max co-planarity angle*/};
   std::string parameter_names[num_params] = {"pair_width", "voxel_size", "max_coplanarity_angle"};
 

--- a/tools/openni_image.cpp
+++ b/tools/openni_image.cpp
@@ -82,7 +82,7 @@ getTotalSystemMemory ()
 const int BUFFER_SIZE = int (getTotalSystemMemory () / (640 * 480) / 2);
 #else
 
-const int BUFFER_SIZE = 200;
+constexpr int BUFFER_SIZE = 200;
 #endif
 
 int buff_size = BUFFER_SIZE;

--- a/tools/train_linemod_template.cpp
+++ b/tools/train_linemod_template.cpp
@@ -118,8 +118,8 @@ maskForegroundPoints (const PointCloudXYZRGBA::ConstPtr & input,
   }
 
   // Find the dominant plane between the specified near/far thresholds
-  const float distance_threshold = 0.02f;
-  const int max_iterations = 500;
+  constexpr float distance_threshold = 0.02f;
+  constexpr int max_iterations = 500;
   pcl::SACSegmentation<pcl::PointXYZRGBA> seg;
   seg.setOptimizeCoefficients (true);
   seg.setModelType (pcl::SACMODEL_PLANE);

--- a/tracking/include/pcl/tracking/impl/tracking.hpp
+++ b/tracking/include/pcl/tracking/impl/tracking.hpp
@@ -86,7 +86,7 @@ struct EIGEN_ALIGN16 ParticleXYZRPY : public _ParticleXYZRPY {
 
     // Scales 1.0 radians of variance in RPY sampling into equivalent units for
     // quaternion sampling.
-    const float scale_factor = 0.2862;
+    constexpr float scale_factor = 0.2862;
 
     float a = sampleNormal(0, scale_factor * cov[3]);
     float b = sampleNormal(0, scale_factor * cov[4]);


### PR DESCRIPTION
Fix MSVC warning C26814: `The const variable 'variable' can be computed at compile time. Consider using constexpr.`