### PR TITLE
Octree: grow in positive direction instead of negative

### DIFF
--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -523,9 +523,9 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
 
         // octree not empty - we add another tree level and thus increase its size by a
         // factor of 2*2*2
-        child_idx = static_cast<unsigned char>(((!bUpperBoundViolationX) << 2) |
-                                               ((!bUpperBoundViolationY) << 1) |
-                                               ((!bUpperBoundViolationZ)));
+        child_idx = static_cast<unsigned char>(((bLowerBoundViolationX) << 2) |
+                                               ((bLowerBoundViolationY) << 1) |
+                                               ((bLowerBoundViolationZ)));
 
         BranchNode* newRootBranch;
 
@@ -538,13 +538,13 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
 
         octreeSideLen = static_cast<double>(1 << this->octree_depth_) * resolution_;
 
-        if (!bUpperBoundViolationX)
+        if (bLowerBoundViolationX)
           min_x_ -= octreeSideLen;
 
-        if (!bUpperBoundViolationY)
+        if (bLowerBoundViolationY)
           min_y_ -= octreeSideLen;
 
-        if (!bUpperBoundViolationZ)
+        if (bLowerBoundViolationZ)
           min_z_ -= octreeSideLen;
 
         // configure tree depth of octree

--- a/test/features/test_pfh_estimation.cpp
+++ b/test/features/test_pfh_estimation.cpp
@@ -504,7 +504,7 @@ TEST (PCL, GFPFH)
   PointCloud<GFPFHSignature16> descriptor;
   gfpfh.compute (descriptor);
 
-  const float ref_values[] = { 1877, 6375, 5361, 14393, 6674, 2471, 2248, 2753, 3117, 4585, 14388, 32407, 15122, 3061, 3202, 794 };
+  const float ref_values[] = { 1881, 6378, 5343, 14406, 6726, 2379, 2295, 2724, 3177, 4518, 14283, 32341, 15131, 3195, 3238, 813 };
 
   EXPECT_EQ (descriptor.size (), 1);
   for (std::size_t i = 0; i < static_cast<std::size_t>(descriptor[0].descriptorSize ()); ++i)


### PR DESCRIPTION
Fixes https://github.com/PointCloudLibrary/pcl/issues/5637
The octree must grow if a point lies outside in (at least) one axis. For each axis, the bounding box may be violated in the lower bound, or upper bound, or neither. Currently, in the last case, the tree will grow in the negative direction. With these changes it will instead grow in the positive direction. This is better because the points will be closer to min_*_, which will lead to smaller errors when computing the key.

It is necessary to adapt the GFPFH test because GFPFH uses an octree and the feature is influenced by which octree leafs are occupied exactly.
Previously, the test cloud resulted in an octree with bounding box (-108;20)(-104;24)(-72;56), with these changes the bounding box is (-12;20)(-12;20)(-12;20), which makes more sense.
As a side note, I am also not sure how much sense this test makes because the test assigns the class labels more or less randomly, while the paper says they should represent a "geometric primitive" (plane, sphere, ...).