### PR TITLE
Fix potential memory problems in GICP and IncrementalRegistration

### DIFF
--- a/registration/include/pcl/registration/gicp.h
+++ b/registration/include/pcl/registration/gicp.h
@@ -113,6 +113,8 @@ public:
       typename IterativeClosestPoint<PointSource, PointTarget, Scalar>::Matrix4;
   using AngleAxis = typename Eigen::AngleAxis<Scalar>;
 
+  PCL_MAKE_ALIGNED_OPERATOR_NEW;
+
   /** \brief Empty constructor. */
   GeneralizedIterativeClosestPoint()
   : k_correspondences_(20)

--- a/registration/include/pcl/registration/incremental_registration.h
+++ b/registration/include/pcl/registration/incremental_registration.h
@@ -111,6 +111,8 @@ public:
   /** \brief Set registration instance used to align clouds */
   inline void setRegistration(RegistrationPtr);
 
+  PCL_MAKE_ALIGNED_OPERATOR_NEW;
+
 protected:
   /** \brief last registered point cloud */
   PointCloudConstPtr last_cloud_;


### PR DESCRIPTION
The aligned operator new is surely missing due to `base_transformation_` member possibly being of type `Matrix4f`.

About the aligned vector I'm not so sure, but the `MatricesVector` which is vector of Matrix3d uses it, so either that can go away or should be used consistently.

Added the operator also to classes derived from those needing it. Never really sure about that one, but back when I tested this, this requirement seemed to be infectuious and leaving it out from child classes would fail, even though they only inherited the base class' members with alignment requirements.