### PR TITLE
Fix Linux and Windows spinOnce behaviour

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -593,11 +593,13 @@ pcl::visualization::PCLVisualizer::spinOnce (int time, bool force_redraw)
 
 #if VTK_MAJOR_VERSION >= 9 && (VTK_MINOR_VERSION != 0 || VTK_BUILD_VERSION != 0) && (VTK_MINOR_VERSION != 0 || VTK_BUILD_VERSION != 1)
 // All VTK 9 versions, except 9.0.0 and 9.0.1
-  if(interactor_->IsA("vtkXRenderWindowInteractor")) {
-    DO_EVERY (1.0 / interactor_->GetDesiredUpdateRate (),
-      interactor_->ProcessEvents ();
-      std::this_thread::sleep_for (std::chrono::milliseconds (time));
-    );
+  if (interactor_->IsA("vtkXRenderWindowInteractor") || interactor_->IsA("vtkWin32RenderWindowInteractor")) {
+    const auto start_time = std::chrono::steady_clock::now();
+    const auto stop_time = start_time + std::chrono::milliseconds(time);
+    do {
+      interactor_->ProcessEvents();
+      // Exit immediately via GetDone being true when terminateApp is called
+    } while (std::chrono::steady_clock::now() < stop_time && !interactor_->GetDone());
   }
   else
 #endif


### PR DESCRIPTION
This fixes two issues; one each on Windows and Linux with the behaviour of spinOnce in VTK 9.

Linux:
#5252 changed spinOnce to use ProcessEvents + sleeping to service the event queue. However, calling ProcessEvents on a vtkXRenderWindowInteractor only handles a single event and does not empty the queue so we need to repeatedly call it for smooth interaction.

Windows:
VTK 9.2 introduced this commit [VTK#8696](https://gitlab.kitware.com/vtk/vtk/-/merge_requests/8696) which prevents calling PostQuitMessage more than once if TerminateApp is called multiple times.
Problem here being the Start + Timer callback with TerminateApp method relied on this behaviour. 
When the window is in a modal event loop (most commonly due to the user resizing or moving the window) the VTK event loop does not receive the WM_QUIT message posted by TerminateApp.
Since the change in 9.2 if we miss that message the event loop will be forever stuck and spinOnce blocks forever because the event loop can't be closed.

In summary, we should call repeatedly call ProcessEvents and break out after the requested period of time or the window's Done member becomes True due to TerminateApp.

I am not throttling the rate at which ProcessEvents is called by using DO_EVERY to most closely match the behaviour of both spin(), where the window can't throttle the update rate, and the implementation of the RenderWindowInteractor::Start() methods.

I've tested this with VTK 9.1.0, 9.2.2 and the master as of 04/12/22 on Windows and Linux (Arch) and the changes work great.
If someone could verify this works on macOS then could we remove the checks for specific window interactor implementations?