### PR TITLE
Remove CUDA code for already unsupported CUDA versions

### DIFF
--- a/gpu/kinfu/src/cuda/extract.cu
+++ b/gpu/kinfu/src/cuda/extract.cu
@@ -86,14 +86,9 @@ namespace pcl
         int x = threadIdx.x + blockIdx.x * CTA_SIZE_X;
         int y = threadIdx.y + blockIdx.y * CTA_SIZE_Y;
        
-#if CUDART_VERSION >= 9000
         if (__all_sync (__activemask (), x >= VOLUME_X)
             || __all_sync (__activemask (), y >= VOLUME_Y))
           return;
-#else 
-        if (__all (x >= VOLUME_X) || __all (y >= VOLUME_Y))
-          return;
-#endif
 
         float3 V;
         V.x = (x + 0.5f) * cell_size.x;
@@ -183,14 +178,9 @@ namespace pcl
             }              /* if (W != 0 && F != 1.f) */
           }            /* if (x < VOLUME_X && y < VOLUME_Y) */
 
-#if CUDART_VERSION >= 9000
           int total_warp = __popc (__ballot_sync (__activemask (), local_count > 0))
                          + __popc (__ballot_sync (__activemask (), local_count > 1))
                          + __popc (__ballot_sync (__activemask (), local_count > 2));
-#else
-          ///not we fulfilled points array at current iteration
-          int total_warp = __popc (__ballot (local_count > 0)) + __popc (__ballot (local_count > 1)) + __popc (__ballot (local_count > 2));
-#endif
 
           if (total_warp > 0)
           {

--- a/gpu/kinfu/src/cuda/marching_cubes.cu
+++ b/gpu/kinfu/src/cuda/marching_cubes.cu
@@ -138,14 +138,9 @@ namespace pcl
         int x = threadIdx.x + blockIdx.x * CTA_SIZE_X;
         int y = threadIdx.y + blockIdx.y * CTA_SIZE_Y;
 
-#if CUDART_VERSION >= 9000
         if (__all_sync (__activemask (), x >= VOLUME_X)
             || __all_sync (__activemask (), y >= VOLUME_Y))
           return;
-#else
-        if (__all (x >= VOLUME_X) || __all (y >= VOLUME_Y))
-          return;
-#endif
 
         int ftid = Block::flattenedThreadId ();
 		int warp_id = Warp::id();
@@ -164,11 +159,8 @@ namespace pcl
             // read number of vertices from texture
             numVerts = (cubeindex == 0 || cubeindex == 255) ? 0 : tex1Dfetch (numVertsTex, cubeindex);
           }
-#if CUDART_VERSION >= 9000
+
           int total = __popc (__ballot_sync (__activemask (), numVerts > 0));
-#else
-          int total = __popc (__ballot (numVerts > 0));
-#endif
 		  if (total == 0)
 			continue;
 
@@ -179,11 +171,7 @@ namespace pcl
           }
           int old_global_voxels_count = warps_buffer[warp_id];
 
-#if CUDART_VERSION >= 9000
           int offs = Warp::binaryExclScan (__ballot_sync (__activemask (), numVerts > 0));
-#else
-          int offs = Warp::binaryExclScan (__ballot (numVerts > 0));
-#endif
 
           if (old_global_voxels_count + offs < max_size && numVerts > 0)
           {

--- a/gpu/kinfu_large_scale/src/cuda/extract.cu
+++ b/gpu/kinfu_large_scale/src/cuda/extract.cu
@@ -104,14 +104,9 @@ namespace pcl
           int x = threadIdx.x + blockIdx.x * CTA_SIZE_X;
           int y = threadIdx.y + blockIdx.y * CTA_SIZE_Y;
 
-  #if CUDART_VERSION >= 9000
           if (__all_sync (__activemask (), x >= VOLUME_X)
               || __all_sync (__activemask (), y >= VOLUME_Y))
             return;
-  #else
-          if (__all (x >= VOLUME_X) || __all (y >= VOLUME_Y))
-            return;
-  #endif
 
           float3 V;
           V.x = (x + 0.5f) * cell_size.x;
@@ -201,15 +196,9 @@ namespace pcl
               }/* if (W != 0 && F != 1.f) */
             }/* if (x < VOLUME_X && y < VOLUME_Y) */
 
-
-  #if CUDART_VERSION >= 9000
             int total_warp = __popc (__ballot_sync (__activemask (), local_count > 0))
                            + __popc (__ballot_sync (__activemask (), local_count > 1))
                            + __popc (__ballot_sync (__activemask (), local_count > 2));
-  #else
-            //not we fulfilled points array at current iteration
-            int total_warp = __popc (__ballot (local_count > 0)) + __popc (__ballot (local_count > 1)) + __popc (__ballot (local_count > 2));
-  #endif
 
             if (total_warp > 0)
             {
@@ -312,15 +301,9 @@ namespace pcl
 
             // local_count counts the number of zero crossing for the current thread. Now we need to merge this knowledge with the other threads
             // not we fulfilled points array at current iteration
-          #if CUDART_VERSION >= 9000
             int total_warp = __popc (__ballot_sync (__activemask (), local_count > 0))
                            + __popc (__ballot_sync (__activemask (), local_count > 1))
                            + __popc (__ballot_sync (__activemask (), local_count > 2));
-          #else
-            int total_warp = __popc (__ballot (local_count > 0))
-                           + __popc (__ballot (local_count > 1))
-                           + __popc (__ballot (local_count > 2));
-          #endif
 
             if (total_warp > 0)  ///more than 0 zero-crossings
             {

--- a/gpu/surface/src/cuda/convex_hull.cu
+++ b/gpu/surface/src/cuda/convex_hull.cu
@@ -460,13 +460,8 @@ namespace pcl
 		{
 			int idx = threadIdx.x + blockIdx.x * blockDim.x;
 
-#if CUDART_VERSION >= 9000
       if (__all_sync (__activemask (), idx >= facet_count))
         return;
-#else
-			if (__all (idx >= facet_count))
-				return;
-#endif
 
 			int empty = 0;
 
@@ -490,18 +485,11 @@ namespace pcl
 				  empty = 1;                
 			}
 
-#if CUDART_VERSION >= 9000
       int total = __popc (__ballot_sync (__activemask (), empty));
-#else
-			int total = __popc (__ballot (empty));
-#endif
+
 			if (total > 0)
 			{
-#if CUDART_VERSION >= 9000
         int offset = Warp::binaryExclScan (__ballot_sync (__activemask (), empty));
-#else
-				int offset = Warp::binaryExclScan (__ballot (empty));
-#endif
 
 				volatile __shared__ int wapr_buffer[WARPS];
 


### PR DESCRIPTION
We require at least CUDA 9.0 (since #4317), so we don't need CUDA code for pre 9.0.