### PR TITLE
Added readability-container-data-pointer clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -23,6 +23,7 @@ Checks: >
     performance-no-automatic-move,
     performance-noexcept-move-constructor,
     performance-type-promotion-in-math-fn,
+    readability-container-data-pointer,
     readability-container-size-empty,
     readability-delete-null-pointer,
     readability-duplicate-include,

--- a/common/include/pcl/common/impl/intersections.hpp
+++ b/common/include/pcl/common/impl/intersections.hpp
@@ -70,8 +70,8 @@ lineWithLineIntersection (const pcl::ModelCoefficients &line_a,
                           const pcl::ModelCoefficients &line_b,
                           Eigen::Vector4f &point, double sqr_eps)
 {
-  Eigen::VectorXf coeff1 = Eigen::VectorXf::Map (&line_a.values[0], line_a.values.size ());
-  Eigen::VectorXf coeff2 = Eigen::VectorXf::Map (&line_b.values[0], line_b.values.size ());
+  Eigen::VectorXf coeff1 = Eigen::VectorXf::Map (line_a.values.data(), line_a.values.size ());
+  Eigen::VectorXf coeff2 = Eigen::VectorXf::Map (line_b.values.data(), line_b.values.size ());
   return (lineWithLineIntersection (coeff1, coeff2, point, sqr_eps));
 }
 

--- a/common/include/pcl/common/impl/io.hpp
+++ b/common/include/pcl/common/impl/io.hpp
@@ -133,7 +133,7 @@ namespace detail
                         pcl::PointCloud<PointT> &cloud_out)
   {
     // Use std::copy directly, if the point types of two clouds are same
-    std::copy (&cloud_in[0], (&cloud_in[0]) + cloud_in.size (), &cloud_out[0]);
+    std::copy (cloud_in.data(), cloud_in.data() + cloud_in.size (), cloud_out.data());
   }
 
 } // namespace detail
@@ -360,8 +360,8 @@ copyPointCloud (const pcl::PointCloud<PointT> &cloud_in, pcl::PointCloud<PointT>
 
     if (border_type == pcl::BORDER_TRANSPARENT)
     {
-      const PointT* in = &(cloud_in[0]);
-      PointT* out = &(cloud_out[0]);
+      const PointT* in = cloud_in.data();
+      PointT* out = cloud_out.data();
       PointT* out_inner = out + cloud_out.width*top + left;
       for (std::uint32_t i = 0; i < cloud_in.height; i++, out_inner += cloud_out.width, in += cloud_in.width)
       {
@@ -387,8 +387,8 @@ copyPointCloud (const pcl::PointCloud<PointT> &cloud_in, pcl::PointCloud<PointT>
           for (int i = 0; i < right; i++)
             padding[i+left] = pcl::interpolatePointIndex (cloud_in.width+i, cloud_in.width, border_type);
 
-          const PointT* in = &(cloud_in[0]);
-          PointT* out = &(cloud_out[0]);
+          const PointT* in = cloud_in.data();
+          PointT* out = cloud_out.data();
           PointT* out_inner = out + cloud_out.width*top + left;
 
           for (std::uint32_t i = 0; i < cloud_in.height; i++, out_inner += cloud_out.width, in += cloud_in.width)
@@ -428,9 +428,9 @@ copyPointCloud (const pcl::PointCloud<PointT> &cloud_in, pcl::PointCloud<PointT>
         int right = cloud_out.width - cloud_in.width - left;
         int bottom = cloud_out.height - cloud_in.height - top;
         std::vector<PointT> buff (cloud_out.width, value);
-        PointT* buff_ptr = &(buff[0]);
-        const PointT* in = &(cloud_in[0]);
-        PointT* out = &(cloud_out[0]);
+        PointT* buff_ptr = buff.data();
+        const PointT* in = cloud_in.data();
+        PointT* out = cloud_out.data();
         PointT* out_inner = out + cloud_out.width*top + left;
 
         for (std::uint32_t i = 0; i < cloud_in.height; i++, out_inner += cloud_out.width, in += cloud_in.width)

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -826,7 +826,7 @@ RangeImage::extractFarRanges (const pcl::PCLPointCloud2& point_cloud_data,
   }
   
   int point_step = point_cloud_data.point_step;
-  const unsigned char* data = &point_cloud_data.data[0];
+  const unsigned char* data = point_cloud_data.data.data();
   int x_offset = point_cloud_data.fields[x_idx].offset,
       y_offset = point_cloud_data.fields[y_idx].offset,
       z_offset = point_cloud_data.fields[z_idx].offset,

--- a/features/include/pcl/features/impl/brisk_2d.hpp
+++ b/features/include/pcl/features/impl/brisk_2d.hpp
@@ -249,7 +249,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
     const int r_y_1 = (1024 - r_y);
 
     //+const unsigned char* ptr = static_cast<const unsigned char*> (&image[0].r) + x + y * imagecols;
-    const unsigned char* ptr = static_cast<const unsigned char*>(&image[0]) + x + y * imagecols;
+    const unsigned char* ptr = static_cast<const unsigned char*>(image.data()) + x + y * imagecols;
 
     // just interpolate:
     ret_val = (r_x_1 * r_y_1 * static_cast<int>(*ptr));
@@ -312,7 +312,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
     // now the calculation:
 
     //+const unsigned char* ptr = static_cast<const unsigned char*> (&image[0].r) + x_left + imagecols * y_top;
-    const unsigned char* ptr = static_cast<const unsigned char*>(&image[0]) + x_left + imagecols * y_top;
+    const unsigned char* ptr = static_cast<const unsigned char*>(image.data()) + x_left + imagecols * y_top;
 
     // first the corners:
     ret_val = A * static_cast<int>(*ptr);
@@ -334,7 +334,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
 
     // next the edges:
     //+int* ptr_integral;// = static_cast<int*> (integral.data) + x_left + integralcols * y_top + 1;
-    const int* ptr_integral = static_cast<const int*> (&integral_image[0]) + x_left + integralcols * y_top + 1;
+    const int* ptr_integral = static_cast<const int*> (integral_image.data()) + x_left + integralcols * y_top + 1;
 
     // find a simple path through the different surface corners
     const int tmp1 = (*ptr_integral);
@@ -374,7 +374,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
   // now the calculation:
 
   //const unsigned char* ptr = static_cast<const unsigned char*> (&image[0].r) + x_left + imagecols * y_top;
-  const unsigned char* ptr = static_cast<const unsigned char*>(&image[0]) + x_left + imagecols * y_top;
+  const unsigned char* ptr = static_cast<const unsigned char*>(image.data()) + x_left + imagecols * y_top;
 
   // first row:
   ret_val = A * static_cast<int>(*ptr);

--- a/features/include/pcl/features/impl/integral_image2D.hpp
+++ b/features/include/pcl/features/impl/integral_image2D.hpp
@@ -156,12 +156,12 @@ template <typename DataType, unsigned Dimension> void
 IntegralImage2D<DataType, Dimension>::computeIntegralImages (
     const DataType *data, unsigned row_stride, unsigned element_stride)
 {
-  ElementType* previous_row = &first_order_integral_image_[0];
+  ElementType* previous_row = first_order_integral_image_.data();
   ElementType* current_row  = previous_row + (width_ + 1);
   for (unsigned int i = 0; i < (width_ + 1); ++i)
     previous_row[i].setZero();
 
-  unsigned* count_previous_row = &finite_values_integral_image_[0];
+  unsigned* count_previous_row = finite_values_integral_image_.data();
   unsigned* count_current_row  = count_previous_row + (width_ + 1);
   std::fill_n(count_previous_row, width_ + 1, 0);
 
@@ -188,7 +188,7 @@ IntegralImage2D<DataType, Dimension>::computeIntegralImages (
   }
   else
   {
-    SecondOrderType* so_previous_row = &second_order_integral_image_[0];
+    SecondOrderType* so_previous_row = second_order_integral_image_.data();
     SecondOrderType* so_current_row  = so_previous_row + (width_ + 1);
     for (unsigned int i = 0; i < (width_ + 1); ++i)
       so_previous_row[i].setZero();
@@ -327,11 +327,11 @@ template <typename DataType> void
 IntegralImage2D<DataType, 1>::computeIntegralImages (
     const DataType *data, unsigned row_stride, unsigned element_stride)
 {
-  ElementType* previous_row = &first_order_integral_image_[0];
+  ElementType* previous_row = first_order_integral_image_.data();
   ElementType* current_row  = previous_row + (width_ + 1);
   std::fill_n(previous_row, width_ + 1, 0);
 
-  unsigned* count_previous_row = &finite_values_integral_image_[0];
+  unsigned* count_previous_row = finite_values_integral_image_.data();
   unsigned* count_current_row  = count_previous_row + (width_ + 1);
   std::fill_n(count_previous_row, width_ + 1, 0);
 
@@ -357,7 +357,7 @@ IntegralImage2D<DataType, 1>::computeIntegralImages (
   }
   else
   {
-    SecondOrderType* so_previous_row = &second_order_integral_image_[0];
+    SecondOrderType* so_previous_row = second_order_integral_image_.data();
     SecondOrderType* so_current_row  = so_previous_row + (width_ + 1);
     std::fill_n(so_previous_row, width_ + 1, 0);
 

--- a/filters/src/passthrough.cpp
+++ b/filters/src/passthrough.cpp
@@ -217,7 +217,7 @@ pcl::PassThrough<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
         }
 
         // Unoptimized memcpys: assume fields x, y, z are in random order
-        memcpy (&pt[0], &input_->data[xyz_offset[0]], sizeof(float));
+        memcpy (&pt[0], &input_->data[xyz_offset[0]], sizeof(float)); // NOLINT(readability-container-data-pointer)
         memcpy (&pt[1], &input_->data[xyz_offset[1]], sizeof(float));
         memcpy (&pt[2], &input_->data[xyz_offset[2]], sizeof(float));
 
@@ -245,7 +245,7 @@ pcl::PassThrough<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
     for (int cp = 0; cp < nr_points; ++cp, xyz_offset += input_->point_step)
     {
       // Unoptimized memcpys: assume fields x, y, z are in random order
-      memcpy (&pt[0], &input_->data[xyz_offset[0]], sizeof(float));
+      memcpy (&pt[0], &input_->data[xyz_offset[0]], sizeof(float)); // NOLINT(readability-container-data-pointer)
       memcpy (&pt[1], &input_->data[xyz_offset[1]], sizeof(float));
       memcpy (&pt[2], &input_->data[xyz_offset[2]], sizeof(float));
 

--- a/filters/src/voxel_grid.cpp
+++ b/filters/src/voxel_grid.cpp
@@ -45,7 +45,7 @@
 #include <array>
 
 using Array4size_t = Eigen::Array<std::size_t, 4, 1>;
-
+// NOLINTBEGIN(readability-container-data-pointer)
 ///////////////////////////////////////////////////////////////////////////////////////////
 void
 pcl::getMinMax3D (const pcl::PCLPointCloud2ConstPtr &cloud, int x_idx, int y_idx, int z_idx,
@@ -525,7 +525,7 @@ pcl::VoxelGrid<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
     ++index;
   }
 }
-
+// NOLINTEND(readability-container-data-pointer)
 #ifndef PCL_NO_PRECOMPILE
 #include <pcl/impl/instantiate.hpp>
 #include <pcl/point_types.h>

--- a/io/include/pcl/compression/impl/entropy_range_coder.hpp
+++ b/io/include/pcl/compression/impl/entropy_range_coder.hpp
@@ -119,7 +119,7 @@ pcl::AdaptiveRangeCoder::encodeCharVectorToStream (const std::vector<char>& inpu
   }
 
   // write to stream
-  outputByteStream_arg.write (&outputCharVector_[0], outputCharVector_.size ());
+  outputByteStream_arg.write (outputCharVector_.data(), outputCharVector_.size ());
 
   return (static_cast<unsigned long> (outputCharVector_.size ()));
 }
@@ -340,7 +340,7 @@ pcl::StaticRangeCoder::encodeIntVectorToStream (std::vector<unsigned int>& input
   }
 
   // write encoded data to stream
-  outputByteStream_arg.write (&outputCharVector_[0], outputCharVector_.size ());
+  outputByteStream_arg.write (outputCharVector_.data(), outputCharVector_.size ());
 
   streamByteCount += static_cast<unsigned long> (outputCharVector_.size ());
 
@@ -528,7 +528,7 @@ pcl::StaticRangeCoder::encodeCharVectorToStream (const std::vector<char>& inputB
   }
 
   // write encoded data to stream
-  outputByteStream_arg.write (&outputCharVector_[0], outputCharVector_.size ());
+  outputByteStream_arg.write (outputCharVector_.data(), outputCharVector_.size ());
 
   streamByteCount += static_cast<unsigned long> (outputCharVector_.size ());
 

--- a/io/include/pcl/compression/impl/organized_pointcloud_compression.hpp
+++ b/io/include/pcl/compression/impl/organized_pointcloud_compression.hpp
@@ -109,7 +109,7 @@ namespace pcl
       // Encode size of compressed disparity image data
       compressedDataOut_arg.write (reinterpret_cast<const char*> (&compressedDisparitySize), sizeof (compressedDisparitySize));
       // Output compressed disparity to ostream
-      compressedDataOut_arg.write (reinterpret_cast<const char*> (&compressedDisparity[0]), compressedDisparity.size () * sizeof(std::uint8_t));
+      compressedDataOut_arg.write (reinterpret_cast<const char*> (compressedDisparity.data()), compressedDisparity.size () * sizeof(std::uint8_t));
 
       // Compress color information
       if (CompressionPointTraits<PointT>::hasColor && doColorEncoding)
@@ -127,7 +127,7 @@ namespace pcl
       // Encode size of compressed Color image data
       compressedDataOut_arg.write (reinterpret_cast<const char*> (&compressedColorSize), sizeof (compressedColorSize));
       // Output compressed disparity to ostream
-      compressedDataOut_arg.write (reinterpret_cast<const char*> (&compressedColor[0]), compressedColor.size () * sizeof(std::uint8_t));
+      compressedDataOut_arg.write (reinterpret_cast<const char*> (compressedColor.data()), compressedColor.size () * sizeof(std::uint8_t));
 
       if (bShowStatistics_arg)
       {
@@ -194,8 +194,8 @@ namespace pcl
        std::uint32_t compressedColorSize = 0;
 
        // Remove color information of invalid points
-       std::uint16_t* depth_ptr = &disparityMap_arg[0];
-       std::uint8_t* color_ptr = &colorImage_arg[0];
+       std::uint16_t* depth_ptr = disparityMap_arg.data();
+       std::uint8_t* color_ptr = colorImage_arg.data();
 
        for (std::size_t i = 0; i < cloud_size; ++i, ++depth_ptr, color_ptr += sizeof(std::uint8_t) * 3)
        {
@@ -211,7 +211,7 @@ namespace pcl
        // Encode size of compressed disparity image data
        compressedDataOut_arg.write (reinterpret_cast<const char*> (&compressedDisparitySize), sizeof (compressedDisparitySize));
        // Output compressed disparity to ostream
-       compressedDataOut_arg.write (reinterpret_cast<const char*> (&compressedDisparity[0]), compressedDisparity.size () * sizeof(std::uint8_t));
+       compressedDataOut_arg.write (reinterpret_cast<const char*> (compressedDisparity.data()), compressedDisparity.size () * sizeof(std::uint8_t));
 
        // Compress color information
        if (!colorImage_arg.empty () && doColorEncoding)
@@ -244,7 +244,7 @@ namespace pcl
        // Encode size of compressed Color image data
        compressedDataOut_arg.write (reinterpret_cast<const char*> (&compressedColorSize), sizeof (compressedColorSize));
        // Output compressed disparity to ostream
-       compressedDataOut_arg.write (reinterpret_cast<const char*> (&compressedColor[0]), compressedColor.size () * sizeof(std::uint8_t));
+       compressedDataOut_arg.write (reinterpret_cast<const char*> (compressedColor.data()), compressedColor.size () * sizeof(std::uint8_t));
 
        if (bShowStatistics_arg)
        {
@@ -320,12 +320,12 @@ namespace pcl
         // reading compressed disparity data
         compressedDataIn_arg.read (reinterpret_cast<char*> (&compressedDisparitySize), sizeof (compressedDisparitySize));
         compressedDisparity.resize (compressedDisparitySize);
-        compressedDataIn_arg.read (reinterpret_cast<char*> (&compressedDisparity[0]), compressedDisparitySize * sizeof(std::uint8_t));
+        compressedDataIn_arg.read (reinterpret_cast<char*> (compressedDisparity.data()), compressedDisparitySize * sizeof(std::uint8_t));
 
         // reading compressed rgb data
         compressedDataIn_arg.read (reinterpret_cast<char*> (&compressedColorSize), sizeof (compressedColorSize));
         compressedColor.resize (compressedColorSize);
-        compressedDataIn_arg.read (reinterpret_cast<char*> (&compressedColor[0]), compressedColorSize * sizeof(std::uint8_t));
+        compressedDataIn_arg.read (reinterpret_cast<char*> (compressedColor.data()), compressedColorSize * sizeof(std::uint8_t));
 
         std::size_t png_width = 0;
         std::size_t png_height = 0;

--- a/io/include/pcl/io/impl/lzf_image_io.hpp
+++ b/io/include/pcl/io/impl/lzf_image_io.hpp
@@ -236,7 +236,7 @@ LZFRGB24ImageReader::read (
   cloud.resize (getWidth () * getHeight ());
 
   int rgb_idx = 0;
-  auto *color_r = reinterpret_cast<unsigned char*> (&uncompressed_data[0]);
+  auto *color_r = reinterpret_cast<unsigned char*> (uncompressed_data.data());
   auto *color_g = reinterpret_cast<unsigned char*> (&uncompressed_data[getWidth () * getHeight ()]);
   auto *color_b = reinterpret_cast<unsigned char*> (&uncompressed_data[2 * getWidth () * getHeight ()]);
 
@@ -284,7 +284,7 @@ LZFRGB24ImageReader::readOMP (
   cloud.height = getHeight ();
   cloud.resize (getWidth () * getHeight ());
 
-  auto *color_r = reinterpret_cast<unsigned char*> (&uncompressed_data[0]);
+  auto *color_r = reinterpret_cast<unsigned char*> (uncompressed_data.data());
   auto *color_g = reinterpret_cast<unsigned char*> (&uncompressed_data[getWidth () * getHeight ()]);
   auto *color_b = reinterpret_cast<unsigned char*> (&uncompressed_data[2 * getWidth () * getHeight ()]);
 
@@ -341,7 +341,7 @@ LZFYUV422ImageReader::read (
   cloud.resize (getWidth () * getHeight ());
 
   int wh2 = getWidth () * getHeight () / 2;
-  auto *color_u = reinterpret_cast<unsigned char*> (&uncompressed_data[0]);
+  auto *color_u = reinterpret_cast<unsigned char*> (uncompressed_data.data());
   auto *color_y = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2]);
   auto *color_v = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2 + getWidth () * getHeight ()]);
 
@@ -399,7 +399,7 @@ LZFYUV422ImageReader::readOMP (
   cloud.resize (getWidth () * getHeight ());
 
   int wh2 = getWidth () * getHeight () / 2;
-  auto *color_u = reinterpret_cast<unsigned char*> (&uncompressed_data[0]);
+  auto *color_u = reinterpret_cast<unsigned char*> (uncompressed_data.data());
   auto *color_y = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2]);
   auto *color_v = reinterpret_cast<unsigned char*> (&uncompressed_data[wh2 + getWidth () * getHeight ()]);
 
@@ -462,8 +462,8 @@ LZFBayer8ImageReader::read (
   // Convert Bayer8 to RGB24
   std::vector<unsigned char> rgb_buffer (getWidth () * getHeight () * 3);
   DeBayer i;
-  i.debayerEdgeAware (reinterpret_cast<unsigned char*> (&uncompressed_data[0]),
-                     static_cast<unsigned char*> (&rgb_buffer[0]),
+  i.debayerEdgeAware (reinterpret_cast<unsigned char*> (uncompressed_data.data()),
+                     static_cast<unsigned char*> (rgb_buffer.data()),
                      getWidth (), getHeight ());
   // Copy to PointT
   cloud.width  = getWidth ();
@@ -512,8 +512,8 @@ LZFBayer8ImageReader::readOMP (
   // Convert Bayer8 to RGB24
   std::vector<unsigned char> rgb_buffer (getWidth () * getHeight () * 3);
   DeBayer i;
-  i.debayerEdgeAware (reinterpret_cast<unsigned char*> (&uncompressed_data[0]),
-                     static_cast<unsigned char*> (&rgb_buffer[0]),
+  i.debayerEdgeAware (reinterpret_cast<unsigned char*> (uncompressed_data.data()),
+                     static_cast<unsigned char*> (rgb_buffer.data()),
                      getWidth (), getHeight ());
   // Copy to PointT
   cloud.width  = getWidth ();

--- a/io/include/pcl/io/impl/point_cloud_image_extractors.hpp
+++ b/io/include/pcl/io/impl/point_cloud_image_extractors.hpp
@@ -154,7 +154,7 @@ pcl::io::PointCloudImageExtractorFromLabelField<PointT>::extractImpl (const Poin
       img.height = cloud.height;
       img.step = img.width * sizeof (unsigned short);
       img.data.resize (img.step * img.height);
-      auto* data = reinterpret_cast<unsigned short*>(&img.data[0]);
+      auto* data = reinterpret_cast<unsigned short*>(img.data.data());
       for (std::size_t i = 0; i < cloud.size (); ++i)
       {
         std::uint32_t val;
@@ -255,7 +255,7 @@ pcl::io::PointCloudImageExtractorWithScaling<PointT>::extractImpl (const PointCl
   img.height = cloud.height;
   img.step = img.width * sizeof (unsigned short);
   img.data.resize (img.step * img.height);
-  auto* data = reinterpret_cast<unsigned short*>(&img.data[0]);
+  auto* data = reinterpret_cast<unsigned short*>(img.data.data());
 
   float scaling_factor = scaling_factor_;
   float data_min = 0.0f;

--- a/io/src/ascii_io.cpp
+++ b/io/src/ascii_io.cpp
@@ -143,7 +143,7 @@ pcl::ASCIIReader::read (
 
   int total=0;
 
-  std::uint8_t* data = &cloud.data[0];
+  std::uint8_t* data = cloud.data.data();
   while (std::getline (ifile, line))
   {
     boost::algorithm::trim (line);

--- a/io/src/ifs_io.cpp
+++ b/io/src/ifs_io.cpp
@@ -213,7 +213,7 @@ pcl::IFSReader::read (const std::string &file_name,
   }
 
   // Copy the data
-  memcpy (&cloud.data[0], mapped_file.data () + data_idx, cloud.data.size ());
+  memcpy (cloud.data.data(), mapped_file.data () + data_idx, cloud.data.size ());
 
   mapped_file.close ();
 
@@ -264,7 +264,7 @@ pcl::IFSReader::read (const std::string &file_name, pcl::PolygonMesh &mesh, int 
   }
 
   // Copy the data
-  memcpy (&mesh.cloud.data[0], mapped_file.data () + data_idx, mesh.cloud.data.size ());
+  memcpy (mesh.cloud.data.data(), mapped_file.data () + data_idx, mesh.cloud.data.size ());
 
   mapped_file.close ();
 
@@ -308,6 +308,7 @@ pcl::IFSReader::read (const std::string &file_name, pcl::PolygonMesh &mesh, int 
   {
     pcl::Vertices &facet = mesh.polygons[i];
     facet.vertices.resize (3);
+    // NOLINTNEXTLINE(readability-container-data-pointer)
     fs.read (reinterpret_cast<char*>(&(facet.vertices[0])), sizeof (std::uint32_t));
     fs.read (reinterpret_cast<char*>(&(facet.vertices[1])), sizeof (std::uint32_t));
     fs.read (reinterpret_cast<char*>(&(facet.vertices[2])), sizeof (std::uint32_t));
@@ -345,7 +346,7 @@ pcl::IFSWriter::write (const std::string &file_name, const pcl::PCLPointCloud2 &
                             sizeof (std::uint32_t) + cloud_name.size () + 1 +
                             sizeof (std::uint32_t) + vertices.size () + 1 +
                             sizeof (std::uint32_t));
-  char* addr = &(header[0]);
+  char* addr = header.data();
   const std::uint32_t magic_size = static_cast<std::uint32_t> (magic.size ()) + 1;
   memcpy (addr, &magic_size, sizeof (std::uint32_t));
   addr+= sizeof (std::uint32_t);
@@ -396,10 +397,10 @@ pcl::IFSWriter::write (const std::string &file_name, const pcl::PCLPointCloud2 &
   }
 
   // copy header
-  memcpy (sink.data (), &header[0], data_idx);
+  memcpy (sink.data (), header.data(), data_idx);
 
   // Copy the data
-  memcpy (sink.data () + data_idx, &cloud.data[0], cloud.data.size ());
+  memcpy (sink.data () + data_idx, cloud.data.data(), cloud.data.size ());
 
   sink.close ();
 

--- a/io/src/libpng_wrapper.cpp
+++ b/io/src/libpng_wrapper.cpp
@@ -201,7 +201,7 @@ namespace pcl
       // Setup Exception handling
       setjmp (png_jmpbuf(png_ptr));
 
-      std::uint8_t* input_pointer = &pngData_arg[0];
+      std::uint8_t* input_pointer = pngData_arg.data();
       png_set_read_fn (png_ptr, reinterpret_cast<void*> (&input_pointer), user_read_data);
 
       png_read_info (png_ptr, info_ptr);

--- a/io/src/lzf_image_io.cpp
+++ b/io/src/lzf_image_io.cpp
@@ -140,7 +140,7 @@ pcl::io::LZFImageWriter::compress (const char* input,
     if (itype.size () < 16)
       itype.insert (itype.end (), 16 - itype.size (), ' ');
 
-    memcpy (&output[13], &itype[0], 16);
+    memcpy (&output[13], itype.data(), 16);
     memcpy (&output[29], &compressed_size, sizeof (std::uint32_t));
     memcpy (&output[33], &uncompressed_size, sizeof (std::uint32_t));
     compressed_final_size = static_cast<std::uint32_t>(compressed_size + header_size);
@@ -238,7 +238,7 @@ pcl::io::LZFRGB24ImageWriter::write (const char *data,
   }
 
   char* compressed_rgb = static_cast<char*> (malloc (static_cast<std::size_t>(static_cast<float>(rrggbb.size ()) * 1.5f + static_cast<float>(LZF_HEADER_SIZE))));
-  std::size_t compressed_size = compress (reinterpret_cast<const char*> (&rrggbb[0]), 
+  std::size_t compressed_size = compress (reinterpret_cast<const char*> (rrggbb.data()), 
                                      static_cast<std::uint32_t>(rrggbb.size ()),
                                      width, height,
                                      "rgb24",
@@ -299,7 +299,7 @@ pcl::io::LZFYUV422ImageWriter::write (const char *data,
   }
 
   char* compressed_yuv = static_cast<char*> (malloc (static_cast<std::size_t>(static_cast<float>(uuyyvv.size ()) * 1.5f + static_cast<float>(LZF_HEADER_SIZE))));
-  std::size_t compressed_size = compress (reinterpret_cast<const char*> (&uuyyvv[0]), 
+  std::size_t compressed_size = compress (reinterpret_cast<const char*> (uuyyvv.data()), 
                                      static_cast<std::uint32_t>(uuyyvv.size ()),
                                      width, height,
                                      "yuv422",
@@ -442,7 +442,7 @@ pcl::io::LZFImageReader::loadImageBlob (const std::string &filename,
   memcpy (&uncompressed_size, &map[33], sizeof (std::uint32_t));
 
   data.resize (compressed_size);
-  memcpy (&data[0], &map[header_size], compressed_size);
+  memcpy (data.data(), &map[header_size], compressed_size);
 
 #ifdef _WIN32
   UnmapViewOfFile (map);
@@ -466,9 +466,9 @@ pcl::io::LZFImageReader::decompress (const std::vector<char> &input,
     PCL_ERROR ("[pcl::io::LZFImageReader::decompress] Output array needs to be preallocated! The correct uncompressed array value should have been stored during the compression.\n");
     return (false);
   }
-  unsigned int tmp_size = pcl::lzfDecompress (static_cast<const char*>(&input[0]), 
+  unsigned int tmp_size = pcl::lzfDecompress (static_cast<const char*>(input.data()), 
                                               static_cast<std::uint32_t>(input.size ()), 
-                                              static_cast<char*>(&output[0]), 
+                                              static_cast<char*>(output.data()), 
                                               static_cast<std::uint32_t>(output.size ()));
 
   if (tmp_size != output.size ())

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -559,7 +559,7 @@ pcl::PCDReader::readBodyBinary (const unsigned char *map, pcl::PCLPointCloud2 &c
     auto data_size = static_cast<unsigned int> (cloud.data.size ());
     std::vector<char> buf (data_size);
     // The size of the uncompressed data better be the same as what we stored in the header
-    unsigned int tmp_size = pcl::lzfDecompress (&map[data_idx + 8], compressed_size, &buf[0], data_size);
+    unsigned int tmp_size = pcl::lzfDecompress (&map[data_idx + 8], compressed_size, buf.data(), data_size);
     if (tmp_size != uncompressed_size)
     {
       PCL_ERROR ("[pcl::PCDReader::read] Size of decompressed lzf data (%u) does not match value stored in PCD header (%u). Errno: %d\n", tmp_size, uncompressed_size, errno);
@@ -604,7 +604,7 @@ pcl::PCDReader::readBodyBinary (const unsigned char *map, pcl::PCLPointCloud2 &c
   }
   else
     // Copy the data
-    memcpy (&cloud.data[0], &map[0] + data_idx, cloud.data.size ());
+    memcpy ((cloud.data).data(), &map[0] + data_idx, cloud.data.size ());
 
   // Extra checks (not needed for ASCII)
   int point_size = (cloud.width * cloud.height == 0) ? 0 : static_cast<int> (cloud.data.size () / (cloud.height * cloud.width));
@@ -1259,7 +1259,7 @@ pcl::PCDWriter::writeBinary (const std::string &file_name, const pcl::PCLPointCl
   memcpy (&map[0], oss.str().c_str (), static_cast<std::size_t> (data_idx));
 
   // Copy the data
-  memcpy (&map[0] + data_idx, &cloud.data[0], cloud.data.size ());
+  memcpy (&map[0] + data_idx, cloud.data.data(), cloud.data.size ());
 
 #ifndef _WIN32
   // If the user set the synchronization flag on, call msync
@@ -1387,11 +1387,11 @@ pcl::PCDWriter::writeBinaryCompressed (std::ostream &os, const pcl::PCLPointClou
     {
       return (-1);
     }
-    memcpy (&temp_buf[0], &compressed_size, 4);
+    memcpy (temp_buf.data(), &compressed_size, 4);
     memcpy (&temp_buf[4], &data_size, 4);
     temp_buf.resize (compressed_size + 8);
   } else {
-    auto *header = reinterpret_cast<std::uint32_t*>(&temp_buf[0]);
+    auto *header = reinterpret_cast<std::uint32_t*>(temp_buf.data());
     header[0] = 0; // compressed_size is 0
     header[1] = 0; // data_size is 0
   }

--- a/io/src/png_io.cpp
+++ b/io/src/png_io.cpp
@@ -103,13 +103,13 @@ pcl::io::saveRgbPNGFile (const std::string& file_name, const unsigned char *rgb_
 void
 pcl::io::savePNGFile (const std::string& file_name, const pcl::PointCloud<unsigned char>& cloud)
 {
-  saveCharPNGFile(file_name, &cloud[0], cloud.width, cloud.height, 1);
+  saveCharPNGFile(file_name, cloud.data(), cloud.width, cloud.height, 1);
 }
 
 void
 pcl::io::savePNGFile (const std::string& file_name, const pcl::PointCloud<unsigned short>& cloud)
 {
-  saveShortPNGFile(file_name, &cloud[0], cloud.width, cloud.height, 1);
+  saveShortPNGFile(file_name, cloud.data(), cloud.width, cloud.height, 1);
 }
 
 void
@@ -117,15 +117,15 @@ pcl::io::savePNGFile (const std::string& file_name, const pcl::PCLImage& image)
 {
     if (image.encoding == "rgb8")
     {
-        saveRgbPNGFile(file_name, &image.data[0], image.width, image.height);
+        saveRgbPNGFile(file_name, image.data.data(), image.width, image.height);
     }
     else if (image.encoding == "mono8")
     {
-        saveCharPNGFile(file_name, &image.data[0], image.width, image.height, 1);
+        saveCharPNGFile(file_name, image.data.data(), image.width, image.height, 1);
     }
     else if (image.encoding == "mono16")
     {
-        saveShortPNGFile(file_name, reinterpret_cast<const unsigned short*>(&image.data[0]), image.width, image.height, 1);
+        saveShortPNGFile(file_name, reinterpret_cast<const unsigned short*>(image.data.data()), image.width, image.height, 1);
     }
     else
     {

--- a/io/src/vtk_lib_io.cpp
+++ b/io/src/vtk_lib_io.cpp
@@ -456,7 +456,7 @@ pcl::io::mesh2vtk (const pcl::PolygonMesh& mesh, vtkSmartPointer<vtkPolyData>& p
     Eigen::Array4i xyz_offset (mesh.cloud.fields[idx_x].offset, mesh.cloud.fields[idx_y].offset, mesh.cloud.fields[idx_z].offset, 0);
     for (vtkIdType cp = 0; cp < static_cast<vtkIdType> (nr_points); ++cp, xyz_offset += mesh.cloud.point_step)
     {
-      memcpy(&pt[0], &mesh.cloud.data[xyz_offset[0]], sizeof (float));
+      memcpy(&pt[0], &mesh.cloud.data[xyz_offset[0]], sizeof (float)); // NOLINT(readability-container-data-pointer)
       memcpy(&pt[1], &mesh.cloud.data[xyz_offset[1]], sizeof (float));
       memcpy(&pt[2], &mesh.cloud.data[xyz_offset[2]], sizeof (float));
       vtk_mesh_points->InsertPoint (cp, pt[0], pt[1], pt[2]);

--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -169,7 +169,7 @@ knn_search(A& index, B& query, C& k_indices, D& dists, unsigned int k, F& params
   std::vector<std::size_t> indices(k);
   k_indices.resize(k);
   // Wrap indices vector (no data allocation)
-  ::flann::Matrix<std::size_t> indices_mat(&indices[0], 1, k);
+  ::flann::Matrix<std::size_t> indices_mat(indices.data(), 1, k);
   auto ret = index.knnSearch(query, indices_mat, dists, k, params);
   // cast appropriately
   std::transform(indices.cbegin(),
@@ -253,10 +253,10 @@ pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, unsigned in
   point_representation_->vectorize (static_cast<PointT> (point), query);
 
   // Wrap the k_distances vector (no data copy)
-  ::flann::Matrix<float> k_distances_mat (&k_distances[0], 1, k);
+  ::flann::Matrix<float> k_distances_mat (k_distances.data(), 1, k);
 
   knn_search(*flann_index_,
-             ::flann::Matrix<float>(&query[0], 1, dim_),
+             ::flann::Matrix<float>(query.data(), 1, dim_),
              k_indices,
              k_distances_mat,
              k,
@@ -392,7 +392,7 @@ pcl::KdTreeFLANN<PointT, Dist>::radiusSearch (const PointT &point, double radius
   else
     params.max_neighbors = max_nn;
 
-  auto query_mat = ::flann::Matrix<float>(&query[0], 1, dim_);
+  auto query_mat = ::flann::Matrix<float>(query.data(), 1, dim_);
   int neighbors_in_radius = radius_search(*flann_index_,
                                           query_mat,
                                           k_indices,

--- a/keypoints/src/agast_2d.cpp
+++ b/keypoints/src/agast_2d.cpp
@@ -81,7 +81,7 @@ pcl::keypoints::agast::AbstractAgastDetector::detectKeypoints (
     const std::vector<unsigned char> & intensity_data,
     pcl::PointCloud<pcl::PointUV> &output) const
 {
-  detect (&(intensity_data[0]), output.points);
+  detect (intensity_data.data(), output.points);
 
   output.height = 1;
   output.width = output.size ();
@@ -93,7 +93,7 @@ pcl::keypoints::agast::AbstractAgastDetector::detectKeypoints (
     const std::vector<float> & intensity_data,
     pcl::PointCloud<pcl::PointUV> &output) const
 {
-  detect (&(intensity_data[0]), output.points);
+  detect (intensity_data.data(), output.points);
 
   output.height = 1;
   output.width = output.size ();
@@ -244,7 +244,7 @@ pcl::keypoints::agast::AbstractAgastDetector::applyNonMaxSuppression (
   pcl::PointCloud<pcl::PointUV> &output)
 {
   std::vector<ScoreIndex> scores;
-  computeCornerScores (&(intensity_data[0]), input.points, scores);
+  computeCornerScores (intensity_data.data(), input.points, scores);
 
   // If a threshold for the maximum number of keypoints is given
   if (nr_max_keypoints_ <= scores.size ()) //std::numeric_limits<unsigned int>::max ())
@@ -272,7 +272,7 @@ pcl::keypoints::agast::AbstractAgastDetector::applyNonMaxSuppression (
   pcl::PointCloud<pcl::PointUV> &output)
 {
   std::vector<ScoreIndex> scores;
-  computeCornerScores (&(intensity_data[0]), input.points, scores);
+  computeCornerScores (intensity_data.data(), input.points, scores);
 
   // If a threshold for the maximum number of keypoints is given
   if (nr_max_keypoints_ <= scores.size ()) //std::numeric_limits<unsigned int>::max ())

--- a/recognition/include/pcl/recognition/color_gradient_modality.h
+++ b/recognition/include/pcl/recognition/color_gradient_modality.h
@@ -310,7 +310,7 @@ computeGaussianKernel (const std::size_t kernel_size, const float sigma, std::ve
   //CV_Assert( ktype == CV_32F || ktype == CV_64F );
   /*Mat kernel(n, 1, ktype);*/
   kernel_values.resize (n);
-  float* cf = &(kernel_values[0]);
+  float* cf = kernel_values.data();
   //double* cd = (double*)kernel.data;
 
   double sigmaX = sigma > 0 ? sigma : ((n-1)*0.5 - 1)*0.3 + 0.8;

--- a/recognition/include/pcl/recognition/distance_map.h
+++ b/recognition/include/pcl/recognition/distance_map.h
@@ -69,7 +69,7 @@ namespace pcl
       inline float * 
       getData () 
       { 
-        return (&data_[0]); 
+        return (data_.data());
       }
 
       /** \brief Resizes the map to the specified size.

--- a/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
+++ b/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
@@ -1280,7 +1280,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::computeKMe
   Eigen::MatrixXf old_centers (number_of_clusters, feature_dimension);
   std::vector<int> counters (number_of_clusters);
   std::vector<Eigen::Vector2f, Eigen::aligned_allocator<Eigen::Vector2f> > boxes (feature_dimension);
-  Eigen::Vector2f* box = &boxes[0];
+  Eigen::Vector2f* box = boxes.data();
 
   double best_compactness = std::numeric_limits<double>::max ();
   double compactness = 0.0;
@@ -1428,7 +1428,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::generateCe
   std::size_t dimension = data.cols ();
   auto number_of_points = static_cast<unsigned int> (data.rows ());
   std::vector<int> centers_vec (number_of_clusters);
-  int* centers = &centers_vec[0];
+  int* centers = centers_vec.data();
   std::vector<double> dist (number_of_points);
   std::vector<double> tdist (number_of_points);
   std::vector<double> tdist2 (number_of_points);

--- a/recognition/include/pcl/recognition/quantized_map.h
+++ b/recognition/include/pcl/recognition/quantized_map.h
@@ -59,10 +59,10 @@ namespace pcl
       getHeight () const { return (height_); }
       
       inline unsigned char*
-      getData () { return (&data_[0]); }
+      getData () { return (data_.data()); }
 
       inline const unsigned char*
-      getData () const { return (&data_[0]); }
+      getData () const { return (data_.data()); }
 
       inline QuantizedMap
       getSubMap (std::size_t x,

--- a/recognition/src/dotmod.cpp
+++ b/recognition/src/dotmod.cpp
@@ -160,7 +160,7 @@ detectTemplates (const std::vector<DOTModality*> & modalities,
         const unsigned char * image_data = map.getData ();
         for (std::size_t template_index = 0; template_index < nr_templates; ++template_index)
         {
-          const unsigned char * template_data = &(templates_[template_index].modalities[modality_index].features[0]);
+          const unsigned char * template_data = templates_[template_index].modalities[modality_index].features.data();
           for (std::size_t data_index = 0; data_index < (nr_template_horizontal_bins*nr_template_vertical_bins); ++data_index)
           {
             if ((image_data[data_index] & template_data[data_index]) != 0)

--- a/recognition/src/face_detection/face_detector_data_provider.cpp
+++ b/recognition/src/face_detection/face_detector_data_provider.cpp
@@ -254,7 +254,7 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
 
     int element_stride = sizeof(pcl::PointXYZ) / sizeof(float);
     int row_stride = element_stride * cloud->width;
-    const float *data = reinterpret_cast<const float*> (&(*cloud)[0]);
+    const float *data = reinterpret_cast<const float*> (&(*cloud)[0]); // NOLINT(readability-container-data-pointer)
     integral_image_depth->setInput (data + 2, cloud->width, cloud->height, element_stride, row_stride);
 
     //Compute normals and normal integral images
@@ -282,15 +282,15 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
     if (USE_NORMALS_)
     {
       integral_image_normal_x.reset (new pcl::IntegralImage2D<float, 1> (false));
-      const float *data_nx = reinterpret_cast<const float*> (&(*normals)[0]);
+      const float *data_nx = reinterpret_cast<const float*> (&(*normals)[0]);// NOLINT(readability-container-data-pointer)
       integral_image_normal_x->setInput (data_nx, normals->width, normals->height, element_stride_normal, row_stride_normal);
 
       integral_image_normal_y.reset (new pcl::IntegralImage2D<float, 1> (false));
-      const float *data_ny = reinterpret_cast<const float*> (&(*normals)[0]);
+      const float *data_ny = reinterpret_cast<const float*> (&(*normals)[0]);// NOLINT(readability-container-data-pointer)
       integral_image_normal_y->setInput (data_ny + 1, normals->width, normals->height, element_stride_normal, row_stride_normal);
 
       integral_image_normal_z.reset (new pcl::IntegralImage2D<float, 1> (false));
-      const float *data_nz = reinterpret_cast<const float*> (&(*normals)[0]);
+      const float *data_nz = reinterpret_cast<const float*> (&(*normals)[0]);// NOLINT(readability-container-data-pointer)
       integral_image_normal_z->setInput (data_nz + 2, normals->width, normals->height, element_stride_normal, row_stride_normal);
     }
 

--- a/recognition/src/face_detection/face_detector_data_provider.cpp
+++ b/recognition/src/face_detection/face_detector_data_provider.cpp
@@ -282,16 +282,14 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
     if (USE_NORMALS_)
     {
       integral_image_normal_x.reset (new pcl::IntegralImage2D<float, 1> (false));
-      const float *data_nx = reinterpret_cast<const float*> (&(*normals)[0]);// NOLINT(readability-container-data-pointer)
-      integral_image_normal_x->setInput (data_nx, normals->width, normals->height, element_stride_normal, row_stride_normal);
+      const float *data = reinterpret_cast<const float*> (normals->data());
+      integral_image_normal_x->setInput (data + 0, normals->width, normals->height, element_stride_normal, row_stride_normal);
 
       integral_image_normal_y.reset (new pcl::IntegralImage2D<float, 1> (false));
-      const float *data_ny = reinterpret_cast<const float*> (&(*normals)[0]);// NOLINT(readability-container-data-pointer)
-      integral_image_normal_y->setInput (data_ny + 1, normals->width, normals->height, element_stride_normal, row_stride_normal);
+      integral_image_normal_y->setInput (data + 1, normals->width, normals->height, element_stride_normal, row_stride_normal);
 
       integral_image_normal_z.reset (new pcl::IntegralImage2D<float, 1> (false));
-      const float *data_nz = reinterpret_cast<const float*> (&(*normals)[0]);// NOLINT(readability-container-data-pointer)
-      integral_image_normal_z->setInput (data_nz + 2, normals->width, normals->height, element_stride_normal, row_stride_normal);
+      integral_image_normal_z->setInput (data + 2, normals->width, normals->height, element_stride_normal, row_stride_normal);
     }
 
     //Using cloud labels estimate a 2D window from where to extract positive samples

--- a/recognition/src/face_detection/rf_face_detector_trainer.cpp
+++ b/recognition/src/face_detection/rf_face_detector_trainer.cpp
@@ -276,7 +276,7 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
 
   int element_stride = sizeof(pcl::PointXYZ) / sizeof(float);
   int row_stride = element_stride * cloud->width;
-  const float *data = reinterpret_cast<const float*> (&(*cloud)[0]); // NOLINT(readability-container-data-pointer)
+  const float *data = reinterpret_cast<const float*> (cloud->data());
   integral_image_depth->setInput (data + 2, cloud->width, cloud->height, element_stride, row_stride);
 
   //Compute normals and normal integral images
@@ -302,16 +302,14 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
   if (use_normals_)
   {
     integral_image_normal_x.reset (new pcl::IntegralImage2D<float, 1> (false));
-    const float *data_nx = reinterpret_cast<const float*> (&(*normals)[0]);// NOLINT(readability-container-data-pointer)
-    integral_image_normal_x->setInput (data_nx, normals->width, normals->height, element_stride_normal, row_stride_normal);
+    const float *datum = reinterpret_cast<const float*> (normals->data());
+    integral_image_normal_x->setInput (datum + 0, normals->width, normals->height, element_stride_normal, row_stride_normal);
 
     integral_image_normal_y.reset (new pcl::IntegralImage2D<float, 1> (false));
-    const float *data_ny = reinterpret_cast<const float*> (&(*normals)[0]);// NOLINT(readability-container-data-pointer)
-    integral_image_normal_y->setInput (data_ny + 1, normals->width, normals->height, element_stride_normal, row_stride_normal);
+    integral_image_normal_y->setInput (datum + 1, normals->width, normals->height, element_stride_normal, row_stride_normal);
 
     integral_image_normal_z.reset (new pcl::IntegralImage2D<float, 1> (false));
-    const float *data_nz = reinterpret_cast<const float*> (&(*normals)[0]);// NOLINT(readability-container-data-pointer)
-    integral_image_normal_z->setInput (data_nz + 2, normals->width, normals->height, element_stride_normal, row_stride_normal);
+    integral_image_normal_z->setInput (datum + 2, normals->width, normals->height, element_stride_normal, row_stride_normal);
   }
 
   {

--- a/recognition/src/face_detection/rf_face_detector_trainer.cpp
+++ b/recognition/src/face_detection/rf_face_detector_trainer.cpp
@@ -276,7 +276,7 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
 
   int element_stride = sizeof(pcl::PointXYZ) / sizeof(float);
   int row_stride = element_stride * cloud->width;
-  const float *data = reinterpret_cast<const float*> (&(*cloud)[0]);
+  const float *data = reinterpret_cast<const float*> (&(*cloud)[0]); // NOLINT(readability-container-data-pointer)
   integral_image_depth->setInput (data + 2, cloud->width, cloud->height, element_stride, row_stride);
 
   //Compute normals and normal integral images
@@ -302,15 +302,15 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
   if (use_normals_)
   {
     integral_image_normal_x.reset (new pcl::IntegralImage2D<float, 1> (false));
-    const float *data_nx = reinterpret_cast<const float*> (&(*normals)[0]);
+    const float *data_nx = reinterpret_cast<const float*> (&(*normals)[0]);// NOLINT(readability-container-data-pointer)
     integral_image_normal_x->setInput (data_nx, normals->width, normals->height, element_stride_normal, row_stride_normal);
 
     integral_image_normal_y.reset (new pcl::IntegralImage2D<float, 1> (false));
-    const float *data_ny = reinterpret_cast<const float*> (&(*normals)[0]);
+    const float *data_ny = reinterpret_cast<const float*> (&(*normals)[0]);// NOLINT(readability-container-data-pointer)
     integral_image_normal_y->setInput (data_ny + 1, normals->width, normals->height, element_stride_normal, row_stride_normal);
 
     integral_image_normal_z.reset (new pcl::IntegralImage2D<float, 1> (false));
-    const float *data_nz = reinterpret_cast<const float*> (&(*normals)[0]);
+    const float *data_nz = reinterpret_cast<const float*> (&(*normals)[0]);// NOLINT(readability-container-data-pointer)
     integral_image_normal_z->setInput (data_nz + 2, normals->width, normals->height, element_stride_normal, row_stride_normal);
   }
 

--- a/registration/include/pcl/registration/impl/ia_fpcs.hpp
+++ b/registration/include/pcl/registration/impl/ia_fpcs.hpp
@@ -419,7 +419,7 @@ pcl::registration::FPCSInitialAlignment<PointSource, PointTarget, NormalT, Scala
 
   // choose random first point
   base_indices[0] = (*target_indices_)[rand() % nr_points];
-  auto* index1 = &base_indices[0];
+  auto* index1 = base_indices.data();
 
   // random search for 2 other points (as far away as overlap allows)
   for (int i = 0; i < ransac_iterations_; i++) {

--- a/registration/include/pcl/registration/impl/icp.hpp
+++ b/registration/include/pcl/registration/impl/icp.hpp
@@ -44,6 +44,7 @@
 #include <pcl/correspondence.h>
 
 namespace pcl {
+// NOLINTBEGIN(readability-container-data-pointer)
 
 template <typename PointSource, typename PointTarget, typename Scalar>
 void
@@ -317,6 +318,7 @@ IterativeClosestPointWithNormals<PointSource, PointTarget, Scalar>::transformClo
 {
   pcl::transformPointCloudWithNormals(input, output, transform);
 }
+// NOLINTEND(readability-container-data-pointer)
 
 } // namespace pcl
 

--- a/registration/include/pcl/registration/impl/registration.hpp
+++ b/registration/include/pcl/registration/impl/registration.hpp
@@ -124,8 +124,8 @@ Registration<PointSource, PointTarget, Scalar>::getFitnessScore(
 {
   unsigned int nr_elem =
       static_cast<unsigned int>(std::min(distances_a.size(), distances_b.size()));
-  Eigen::VectorXf map_a = Eigen::VectorXf::Map(&distances_a[0], nr_elem);
-  Eigen::VectorXf map_b = Eigen::VectorXf::Map(&distances_b[0], nr_elem);
+  Eigen::VectorXf map_a = Eigen::VectorXf::Map(distances_a.data(), nr_elem);
+  Eigen::VectorXf map_b = Eigen::VectorXf::Map(distances_b.data(), nr_elem);
   return (static_cast<double>((map_a - map_b).sum()) / static_cast<double>(nr_elem));
 }
 

--- a/registration/src/correspondence_rejection_var_trimmed.cpp
+++ b/registration/src/correspondence_rejection_var_trimmed.cpp
@@ -89,7 +89,7 @@ pcl::registration::CorrespondenceRejectorVarTrimmed::optimizeInlierRatio(
   const int max_el = static_cast<int>(std::floor(max_ratio_ * points_nbr));
 
   using LineArray = Eigen::Array<double, Eigen::Dynamic, 1>;
-  Eigen::Map<LineArray> sorted_dist(&dists[0], points_nbr);
+  Eigen::Map<LineArray> sorted_dist(dists.data(), points_nbr);
 
   const LineArray trunk_sorted_dist = sorted_dist.segment(min_el, max_el - min_el);
   const double lower_sum = sorted_dist.head(min_el).sum();

--- a/search/include/pcl/search/impl/flann_search.hpp
+++ b/search/include/pcl/search/impl/flann_search.hpp
@@ -126,7 +126,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::nearestKSearch (const PointT &p
     indices.resize (k,-1);
   if (dists.size() != static_cast<unsigned int> (k))
     dists.resize (k);
-  flann::Matrix<float> d (&dists[0],1,k);
+  flann::Matrix<float> d (dists.data(),1,k);
   int result = knn_search(*index_, m, indices, d, k, p);
 
   delete [] data;

--- a/segmentation/include/pcl/segmentation/impl/sac_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/sac_segmentation.hpp
@@ -118,14 +118,14 @@ pcl::SACSegmentation<PointT>::segment (PointIndices &inliers, ModelCoefficients 
     Eigen::VectorXf coeff_refined (model_->getModelSize ());
     model_->optimizeModelCoefficients (inliers.indices, coeff, coeff_refined);
     model_coefficients.values.resize (coeff_refined.size ());
-    memcpy (&model_coefficients.values[0], &coeff_refined[0], coeff_refined.size () * sizeof (float));
+    memcpy (model_coefficients.values.data(), coeff_refined.data(), coeff_refined.size () * sizeof (float));
     // Refine inliers
     model_->selectWithinDistance (coeff_refined, threshold_, inliers.indices);
   }
   else
   {
     model_coefficients.values.resize (coeff.size ());
-    memcpy (&model_coefficients.values[0], &coeff[0], coeff.size () * sizeof (float));
+    memcpy (model_coefficients.values.data(), coeff.data(), coeff.size () * sizeof (float));
   }
 
   deinitCompute ();

--- a/simulation/src/model.cpp
+++ b/simulation/src/model.cpp
@@ -53,7 +53,7 @@ pcl::simulation::TriangleMeshModel::TriangleMeshModel(pcl::PolygonMesh::Ptr plg)
   glBindBuffer(GL_ARRAY_BUFFER, vbo_);
   glBufferData(GL_ARRAY_BUFFER,
                vertices.size() * sizeof(vertices[0]),
-               &(vertices[0]),
+               vertices.data(),
                GL_STATIC_DRAW);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
 
@@ -61,7 +61,7 @@ pcl::simulation::TriangleMeshModel::TriangleMeshModel(pcl::PolygonMesh::Ptr plg)
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, ibo_);
   glBufferData(GL_ELEMENT_ARRAY_BUFFER,
                indices.size() * sizeof(indices[0]),
-               &(indices[0]),
+               indices.data(),
                GL_STATIC_DRAW);
   glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
 

--- a/simulation/src/range_likelihood.cpp
+++ b/simulation/src/range_likelihood.cpp
@@ -470,7 +470,7 @@ pcl::simulation::RangeLikelihood::RangeLikelihood(
   glBindBuffer(GL_ARRAY_BUFFER, quad_vbo_);
   glBufferData(GL_ARRAY_BUFFER,
                sizeof(Eigen::Vector3f) * vertices_.size(),
-               &(vertices_[0]),
+               vertices_.data(),
                GL_STATIC_DRAW);
   glBindBuffer(GL_ARRAY_BUFFER, 0);
 

--- a/surface/src/vtk_smoothing/vtk_utils.cpp
+++ b/surface/src/vtk_smoothing/vtk_utils.cpp
@@ -212,7 +212,7 @@ pcl::VTKUtils::mesh2vtk (const pcl::PolygonMesh& mesh, vtkSmartPointer<vtkPolyDa
     Eigen::Array4i xyz_offset (mesh.cloud.fields[idx_x].offset, mesh.cloud.fields[idx_y].offset, mesh.cloud.fields[idx_z].offset, 0);
     for (vtkIdType cp = 0; cp < nr_points; ++cp, xyz_offset += mesh.cloud.point_step)
     {
-      memcpy(&pt[0], &mesh.cloud.data[xyz_offset[0]], sizeof(float));
+      memcpy(&pt[0], &mesh.cloud.data[xyz_offset[0]], sizeof(float)); // NOLINT(readability-container-data-pointer)
       memcpy(&pt[1], &mesh.cloud.data[xyz_offset[1]], sizeof(float));
       memcpy(&pt[2], &mesh.cloud.data[xyz_offset[2]], sizeof(float));
       vtk_mesh_points->InsertPoint(cp, pt[0], pt[1], pt[2]);

--- a/test/common/test_plane_intersection.cpp
+++ b/test/common/test_plane_intersection.cpp
@@ -169,8 +169,8 @@ TEST (PCL, lineWithLineIntersection)
   Eigen::Vector4f point_mod_case_2;
   double sqr_mod_case_2 = 1e-1;
 
-  Eigen::VectorXf coeff1 = Eigen::VectorXf::Map (&line_a_mod_2.values[0], line_a_mod_2.values.size ());
-  Eigen::VectorXf coeff2 = Eigen::VectorXf::Map (&line_b_mod_2.values[0], line_b_mod_2.values.size ());
+  Eigen::VectorXf coeff1 = Eigen::VectorXf::Map (line_a_mod_2.values.data(), line_a_mod_2.values.size ());
+  Eigen::VectorXf coeff2 = Eigen::VectorXf::Map (line_b_mod_2.values.data(), line_b_mod_2.values.size ());
 
   Eigen::Vector4f p1_mod, p2_mod;
   lineToLineSegment (coeff1, coeff2, p1_mod, p2_mod);

--- a/test/io/test_ply_io.cpp
+++ b/test/io/test_ply_io.cpp
@@ -590,7 +590,7 @@ TEST_F (PLYTest, Float64Cloud)
   }
   for (size_t pointIdx = 0; pointIdx < cloud.size(); ++pointIdx)
   {
-    unsigned char const * ptr = &cloud2.data[0] + pointIdx*cloud2.point_step;
+    unsigned char const * ptr = cloud2.data.data() + pointIdx*cloud2.point_step;
     double xValue, yValue, zValue;
     memcpy(
         reinterpret_cast<char*>(&xValue),

--- a/test/io/test_ply_mesh_io.cpp
+++ b/test/io/test_ply_mesh_io.cpp
@@ -295,7 +295,7 @@ TEST (PCL, PLYPolygonMeshSpecificFieldOrder)
   mesh.cloud.data.resize(28);
   constexpr float x = 0.0, y = 1.0, z = 2.0, normal_x = 1.0, normal_y = 0.0, normal_z = 0.0;
   constexpr std::uint32_t rgba = 0x326496;
-  memcpy(&mesh.cloud.data[0], &x, sizeof(float));
+  memcpy(&mesh.cloud.data[0], &x, sizeof(float)); // NOLINT(readability-container-data-pointer)
   memcpy(&mesh.cloud.data[4], &y, sizeof(float));
   memcpy(&mesh.cloud.data[8], &z, sizeof(float));
   memcpy(&mesh.cloud.data[12], &normal_x, sizeof(float));

--- a/test/io/test_point_cloud_image_extractors.cpp
+++ b/test/io/test_point_cloud_image_extractors.cpp
@@ -178,7 +178,7 @@ TEST (PCL, PointCloudImageExtractorFromLabelFieldMono)
   pcie.setColorMode (pcie.COLORS_MONO);
 
   ASSERT_TRUE (pcie.extract (cloud, image));
-  auto* data = reinterpret_cast<unsigned short*> (&image.data[0]);
+  auto* data = reinterpret_cast<unsigned short*> (image.data.data());
 
   EXPECT_EQ ("mono16", image.encoding);
   EXPECT_EQ (cloud.width, image.width);
@@ -279,7 +279,7 @@ TEST (PCL, PointCloudImageExtractorFromZField)
   PointCloudImageExtractorFromZField<PointT> pcie;
 
   ASSERT_TRUE (pcie.extract (cloud, image));
-  auto* data = reinterpret_cast<unsigned short*> (&image.data[0]);
+  auto* data = reinterpret_cast<unsigned short*> (image.data.data());
 
   EXPECT_EQ ("mono16", image.encoding);
   EXPECT_EQ (cloud.width, image.width);
@@ -309,7 +309,7 @@ TEST (PCL, PointCloudImageExtractorFromCurvatureField)
   PointCloudImageExtractorFromCurvatureField<PointT> pcie;
 
   ASSERT_TRUE (pcie.extract (cloud, image));
-  auto* data = reinterpret_cast<unsigned short*> (&image.data[0]);
+  auto* data = reinterpret_cast<unsigned short*> (image.data.data());
 
   EXPECT_EQ ("mono16", image.encoding);
   EXPECT_EQ (cloud.width, image.width);
@@ -341,7 +341,7 @@ TEST (PCL, PointCloudImageExtractorFromIntensityField)
   PointCloudImageExtractorFromIntensityField<PointT> pcie;
 
   ASSERT_TRUE (pcie.extract (cloud, image));
-  auto* data = reinterpret_cast<unsigned short*> (&image.data[0]);
+  auto* data = reinterpret_cast<unsigned short*> (image.data.data());
 
   EXPECT_EQ ("mono16", image.encoding);
   EXPECT_EQ (cloud.width, image.width);
@@ -412,7 +412,7 @@ TEST (PCL, PointCloudImageExtractorBlackNaNs)
   ASSERT_TRUE (pcie.extract (cloud, image));
 
   {
-    auto* data = reinterpret_cast<unsigned short*> (&image.data[0]);
+    auto* data = reinterpret_cast<unsigned short*> (image.data.data());
     EXPECT_EQ (std::numeric_limits<unsigned short>::max (), data[3]);
   }
 
@@ -421,7 +421,7 @@ TEST (PCL, PointCloudImageExtractorBlackNaNs)
   ASSERT_TRUE (pcie.extract (cloud, image));
 
   {
-    auto* data = reinterpret_cast<unsigned short*> (&image.data[0]);
+    auto* data = reinterpret_cast<unsigned short*> (image.data.data());
     EXPECT_EQ (0, data[3]);
   }
 }

--- a/tools/openni_image.cpp
+++ b/tools/openni_image.cpp
@@ -501,14 +501,14 @@ class Viewer
             {
               frame->image->fillRGB (frame->image->getWidth (), 
                                      frame->image->getHeight (), 
-                                     &rgb_data[0]);
+                                     rgb_data.data());
             }
             else
-              memcpy (&rgb_data[0],
+              memcpy (rgb_data.data(),
                       frame->image->getMetaData ().Data (),
                       rgb_data.size ());
 
-            image_viewer_->addRGBImage (reinterpret_cast<unsigned char*> (&rgb_data[0]), 
+            image_viewer_->addRGBImage (reinterpret_cast<unsigned char*> (rgb_data.data()), 
                                         frame->image->getWidth (),
                                         frame->image->getHeight (),
                                         "rgb_image");

--- a/visualization/include/pcl/visualization/pcl_painter2D.h
+++ b/visualization/include/pcl/visualization/pcl_painter2D.h
@@ -123,7 +123,7 @@ namespace pcl
       void draw (vtkContext2D * painter) override
       {
         applyInternals(painter);  
-        painter->DrawPoly (&info_[0], static_cast<unsigned int> (info_.size ()) / 2);
+        painter->DrawPoly (info_.data(), static_cast<unsigned int> (info_.size ()) / 2);
       }
     };
 
@@ -137,7 +137,7 @@ namespace pcl
       void draw (vtkContext2D * painter) override
       {
         applyInternals(painter);  
-        painter->DrawPoints (&info_[0], static_cast<unsigned int> (info_.size ()) / 2);
+        painter->DrawPoints (info_.data(), static_cast<unsigned int> (info_.size ()) / 2);
       }
     };
 
@@ -151,7 +151,7 @@ namespace pcl
       void draw (vtkContext2D * painter) override
       {
         applyInternals(painter);  
-        painter->DrawQuad (&info_[0]);
+        painter->DrawQuad (info_.data());
       }
     };
     
@@ -165,7 +165,7 @@ namespace pcl
       void draw (vtkContext2D * painter) override
       {
         applyInternals(painter);  
-        painter->DrawPolygon (&info_[0], static_cast<unsigned int> (info_.size ()) / 2);
+        painter->DrawPolygon (info_.data(), static_cast<unsigned int> (info_.size ()) / 2);
       }
     };
     

--- a/visualization/src/pcl_plotter.cpp
+++ b/visualization/src/pcl_plotter.cpp
@@ -145,7 +145,7 @@ pcl::visualization::PCLPlotter::addPlotData (
     int type /* = vtkChart::LINE */, 
     std::vector<char> const &color)
 {
-  this->addPlotData (&array_X[0], &array_Y[0], static_cast<unsigned long> (array_X.size ()), name, type, (color.empty ()) ? nullptr : &color[0]);
+  this->addPlotData (array_X.data(), array_Y.data(), static_cast<unsigned long> (array_X.size ()), name, type, (color.empty ()) ? nullptr : color.data());
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -164,7 +164,7 @@ pcl::visualization::PCLPlotter::addPlotData (
     array_x[i] = plot_data[i].first;
     array_y[i] = plot_data[i].second;
   }
-  this->addPlotData (array_x, array_y, static_cast<unsigned long> (plot_data.size ()), name, type, (color.empty ()) ? nullptr : &color[0]);
+  this->addPlotData (array_x, array_y, static_cast<unsigned long> (plot_data.size ()), name, type, (color.empty ()) ? nullptr : color.data());
   delete[] array_x;
   delete[] array_y;
 }

--- a/visualization/src/vtk/pcl_context_item.cpp
+++ b/visualization/src/vtk/pcl_context_item.cpp
@@ -197,7 +197,7 @@ pcl::visualization::context_items::Polygon::Paint (vtkContext2D *painter)
 {
   painter->GetBrush ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
   painter->GetPen ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
-  painter->DrawPolygon (&params[0], static_cast<int> (params.size () / 2));
+  painter->DrawPolygon (params.data(), static_cast<int> (params.size () / 2));
   return (true);
 }
 
@@ -215,7 +215,7 @@ bool
 pcl::visualization::context_items::Points::Paint (vtkContext2D *painter)
 {
   painter->GetPen ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
-  painter->DrawPoints (&params[0], static_cast<int> (params.size () / 2));
+  painter->DrawPoints (params.data(), static_cast<int> (params.size () / 2));
   return (true);
 }
 
@@ -259,10 +259,10 @@ pcl::visualization::context_items::Markers::Paint (vtkContext2D *painter)
 
   painter->GetPen ()->SetWidth (size);
   painter->GetPen ()->SetColor (colors[0], colors[1], colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
-  painter->DrawPointSprites (nullptr, &params[0], nb_points);
+  painter->DrawPointSprites (nullptr, params.data(), nb_points);
   painter->GetPen ()->SetWidth (1);
   painter->GetPen ()->SetColor (point_colors[0], point_colors[1], point_colors[2], static_cast<unsigned char> ((255.0 * GetOpacity ())));
-  painter->DrawPointSprites (nullptr, &params[0], nb_points);
+  painter->DrawPointSprites (nullptr, params.data(), nb_points);
   return (true);
 }
 


### PR DESCRIPTION
Added the [readability-container-data-pointer](https://clang.llvm.org/extra/clang-tidy/checks/readability/container-data-pointer.html) check to `clang-tidy` to change instances where the code could use `data()` rather than the address of the element at index 0 in a container.