### PR TITLE
[io] Link to VTK::FiltersGeneral

### DIFF
--- a/io/CMakeLists.txt
+++ b/io/CMakeLists.txt
@@ -347,6 +347,7 @@ target_link_libraries("${LIB_NAME}" Boost::boost Boost::filesystem Boost::iostre
 if(VTK_FOUND)
   if(${VTK_VERSION} VERSION_GREATER_EQUAL 9.0)
     target_link_libraries("${LIB_NAME}" 
+                          VTK::FiltersGeneral
                           VTK::IOImage
                           VTK::IOGeometry
                           VTK::IOPLY)


### PR DESCRIPTION
Fix issue on `#include <vtkPolyDataNormals.h>` and `#include <vtkVertexGlyphFilter.h>` not found error