### PR TITLE
[CMake] Require at least MSVC 2017

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,10 @@ endif()
 project(PCL VERSION 1.13.0.99)
 string(TOLOWER ${PROJECT_NAME} PROJECT_NAME_LOWER)
 
+if(MSVC AND ("${MSVC_VERSION}" LESS 1910))
+  message(FATAL_ERROR "The compiler versions prior to Visual Studio version 2017 are not supported. Please upgrade to a newer version or another compiler!")
+endif()
+
 ### ---[ Find universal dependencies
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/" ${CMAKE_MODULE_PATH})
 


### PR DESCRIPTION
Didn't knew anymore if MSVC 2015 is still supported here or not and just found the information in this ticket: #4248

As I don't know if there is any document where we store the supported compiler version, I handled it now via CMake.

Note: I'm using `LESS` and not `VERSION_LESS` as [`MSVC_VERSION`](https://cmake.org/cmake/help/latest/variable/MSVC_VERSION.html) is just a single integer value.

Fixes #4250