### PR TITLE
Fix crash in SpinImageEstimation

### DIFF
--- a/features/include/pcl/features/impl/spin_image.hpp
+++ b/features/include/pcl/features/impl/spin_image.hpp
@@ -53,10 +53,13 @@ pcl::SpinImageEstimation<PointInT, PointNT, PointOutT>::SpinImageEstimation (
   unsigned int image_width, double support_angle_cos, unsigned int min_pts_neighb) :
   input_normals_ (), rotation_axes_cloud_ (), 
   is_angular_ (false), rotation_axis_ (), use_custom_axis_(false), use_custom_axes_cloud_ (false), 
-  is_radial_ (false), image_width_ (image_width), support_angle_cos_ (support_angle_cos), 
+  is_radial_ (false), support_angle_cos_ (support_angle_cos),
   min_pts_neighb_ (min_pts_neighb)
 {
-  assert (support_angle_cos_ <= 1.0 && support_angle_cos_ >= 0.0); // may be permit negative cosine?
+  if (0.0 > support_angle_cos || support_angle_cos > 1.0) { // may be permit negative cosine?
+    throw PCLException ("Cosine of support angle should be between 0 and 1", "spin_image.hpp", "SpinImageEstimation");
+  }
+  setImageWidth(image_width);
 
   feature_name_ = "SpinImageEstimation";
 }

--- a/features/include/pcl/features/spin_image.h
+++ b/features/include/pcl/features/spin_image.h
@@ -135,11 +135,13 @@ namespace pcl
       {
         const unsigned int necessary_desc_size = (bin_count+1)*(2*bin_count+1);
         if (necessary_desc_size > static_cast<unsigned int>(PointOutT::descriptorSize())) {
-          for(int i=0; ; ++i) // Find the biggest possible image_width_
-            if(((i+1)*(2*i+1)) <= PointOutT::descriptorSize())
+          for(int i=0; ; ++i) { // Find the biggest possible image_width_
+            if(((i+1)*(2*i+1)) <= PointOutT::descriptorSize()) {
               image_width_ = i;
-            else
+            } else {
               break;
+            }
+          }
           PCL_ERROR("[pcl::SpinImageEstimation] The chosen image width is too large, setting it to %u instead. "
             "Consider using pcl::Histogram<%u> as output type of SpinImageEstimation "
             "(possibly with `#define PCL_NO_PRECOMPILE 1`).\n", image_width_, ((bin_count+1)*(2*bin_count+1)));

--- a/features/include/pcl/features/spin_image.h
+++ b/features/include/pcl/features/spin_image.h
@@ -69,7 +69,9 @@ namespace pcl
     *
     * With the default parameters, pcl::Histogram<153> is a good choice for PointOutT.
     * Of course the dimension of this descriptor must change to match the number
-    * of bins set by the parameters.
+    * of bins set by the parameters. If you use SpinImageEstimation with something
+    * other than pcl::Histogram<153>, you may need to put `#define PCL_NO_PRECOMPILE 1`
+    * before including `pcl/features/spin_image.h`.
     *
     * For further information please see:
     *
@@ -131,7 +133,25 @@ namespace pcl
       void 
       setImageWidth (unsigned int bin_count)
       {
-        image_width_ = bin_count;
+        const unsigned int necessary_desc_size = (bin_count+1)*(2*bin_count+1);
+        if (necessary_desc_size > static_cast<unsigned int>(PointOutT::descriptorSize())) {
+          for(int i=0; ; ++i) // Find the biggest possible image_width_
+            if(((i+1)*(2*i+1)) <= PointOutT::descriptorSize())
+              image_width_ = i;
+            else
+              break;
+          PCL_ERROR("[pcl::SpinImageEstimation] The chosen image width is too large, setting it to %u instead. "
+            "Consider using pcl::Histogram<%u> as output type of SpinImageEstimation "
+            "(possibly with `#define PCL_NO_PRECOMPILE 1`).\n", image_width_, ((bin_count+1)*(2*bin_count+1)));
+        } else if (necessary_desc_size < static_cast<unsigned int>(PointOutT::descriptorSize())) {
+          image_width_ = bin_count;
+          PCL_WARN("[pcl::SpinImageEstimation] The chosen image width is smaller than the output histogram allows. "
+            "This is not an error, but the last few histogram bins will not be set. "
+            "Consider using pcl::Histogram<%u> as output type of SpinImageEstimation "
+            "(possibly with `#define PCL_NO_PRECOMPILE 1`).\n", ((bin_count+1)*(2*bin_count+1)));
+        } else {
+          image_width_ = bin_count;
+        }
       }
 
       /** \brief Sets the maximum angle for the point normal to get to support region.


### PR DESCRIPTION
The image width (set by the user) must fit together with the size of the output histogram. `setImageWidth` now checks the given parameter and provides advice if they do not work well together.

Minor additional change: in the constructor, change the assert to an if-statement since the support_angle_cos should always be checked.

Fixes https://github.com/PointCloudLibrary/pcl/issues/1834
Fixes https://github.com/PointCloudLibrary/pcl/issues/5039 (already closed, but same issue)