### PR TITLE
Fix randomly failing search tests (organized and octree)

### DIFF
--- a/test/search/precise_distances.h
+++ b/test/search/precise_distances.h
@@ -1,0 +1,23 @@
+namespace pcl_tests {
+// Here we want very precise distance functions, speed is less important. So we use
+// double precision, unlike euclideanDistance() in pcl/common/distances and distance()
+// in pcl/common/geometry which use float (single precision) and possibly vectorization
+
+template <typename PointT> inline double
+squared_point_distance(const PointT& p1, const PointT& p2)
+{
+  const double x_diff = (static_cast<double>(p1.x) - static_cast<double>(p2.x)),
+               y_diff = (static_cast<double>(p1.y) - static_cast<double>(p2.y)),
+               z_diff = (static_cast<double>(p1.z) - static_cast<double>(p2.z));
+  return (x_diff * x_diff + y_diff * y_diff + z_diff * z_diff);
+}
+
+template <typename PointT> inline double
+point_distance(const PointT& p1, const PointT& p2)
+{
+  const double x_diff = (static_cast<double>(p1.x) - static_cast<double>(p2.x)),
+               y_diff = (static_cast<double>(p1.y) - static_cast<double>(p2.y)),
+               z_diff = (static_cast<double>(p1.z) - static_cast<double>(p2.z));
+  return std::sqrt(x_diff * x_diff + y_diff * y_diff + z_diff * z_diff);
+}
+} // namespace pcl_tests

--- a/test/search/test_octree.cpp
+++ b/test/search/test_octree.cpp
@@ -329,7 +329,7 @@ TEST (PCL, Octree_Pointcloud_Neighbours_Within_Radius_Search)
     ASSERT_GE ( cloudNWRRadius.size() , cloudSearchBruteforce_size_lower);
     ASSERT_LE ( cloudNWRRadius.size() , cloudSearchBruteforce_size_upper);
 
-    // check if results from organized radius search are indeed within the search radius
+    // check if results from octree radius search are indeed within the search radius
     for (const auto& current : cloudNWRSearch)
     {
       const auto pointDist = pcl_tests::point_distance((*cloudIn)[current], searchPoint);

--- a/test/search/test_organized.cpp
+++ b/test/search/test_organized.cpp
@@ -44,6 +44,9 @@
 #include <pcl/point_cloud.h>
 #include <pcl/point_types.h>
 #include <pcl/search/organized.h> // for OrganizedNeighbor
+#include "precise_distances.h" // for point_distance, squared_point_distance
+
+#define TOLERANCE 0.000001
 
 using namespace pcl;
 
@@ -138,9 +141,7 @@ TEST (PCL, Organized_Neighbor_Pointcloud_Nearest_K_Neighbour_Search)
     // push all points and their distance to the search point into a priority queue - bruteforce approach.
     for (std::size_t i = 0; i < cloudIn->size (); i++)
     {
-      double pointDist = (((*cloudIn)[i].x - searchPoint.x) * ((*cloudIn)[i].x - searchPoint.x) +
-                          ((*cloudIn)[i].y - searchPoint.y) * ((*cloudIn)[i].y - searchPoint.y) +
-                          ((*cloudIn)[i].z - searchPoint.z) * ((*cloudIn)[i].z - searchPoint.z));
+      double pointDist = pcl_tests::squared_point_distance((*cloudIn)[i], searchPoint);
 
       prioPointQueueEntry pointEntry ((*cloudIn)[i], pointDist, int (i));
 
@@ -218,24 +219,20 @@ TEST (PCL, Organized_Neighbor_Pointcloud_Neighbours_Within_Radius_Search)
 
     const PointXYZ& searchPoint = (*cloudIn)[randomIdx];
 
-    double pointDist;
     double searchRadius = 1.0 * (double (rand ()) / double (RAND_MAX));
 
     // bruteforce radius search
-    std::vector<int> cloudSearchBruteforce;
-    cloudSearchBruteforce.clear();
+    std::size_t cloudSearchBruteforce_size_lower = 0, cloudSearchBruteforce_size_upper = 0;
 
     for (std::size_t i = 0; i < cloudIn->size (); i++)
     {
-      pointDist = std::sqrt (
-                        ((*cloudIn)[i].x - searchPoint.x) * ((*cloudIn)[i].x - searchPoint.x)
-                      + ((*cloudIn)[i].y - searchPoint.y) * ((*cloudIn)[i].y - searchPoint.y)
-                      + ((*cloudIn)[i].z - searchPoint.z) * ((*cloudIn)[i].z - searchPoint.z));
+      const auto pointDist = pcl_tests::point_distance((*cloudIn)[i], searchPoint);
 
-      if (pointDist <= searchRadius)
-      {
-        // add point candidates to vector list
-        cloudSearchBruteforce.push_back (int (i));
+      if (pointDist <= (searchRadius+TOLERANCE)) {
+        ++cloudSearchBruteforce_size_upper;
+        if (pointDist <= (searchRadius-TOLERANCE)) {
+          ++cloudSearchBruteforce_size_lower;
+        }
       }
     }
 
@@ -246,32 +243,16 @@ TEST (PCL, Organized_Neighbor_Pointcloud_Neighbours_Within_Radius_Search)
     organizedNeighborSearch.setInputCloud (cloudIn);
     organizedNeighborSearch.radiusSearch (searchPoint, searchRadius, cloudNWRSearch, cloudNWRRadius);
 
-    // check if result from organized radius search can be also found in bruteforce search
+    // check if results from organized radius search are indeed within the search radius
     for (const auto& current : cloudNWRSearch)
     {
-      pointDist = std::sqrt (
-          ((*cloudIn)[current].x-searchPoint.x) * ((*cloudIn)[current].x-searchPoint.x) +
-          ((*cloudIn)[current].y-searchPoint.y) * ((*cloudIn)[current].y-searchPoint.y) +
-          ((*cloudIn)[current].z-searchPoint.z) * ((*cloudIn)[current].z-searchPoint.z)
-      );
+      const auto pointDist = pcl_tests::point_distance((*cloudIn)[current], searchPoint);
 
-      ASSERT_LE (pointDist, searchRadius);
+      ASSERT_LE (pointDist, (searchRadius+TOLERANCE));
     }
 
-
-    // check if bruteforce result from organized radius search can be also found in bruteforce search
-    for (const auto& current : cloudSearchBruteforce)
-    {
-      pointDist = std::sqrt (
-          ((*cloudIn)[current].x-searchPoint.x) * ((*cloudIn)[current].x-searchPoint.x) +
-          ((*cloudIn)[current].y-searchPoint.y) * ((*cloudIn)[current].y-searchPoint.y) +
-          ((*cloudIn)[current].z-searchPoint.z) * ((*cloudIn)[current].z-searchPoint.z)
-      );
-
-      ASSERT_LE (pointDist, searchRadius);
-    }
-
-    ASSERT_EQ (cloudNWRRadius.size() , cloudSearchBruteforce.size ());
+    ASSERT_GE (cloudNWRRadius.size() , cloudSearchBruteforce_size_lower);
+    ASSERT_LE (cloudNWRRadius.size() , cloudSearchBruteforce_size_upper);
 
     // check if result limitation works
     organizedNeighborSearch.radiusSearch (searchPoint, searchRadius, cloudNWRSearch, cloudNWRRadius, 5);


### PR DESCRIPTION
For some random seeds, these tests were failing because of numerical imprecision (points very close to the search radius). Now the tests have a tolerance, and the number of points returned by `radiusSearch` must be between a lower and upper bound (computed via brute force)

Fixes https://github.com/PointCloudLibrary/pcl/issues/5553