### PR TITLE
Replace BOOST_MPL_ASSERT by static_assert

### DIFF
--- a/common/include/pcl/common/concatenate.h
+++ b/common/include/pcl/common/concatenate.h
@@ -63,9 +63,8 @@ namespace pcl
       using InT = typename pcl::traits::datatype<PointInT, Key>::type;
       using OutT = typename pcl::traits::datatype<PointOutT, Key>::type;
       // Note: don't currently support different types for the same field (e.g. converting double to float)
-      BOOST_MPL_ASSERT_MSG ((std::is_same<InT, OutT>::value),
-                            POINT_IN_AND_POINT_OUT_HAVE_DIFFERENT_TYPES_FOR_FIELD,
-                            (Key, PointInT&, InT, PointOutT&, OutT));
+      static_assert(std::is_same<InT, OutT>::value,
+                    "PointInT and PointOutT have different types for field.");
       memcpy (reinterpret_cast<std::uint8_t*>(&p2_) + pcl::traits::offset<PointOutT, Key>::value,
               reinterpret_cast<const std::uint8_t*>(&p1_) + pcl::traits::offset<PointInT, Key>::value,
               sizeof (InT));

--- a/common/include/pcl/for_each_type.h
+++ b/common/include/pcl/for_each_type.h
@@ -47,7 +47,6 @@
 #include <boost/mpl/begin_end.hpp>
 #include <boost/mpl/next_prior.hpp>
 #include <boost/mpl/deref.hpp>
-#include <boost/mpl/assert.hpp>
 #include <boost/mpl/remove_if.hpp>
 #include <boost/mpl/contains.hpp>
 #include <boost/mpl/not.hpp>
@@ -90,7 +89,8 @@ namespace pcl
   template<typename Sequence, typename F> inline void 
   for_each_type (F f)
   {
-    BOOST_MPL_ASSERT (( boost::mpl::is_sequence<Sequence> ));
+    static_assert(boost::mpl::is_sequence<Sequence>::type::value,
+                  "Given type is not a valid sequence.");
     using first = typename boost::mpl::begin<Sequence>::type;
     using last = typename boost::mpl::end<Sequence>::type;
     for_each_type_impl<std::is_same<first, last>::value>::template execute<first, last, F> (f);

--- a/common/include/pcl/point_struct_traits.h
+++ b/common/include/pcl/point_struct_traits.h
@@ -37,7 +37,6 @@
 
 #pragma once
 
-#include <boost/mpl/assert.hpp>  // for BOOST_MPL_ASSERT_MSG
 #include <boost/mpl/identity.hpp>  // for boost::mpl::identity
 
 #include <boost/mpl/vector.hpp>  // for boost::mpl::vector
@@ -45,7 +44,7 @@
 #include <boost/preprocessor/tuple/elem.hpp>  // for BOOST_PP_TUPLE_ELEM
 #include <boost/preprocessor/stringize.hpp> // for BOOST_PP_STRINGIZE
 
-// This is required for the workaround at line 84
+// This is required for the MSVC workaround below
 #ifdef _MSC_VER
 #include <Eigen/Core>
 #include <Eigen/src/StlSupport/details.h>
@@ -111,8 +110,8 @@ struct name /** \cond NO_WARN_RECURSIVE */ : name<typename POD<PointT>::type, Ta
   // static const char value[];
 
   // Avoid infinite compile-time recursion
-  BOOST_MPL_ASSERT_MSG((!std::is_same<PointT, typename POD<PointT>::type>::value),
-                        POINT_TYPE_NOT_PROPERLY_REGISTERED, (PointT&));
+  static_assert(!std::is_same<PointT, typename POD<PointT>::type>::value,
+                "Point type not properly registered.");
 };
 } // namespace traits
 } // namespace pcl
@@ -143,8 +142,8 @@ struct offset /** \cond NO_WARN_RECURSIVE */ : offset<typename POD<PointT>::type
   // static const std::size_t value;
 
   // Avoid infinite compile-time recursion
-  BOOST_MPL_ASSERT_MSG((!std::is_same<PointT, typename POD<PointT>::type>::value),
-                        POINT_TYPE_NOT_PROPERLY_REGISTERED, (PointT&));
+   static_assert(!std::is_same<PointT, typename POD<PointT>::type>::value,
+                 "Point type not properly registered.");
 };
 } // namespace traits
 } // namespace pcl
@@ -170,8 +169,8 @@ namespace traits
    // static const std::uint32_t size;
 
    // Avoid infinite compile-time recursion
-   BOOST_MPL_ASSERT_MSG((!std::is_same<PointT, typename POD<PointT>::type>::value),
-                        POINT_TYPE_NOT_PROPERLY_REGISTERED, (PointT&));
+   static_assert(!std::is_same<PointT, typename POD<PointT>::type>::value,
+                 "Point type not properly registered.");
  };
  } // namespace traits
  } // namespace pcl
@@ -198,8 +197,8 @@ struct fieldList /** \cond NO_WARN_RECURSIVE */ : fieldList<typename POD<PointT>
   // using type = boost::mpl::vector<...>;
 
   // Avoid infinite compile-time recursion
-  BOOST_MPL_ASSERT_MSG((!std::is_same<PointT, typename POD<PointT>::type>::value),
-                        POINT_TYPE_NOT_PROPERLY_REGISTERED, (PointT&));
+   static_assert(!std::is_same<PointT, typename POD<PointT>::type>::value,
+                 "Point type not properly registered.");
 };
 } // namespace traits
 } // namespace pcl

--- a/common/include/pcl/register_point_struct.h
+++ b/common/include/pcl/register_point_struct.h
@@ -51,7 +51,6 @@
 #endif
 
 #include <pcl/point_struct_traits.h> // for pcl::traits::POD, POINT_CLOUD_REGISTER_FIELD_(NAME, OFFSET, DATATYPE), POINT_CLOUD_REGISTER_POINT_FIELD_LIST
-#include <boost/mpl/assert.hpp>  // for BOOST_MPL_ASSERT_MSG
 #include <boost/preprocessor/seq/for_each.hpp>  // for BOOST_PP_SEQ_FOR_EACH
 #include <boost/preprocessor/seq/transform.hpp>  // for BOOST_PP_SEQ_TRANSFORM
 #include <boost/preprocessor/tuple/elem.hpp>  // for BOOST_PP_TUPLE_ELEM
@@ -66,12 +65,13 @@
     BOOST_PP_CAT(POINT_CLOUD_REGISTER_POINT_STRUCT_X fseq, 0))
   /***/
 
-#define POINT_CLOUD_REGISTER_POINT_WRAPPER(wrapper, pod)    \
-  BOOST_MPL_ASSERT_MSG(sizeof(wrapper) == sizeof(pod), POINT_WRAPPER_AND_POD_TYPES_HAVE_DIFFERENT_SIZES, (wrapper&, pod&)); \
-  namespace pcl {                                           \
-    namespace traits {                                      \
-      template<> struct POD<wrapper> { using type = pod; }; \
-    }                                                       \
+#define POINT_CLOUD_REGISTER_POINT_WRAPPER(wrapper, pod)              \
+  static_assert(sizeof(wrapper) == sizeof(pod),                       \
+                "Point wrapper and POD types have different sizes."); \
+  namespace pcl {                                                     \
+    namespace traits {                                                \
+      template<> struct POD<wrapper> { using type = pod; };           \
+    }                                                                 \
   }
   /***/
 
@@ -248,8 +248,6 @@ namespace pcl
   /***/
 
 // Construct type traits given full sequence of (type, name, tag) triples
-//  BOOST_MPL_ASSERT_MSG(std::is_pod<name>::value,
-//                       REGISTERED_POINT_TYPE_MUST_BE_PLAIN_OLD_DATA, (name));
 #define POINT_CLOUD_REGISTER_POINT_STRUCT_I(name, seq)                           \
   namespace pcl                                                                  \
   {                                                                              \


### PR DESCRIPTION
When the static code analysis of MSVC is enabled, you are getting a lot of messages like:
```
C:\dev\pcl\common\include\pcl\common\concatenate.h(66): warning C26814: The const variable '`pcl::NdConcatenateFunctor<pcl::PointWithScale,pcl::PointXYZ>::operator()<pcl::fields::x>'::`2'::mpl_assertion_in_line_22' can be computed at compile-time. Consider using constexpr (con.5).
C:\dev\pcl\tracking\include\pcl\tracking\tracking.h(90): warning C26814: The const variable 'mpl_assertion_in_line_53' can be computed at compile-time. Consider using constexpr (con.5).
```

The reason is that the `BOOST_MPL_ASSERT` macros are for pre C++11, where `static_assert` didn't exists. Sadly these macros are still using static variable (see implementation of `BOOST_MPL_ASSERT_MSG_IMPL`).

This small MR reduces the number of warnings during compilation by 221 unique messages (with duplicates 5.778).

Split from #5522 as it changes the compiler output, so in case there will be some discussion.

Output with Boost implementation:
```
error C2664: 'int boost::mpl::assertion_failed<false>(boost::mpl::assert<false>::type)': cannot convert argument 1 from 'boost::mpl::failed ************(__cdecl pcl::NdConcatenateFunctor<PointInT,PointOutT>::()::POINT_IN_AND_POINT_OUT_HAVE_DIFFERENT_TYPES_FOR_FIELD::* ***********)(Key,PointInT &,InT,PointOutT &,OutT)' to 'boost::mpl::assert<false>::type'
        with
        [
            PointInT=pcl::PointXYZRGBNormal,
            PointOutT=pcl::PointXYZ,
            Key=arg
        ]
```

Output with `static_assert`:
```
error C2338: static_assert failed: 'PointInT and PointOutT have different types for field.'
```