### PR TITLE
Fix bad dynamic_casts in visualization

### DIFF
--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -1787,7 +1787,7 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
     return (false);
 
   // Get the current poly data
-  vtkSmartPointer<vtkPolyData> polydata = dynamic_cast<vtkPolyDataMapper*>(am_it->second.actor->GetMapper ())->GetInput ();
+  vtkSmartPointer<vtkPolyData> polydata = dynamic_cast<vtkPolyData*>(am_it->second.actor->GetMapper ()->GetInput ());
   if (!polydata)
     return (false);
   vtkSmartPointer<vtkCellArray> cells = polydata->GetPolys ();

--- a/visualization/src/interactor_style.cpp
+++ b/visualization/src/interactor_style.cpp
@@ -45,6 +45,7 @@
 #include <vtkLODActor.h>
 #include <vtkPolyData.h>
 #include <vtkPolyDataMapper.h>
+#include <vtkDataSetMapper.h>
 #include <vtkCellArray.h>
 #include <vtkTextProperty.h>
 #include <vtkAbstractPropPicker.h>
@@ -666,7 +667,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
         data->SetPoints (points);
         data->SetVerts (vertices);
         // Modify the mapper
-        auto* mapper = dynamic_cast<vtkPolyDataMapper*>(act.actor->GetMapper ());
+        auto* mapper = dynamic_cast<vtkDataSetMapper*>(act.actor->GetMapper ());
         mapper->SetInputData (data);
         // Modify the actor
         act.actor->SetMapper (mapper);
@@ -696,7 +697,7 @@ pcl::visualization::PCLVisualizerInteractorStyle::OnKeyDown ()
         auto *data = dynamic_cast<vtkPolyData*>(act.actor->GetMapper ()->GetInput ());
         data->GetPointData ()->SetScalars (scalars);
         // Modify the mapper
-        auto* mapper = dynamic_cast<vtkPolyDataMapper*>(act.actor->GetMapper ());
+        auto* mapper = dynamic_cast<vtkDataSetMapper*>(act.actor->GetMapper ());
         mapper->SetScalarRange (minmax);
         mapper->SetScalarModeToUsePointData ();
         mapper->SetInputData (data);

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -2963,7 +2963,7 @@ pcl::visualization::PCLVisualizer::updateColorHandlerIndex (const std::string &i
   auto *data = dynamic_cast<vtkPolyData*>(am_it->second.actor->GetMapper ()->GetInput ());
   data->GetPointData ()->SetScalars (scalars);
   // Modify the mapper
-  auto* mapper = dynamic_cast<vtkPolyDataMapper*>(am_it->second.actor->GetMapper ());
+  auto* mapper = dynamic_cast<vtkDataSetMapper*>(am_it->second.actor->GetMapper ());
   mapper->SetScalarRange (minmax);
   mapper->SetScalarModeToUsePointData ();
   mapper->SetInputData (data);
@@ -3120,7 +3120,7 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
   std::vector<pcl::Vertices> verts (poly_mesh.polygons); // copy vector
 
   // Get the current poly data
-  vtkSmartPointer<vtkPolyData> polydata = dynamic_cast<vtkPolyDataMapper*>(am_it->second.actor->GetMapper ())->GetInput ();
+  vtkSmartPointer<vtkPolyData> polydata = dynamic_cast<vtkPolyData*>(am_it->second.actor->GetMapper ()->GetInput ());
   if (!polydata)
     return (false);
   vtkSmartPointer<vtkCellArray> cells = polydata->GetStrips ();


### PR DESCRIPTION
Originally, these were static_casts, and https://github.com/PointCloudLibrary/pcl/pull/5504 made them dynamic_casts. However, the objects are not of type vtkPolyDataMapper, so dynamic_cast returns a null pointer.

I put these fixes in a pull request already so we can merge it as soon as possible to continue with the 1.13.0 release. Then we can continue adding tests (https://github.com/PointCloudLibrary/pcl/pull/5548) without time pressure. That new test (for `updateColorHandlerIndex`) passes with these fixes. I also verified these fixes by pressing the 1, 2, 3, ... keys in the pcl_viewer, and running `pcl_example_nurbs_fitting_surface` (`example_nurbs_fitting_surface.cpp`) to test `updatePolygonMesh`.