### PR TITLE
Added modernize-use-bool-literals, modernize-use-default-member-init clang-tidy checks

### DIFF
--- a/2d/include/pcl/2d/edge.h
+++ b/2d/include/pcl/2d/edge.h
@@ -116,25 +116,16 @@ public:
 private:
   OUTPUT_TYPE output_type_;
   DETECTOR_KERNEL_TYPE detector_kernel_type_;
-  bool non_maximal_suppression_;
-  bool hysteresis_thresholding_;
+  bool non_maximal_suppression_{false};
+  bool hysteresis_thresholding_{false};
 
-  float hysteresis_threshold_low_;
-  float hysteresis_threshold_high_;
-  float non_max_suppression_radius_x_;
-  float non_max_suppression_radius_y_;
+  float hysteresis_threshold_low_{20};
+  float hysteresis_threshold_high_{80};
+  float non_max_suppression_radius_x_{3};
+  float non_max_suppression_radius_y_{3};
 
 public:
-  Edge()
-  : output_type_(OUTPUT_X)
-  , detector_kernel_type_(SOBEL)
-  , non_maximal_suppression_(false)
-  , hysteresis_thresholding_(false)
-  , hysteresis_threshold_low_(20)
-  , hysteresis_threshold_high_(80)
-  , non_max_suppression_radius_x_(3)
-  , non_max_suppression_radius_y_(3)
-  {}
+  Edge() : output_type_(OUTPUT_X), detector_kernel_type_(SOBEL) {}
 
   /** \brief Set the output type.
    * \param[in] output_type the output type

--- a/2d/include/pcl/2d/kernel.h
+++ b/2d/include/pcl/2d/kernel.h
@@ -63,11 +63,11 @@ public:
     GAUSSIAN               //!< GAUSSIAN
   };
 
-  int kernel_size_;
-  float sigma_;
+  int kernel_size_{3};
+  float sigma_{1.0};
   KERNEL_ENUM kernel_type_;
 
-  kernel() : kernel_size_(3), sigma_(1.0), kernel_type_(GAUSSIAN) {}
+  kernel() : kernel_type_(GAUSSIAN) {}
 
   /**
    *

--- a/common/include/pcl/common/bivariate_polynomial.h
+++ b/common/include/pcl/common/bivariate_polynomial.h
@@ -115,8 +115,9 @@ namespace pcl
 
       //-----VARIABLES-----
       int degree{0};
-      real* parameters;
-      BivariatePolynomialT<real>* gradient_x, * gradient_y;
+      real* parameters{nullptr};
+      BivariatePolynomialT<real>* gradient_x{nullptr};
+      BivariatePolynomialT<real>* gradient_y{nullptr};
 
     protected:
       //-----METHODS-----

--- a/common/include/pcl/common/bivariate_polynomial.h
+++ b/common/include/pcl/common/bivariate_polynomial.h
@@ -114,7 +114,7 @@ namespace pcl
       getNoOfParametersFromDegree (int n) { return ((n+2)* (n+1))/2;}
 
       //-----VARIABLES-----
-      int degree;
+      int degree{0};
       real* parameters;
       BivariatePolynomialT<real>* gradient_x, * gradient_y;
 

--- a/common/include/pcl/common/centroid.h
+++ b/common/include/pcl/common/centroid.h
@@ -38,1062 +38,1150 @@
 
 #pragma once
 
+#include <pcl/PointIndices.h>
+#include <pcl/cloud_iterator.h>
 #include <pcl/memory.h>
 #include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/type_traits.h>
-#include <pcl/PointIndices.h>
-#include <pcl/cloud_iterator.h>
 
 /**
-  * \file pcl/common/centroid.h
-  * Define methods for centroid estimation and covariance matrix calculus
-  * \ingroup common
-  */
+ * \file pcl/common/centroid.h
+ * Define methods for centroid estimation and covariance matrix calculus
+ * \ingroup common
+ */
 
 /*@{*/
-namespace pcl
+namespace pcl {
+/** \brief Compute the 3D (X-Y-Z) centroid of a set of points and return it as a 3D
+ * vector. \param[in] cloud_iterator an iterator over the input point cloud \param[out]
+ * centroid the output centroid \return number of valid points used to determine the
+ * centroid. In case of dense point clouds, this is the same as the size of input cloud.
+ * \note if return value is 0, the centroid is not changed, thus not valid.
+ * The last component of the vector is set to 1, this allows to transform the centroid
+ * vector with 4x4 matrices. \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+compute3DCentroid(ConstCloudIterator<PointT>& cloud_iterator,
+                  Eigen::Matrix<Scalar, 4, 1>& centroid);
+
+template <typename PointT>
+inline unsigned int
+compute3DCentroid(ConstCloudIterator<PointT>& cloud_iterator, Eigen::Vector4f& centroid)
 {
-  /** \brief Compute the 3D (X-Y-Z) centroid of a set of points and return it as a 3D vector.
-    * \param[in] cloud_iterator an iterator over the input point cloud
-    * \param[out] centroid the output centroid
-    * \return number of valid points used to determine the centroid. In case of dense point clouds, this is the same as the size of input cloud.
-    * \note if return value is 0, the centroid is not changed, thus not valid.
-    * The last component of the vector is set to 1, this allows to transform the centroid vector with 4x4 matrices.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  compute3DCentroid (ConstCloudIterator<PointT> &cloud_iterator,
-                     Eigen::Matrix<Scalar, 4, 1> &centroid);
+  return (compute3DCentroid<PointT, float>(cloud_iterator, centroid));
+}
 
-  template <typename PointT> inline unsigned int
-  compute3DCentroid (ConstCloudIterator<PointT> &cloud_iterator,
-                     Eigen::Vector4f &centroid)
+template <typename PointT>
+inline unsigned int
+compute3DCentroid(ConstCloudIterator<PointT>& cloud_iterator, Eigen::Vector4d& centroid)
+{
+  return (compute3DCentroid<PointT, double>(cloud_iterator, centroid));
+}
+
+/** \brief Compute the 3D (X-Y-Z) centroid of a set of points and return it as a 3D
+ * vector. \param[in] cloud the input point cloud \param[out] centroid the output
+ * centroid \return number of valid points used to determine the centroid. In case of
+ * dense point clouds, this is the same as the size of input cloud. \note if return
+ * value is 0, the centroid is not changed, thus not valid. The last component of the
+ * vector is set to 1, this allows to transform the centroid vector with 4x4 matrices.
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+compute3DCentroid(const pcl::PointCloud<PointT>& cloud,
+                  Eigen::Matrix<Scalar, 4, 1>& centroid);
+
+template <typename PointT>
+inline unsigned int
+compute3DCentroid(const pcl::PointCloud<PointT>& cloud, Eigen::Vector4f& centroid)
+{
+  return (compute3DCentroid<PointT, float>(cloud, centroid));
+}
+
+template <typename PointT>
+inline unsigned int
+compute3DCentroid(const pcl::PointCloud<PointT>& cloud, Eigen::Vector4d& centroid)
+{
+  return (compute3DCentroid<PointT, double>(cloud, centroid));
+}
+
+/** \brief Compute the 3D (X-Y-Z) centroid of a set of points using their indices and
+ * return it as a 3D vector.
+ * \param[in] cloud the input point cloud
+ * \param[in] indices the point cloud indices that need to be used
+ * \param[out] centroid the output centroid
+ * \return number of valid points used to determine the centroid. In case of dense point
+ * clouds, this is the same as the size of input indices. \note if return value is 0,
+ * the centroid is not changed, thus not valid. The last component of the vector is set
+ * to 1, this allows to transform the centroid vector with 4x4 matrices. \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+compute3DCentroid(const pcl::PointCloud<PointT>& cloud,
+                  const Indices& indices,
+                  Eigen::Matrix<Scalar, 4, 1>& centroid);
+
+template <typename PointT>
+inline unsigned int
+compute3DCentroid(const pcl::PointCloud<PointT>& cloud,
+                  const Indices& indices,
+                  Eigen::Vector4f& centroid)
+{
+  return (compute3DCentroid<PointT, float>(cloud, indices, centroid));
+}
+
+template <typename PointT>
+inline unsigned int
+compute3DCentroid(const pcl::PointCloud<PointT>& cloud,
+                  const Indices& indices,
+                  Eigen::Vector4d& centroid)
+{
+  return (compute3DCentroid<PointT, double>(cloud, indices, centroid));
+}
+
+/** \brief Compute the 3D (X-Y-Z) centroid of a set of points using their indices and
+ * return it as a 3D vector.
+ * \param[in] cloud the input point cloud
+ * \param[in] indices the point cloud indices that need to be used
+ * \param[out] centroid the output centroid
+ * \return number of valid points used to determine the centroid. In case of dense point
+ * clouds, this is the same as the size of input indices. \note if return value is 0,
+ * the centroid is not changed, thus not valid. The last component of the vector is set
+ * to 1, this allows to transform the centroid vector with 4x4 matrices. \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+compute3DCentroid(const pcl::PointCloud<PointT>& cloud,
+                  const pcl::PointIndices& indices,
+                  Eigen::Matrix<Scalar, 4, 1>& centroid);
+
+template <typename PointT>
+inline unsigned int
+compute3DCentroid(const pcl::PointCloud<PointT>& cloud,
+                  const pcl::PointIndices& indices,
+                  Eigen::Vector4f& centroid)
+{
+  return (compute3DCentroid<PointT, float>(cloud, indices, centroid));
+}
+
+template <typename PointT>
+inline unsigned int
+compute3DCentroid(const pcl::PointCloud<PointT>& cloud,
+                  const pcl::PointIndices& indices,
+                  Eigen::Vector4d& centroid)
+{
+  return (compute3DCentroid<PointT, double>(cloud, indices, centroid));
+}
+
+/** \brief Compute the 3x3 covariance matrix of a given set of points.
+ * The result is returned as a Eigen::Matrix3f.
+ * Note: the covariance matrix is not normalized with the number of
+ * points. For a normalized covariance, please use
+ * computeCovarianceMatrixNormalized.
+ * \param[in] cloud the input point cloud
+ * \param[in] centroid the centroid of the set of points in the cloud
+ * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+ * \return number of valid points used to determine the covariance matrix.
+ * In case of dense point clouds, this is the same as the size of input cloud.
+ * \note if return value is 0, the covariance matrix is not changed, thus not valid.
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        const Eigen::Matrix<Scalar, 4, 1>& centroid,
+                        Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        const Eigen::Vector4f& centroid,
+                        Eigen::Matrix3f& covariance_matrix)
+{
+  return (computeCovarianceMatrix<PointT, float>(cloud, centroid, covariance_matrix));
+}
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        const Eigen::Vector4d& centroid,
+                        Eigen::Matrix3d& covariance_matrix)
+{
+  return (computeCovarianceMatrix<PointT, double>(cloud, centroid, covariance_matrix));
+}
+
+/** \brief Compute normalized the 3x3 covariance matrix of a given set of points.
+ * The result is returned as a Eigen::Matrix3f.
+ * Normalized means that every entry has been divided by the number of points in the
+ * point cloud. For small number of points, or if you want explicitly the
+ * sample-variance, use computeCovarianceMatrix and scale the covariance matrix with 1 /
+ * (n-1), where n is the number of points used to calculate the covariance matrix and is
+ * returned by the computeCovarianceMatrix function. \param[in] cloud the input point
+ * cloud \param[in] centroid the centroid of the set of points in the cloud \param[out]
+ * covariance_matrix the resultant 3x3 covariance matrix \return number of valid points
+ * used to determine the covariance matrix. In case of dense point clouds, this is the
+ * same as the size of input cloud. \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
+                                  const Eigen::Matrix<Scalar, 4, 1>& centroid,
+                                  Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
+                                  const Eigen::Vector4f& centroid,
+                                  Eigen::Matrix3f& covariance_matrix)
+{
+  return (computeCovarianceMatrixNormalized<PointT, float>(
+      cloud, centroid, covariance_matrix));
+}
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
+                                  const Eigen::Vector4d& centroid,
+                                  Eigen::Matrix3d& covariance_matrix)
+{
+  return (computeCovarianceMatrixNormalized<PointT, double>(
+      cloud, centroid, covariance_matrix));
+}
+
+/** \brief Compute the 3x3 covariance matrix of a given set of points using their
+ * indices. The result is returned as a Eigen::Matrix3f. Note: the covariance matrix is
+ * not normalized with the number of points. For a normalized covariance, please use
+ * computeCovarianceMatrixNormalized.
+ * \param[in] cloud the input point cloud
+ * \param[in] indices the point cloud indices that need to be used
+ * \param[in] centroid the centroid of the set of points in the cloud
+ * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+ * \return number of valid points used to determine the covariance matrix.
+ * In case of dense point clouds, this is the same as the size of input indices.
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        const Indices& indices,
+                        const Eigen::Matrix<Scalar, 4, 1>& centroid,
+                        Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        const Indices& indices,
+                        const Eigen::Vector4f& centroid,
+                        Eigen::Matrix3f& covariance_matrix)
+{
+  return (computeCovarianceMatrix<PointT, float>(
+      cloud, indices, centroid, covariance_matrix));
+}
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        const Indices& indices,
+                        const Eigen::Vector4d& centroid,
+                        Eigen::Matrix3d& covariance_matrix)
+{
+  return (computeCovarianceMatrix<PointT, double>(
+      cloud, indices, centroid, covariance_matrix));
+}
+
+/** \brief Compute the 3x3 covariance matrix of a given set of points using their
+ * indices. The result is returned as a Eigen::Matrix3f. Note: the covariance matrix is
+ * not normalized with the number of points. For a normalized covariance, please use
+ * computeCovarianceMatrixNormalized.
+ * \param[in] cloud the input point cloud
+ * \param[in] indices the point cloud indices that need to be used
+ * \param[in] centroid the centroid of the set of points in the cloud
+ * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+ * \return number of valid points used to determine the covariance matrix.
+ * In case of dense point clouds, this is the same as the size of input indices.
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        const pcl::PointIndices& indices,
+                        const Eigen::Matrix<Scalar, 4, 1>& centroid,
+                        Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        const pcl::PointIndices& indices,
+                        const Eigen::Vector4f& centroid,
+                        Eigen::Matrix3f& covariance_matrix)
+{
+  return (computeCovarianceMatrix<PointT, float>(
+      cloud, indices, centroid, covariance_matrix));
+}
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        const pcl::PointIndices& indices,
+                        const Eigen::Vector4d& centroid,
+                        Eigen::Matrix3d& covariance_matrix)
+{
+  return (computeCovarianceMatrix<PointT, double>(
+      cloud, indices, centroid, covariance_matrix));
+}
+
+/** \brief Compute the normalized 3x3 covariance matrix of a given set of points using
+ * their indices.
+ * The result is returned as a Eigen::Matrix3f.
+ * Normalized means that every entry has been divided by the number of entries in
+ * indices. For small number of points, or if you want explicitly the sample-variance,
+ * use computeCovarianceMatrix and scale the covariance matrix with 1 / (n-1), where n
+ * is the number of points used to calculate the covariance matrix and is returned by
+ * the computeCovarianceMatrix function. \param[in] cloud the input point cloud
+ * \param[in] indices the point cloud indices that need to be used
+ * \param[in] centroid the centroid of the set of points in the cloud
+ * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+ * \return number of valid points used to determine the covariance matrix.
+ * In case of dense point clouds, this is the same as the size of input indices.
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
+                                  const Indices& indices,
+                                  const Eigen::Matrix<Scalar, 4, 1>& centroid,
+                                  Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
+                                  const Indices& indices,
+                                  const Eigen::Vector4f& centroid,
+                                  Eigen::Matrix3f& covariance_matrix)
+{
+  return (computeCovarianceMatrixNormalized<PointT, float>(
+      cloud, indices, centroid, covariance_matrix));
+}
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
+                                  const Indices& indices,
+                                  const Eigen::Vector4d& centroid,
+                                  Eigen::Matrix3d& covariance_matrix)
+{
+  return (computeCovarianceMatrixNormalized<PointT, double>(
+      cloud, indices, centroid, covariance_matrix));
+}
+
+/** \brief Compute the normalized 3x3 covariance matrix of a given set of points using
+ * their indices. The result is returned as a Eigen::Matrix3f.
+ * Normalized means that every entry has been divided by the number of entries in
+ * indices. For small number of points, or if you want explicitly the sample-variance,
+ * use computeCovarianceMatrix and scale the covariance matrix with 1 / (n-1), where n
+ * is the number of points used to calculate the covariance matrix and is returned by
+ * the computeCovarianceMatrix function. \param[in] cloud the input point cloud
+ * \param[in] indices the point cloud indices that need to be used
+ * \param[in] centroid the centroid of the set of points in the cloud
+ * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+ * \return number of valid points used to determine the covariance matrix.
+ * In case of dense point clouds, this is the same as the size of input indices.
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
+                                  const pcl::PointIndices& indices,
+                                  const Eigen::Matrix<Scalar, 4, 1>& centroid,
+                                  Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
+                                  const pcl::PointIndices& indices,
+                                  const Eigen::Vector4f& centroid,
+                                  Eigen::Matrix3f& covariance_matrix)
+{
+  return (computeCovarianceMatrixNormalized<PointT, float>(
+      cloud, indices, centroid, covariance_matrix));
+}
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
+                                  const pcl::PointIndices& indices,
+                                  const Eigen::Vector4d& centroid,
+                                  Eigen::Matrix3d& covariance_matrix)
+{
+  return (computeCovarianceMatrixNormalized<PointT, double>(
+      cloud, indices, centroid, covariance_matrix));
+}
+
+/** \brief Compute the normalized 3x3 covariance matrix and the centroid of a given set
+ * of points in a single loop. Normalized means that every entry has been divided by the
+ * number of valid entries in the point cloud. For small number of points, or if you
+ * want explicitly the sample-variance, scale the covariance matrix with n / (n-1),
+ * where n is the number of points used to calculate the covariance matrix and is
+ * returned by this function. \note This method is theoretically exact. However using
+ * float for internal calculations reduces the accuracy but increases the efficiency.
+ * \param[in] cloud the input point cloud
+ * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+ * \param[out] centroid the centroid of the set of points in the cloud
+ * \return number of valid points used to determine the covariance matrix.
+ * In case of dense point clouds, this is the same as the size of input cloud.
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                               Eigen::Matrix<Scalar, 3, 3>& covariance_matrix,
+                               Eigen::Matrix<Scalar, 4, 1>& centroid);
+
+template <typename PointT>
+inline unsigned int
+computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                               Eigen::Matrix3f& covariance_matrix,
+                               Eigen::Vector4f& centroid)
+{
+  return (computeMeanAndCovarianceMatrix<PointT, float>(
+      cloud, covariance_matrix, centroid));
+}
+
+template <typename PointT>
+inline unsigned int
+computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                               Eigen::Matrix3d& covariance_matrix,
+                               Eigen::Vector4d& centroid)
+{
+  return (computeMeanAndCovarianceMatrix<PointT, double>(
+      cloud, covariance_matrix, centroid));
+}
+
+/** \brief Compute the normalized 3x3 covariance matrix and the centroid of a given set
+ * of points in a single loop. Normalized means that every entry has been divided by the
+ * number of entries in indices. For small number of points, or if you want explicitly
+ * the sample-variance, scale the covariance matrix with n / (n-1), where n is the
+ * number of points used to calculate the covariance matrix and is returned by this
+ * function. \note This method is theoretically exact. However using float for internal
+ * calculations reduces the accuracy but increases the efficiency. \param[in] cloud the
+ * input point cloud \param[in] indices subset of points given by their indices
+ * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+ * \param[out] centroid the centroid of the set of points in the cloud
+ * \return number of valid points used to determine the covariance matrix.
+ * In case of dense point clouds, this is the same as the size of input indices.
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                               const Indices& indices,
+                               Eigen::Matrix<Scalar, 3, 3>& covariance_matrix,
+                               Eigen::Matrix<Scalar, 4, 1>& centroid);
+
+template <typename PointT>
+inline unsigned int
+computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                               const Indices& indices,
+                               Eigen::Matrix3f& covariance_matrix,
+                               Eigen::Vector4f& centroid)
+{
+  return (computeMeanAndCovarianceMatrix<PointT, float>(
+      cloud, indices, covariance_matrix, centroid));
+}
+
+template <typename PointT>
+inline unsigned int
+computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                               const Indices& indices,
+                               Eigen::Matrix3d& covariance_matrix,
+                               Eigen::Vector4d& centroid)
+{
+  return (computeMeanAndCovarianceMatrix<PointT, double>(
+      cloud, indices, covariance_matrix, centroid));
+}
+
+/** \brief Compute the normalized 3x3 covariance matrix and the centroid of a given set
+ * of points in a single loop. Normalized means that every entry has been divided by the
+ * number of entries in indices. For small number of points, or if you want explicitly
+ * the sample-variance, scale the covariance matrix with n / (n-1), where n is the
+ * number of points used to calculate the covariance matrix and is returned by this
+ * function. \note This method is theoretically exact. However using float for internal
+ * calculations reduces the accuracy but increases the efficiency. \param[in] cloud the
+ * input point cloud \param[in] indices subset of points given by their indices
+ * \param[out] centroid the centroid of the set of points in the cloud
+ * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+ * \return number of valid points used to determine the covariance matrix.
+ * In case of dense point clouds, this is the same as the size of input indices.
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                               const pcl::PointIndices& indices,
+                               Eigen::Matrix<Scalar, 3, 3>& covariance_matrix,
+                               Eigen::Matrix<Scalar, 4, 1>& centroid);
+
+template <typename PointT>
+inline unsigned int
+computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                               const pcl::PointIndices& indices,
+                               Eigen::Matrix3f& covariance_matrix,
+                               Eigen::Vector4f& centroid)
+{
+  return (computeMeanAndCovarianceMatrix<PointT, float>(
+      cloud, indices, covariance_matrix, centroid));
+}
+
+template <typename PointT>
+inline unsigned int
+computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                               const pcl::PointIndices& indices,
+                               Eigen::Matrix3d& covariance_matrix,
+                               Eigen::Vector4d& centroid)
+{
+  return (computeMeanAndCovarianceMatrix<PointT, double>(
+      cloud, indices, covariance_matrix, centroid));
+}
+
+/** \brief Compute the normalized 3x3 covariance matrix for a already demeaned point
+ * cloud. Normalized means that every entry has been divided by the number of entries in
+ * the input point cloud. For small number of points, or if you want explicitly the
+ * sample-variance, scale the covariance matrix with n / (n-1), where n is the number of
+ * points used to calculate the covariance matrix and is returned by this function.
+ * \note This method is theoretically exact. However using float for internal
+ * calculations reduces the accuracy but increases the efficiency. \param[in] cloud the
+ * input point cloud \param[out] covariance_matrix the resultant 3x3 covariance matrix
+ * \return number of valid points used to determine the covariance matrix.
+ * In case of dense point clouds, this is the same as the size of input cloud.
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        Eigen::Matrix3f& covariance_matrix)
+{
+  return (computeCovarianceMatrix<PointT, float>(cloud, covariance_matrix));
+}
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        Eigen::Matrix3d& covariance_matrix)
+{
+  return (computeCovarianceMatrix<PointT, double>(cloud, covariance_matrix));
+}
+
+/** \brief Compute the normalized 3x3 covariance matrix for a already demeaned point
+ * cloud. Normalized means that every entry has been divided by the number of entries in
+ * indices. For small number of points, or if you want explicitly the sample-variance,
+ * scale the covariance matrix with n / (n-1), where n is the number of points used to
+ * calculate the covariance matrix and is returned by this function. \note This method
+ * is theoretically exact. However using float for internal calculations reduces the
+ * accuracy but increases the efficiency. \param[in] cloud the input point cloud
+ * \param[in] indices subset of points given by their indices
+ * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+ * \return number of valid points used to determine the covariance matrix.
+ * In case of dense point clouds, this is the same as the size of input indices.
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        const Indices& indices,
+                        Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        const Indices& indices,
+                        Eigen::Matrix3f& covariance_matrix)
+{
+  return (computeCovarianceMatrix<PointT, float>(cloud, indices, covariance_matrix));
+}
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        const Indices& indices,
+                        Eigen::Matrix3d& covariance_matrix)
+{
+  return (computeCovarianceMatrix<PointT, double>(cloud, indices, covariance_matrix));
+}
+
+/** \brief Compute the normalized 3x3 covariance matrix for a already demeaned point
+ * cloud. Normalized means that every entry has been divided by the number of entries in
+ * indices. For small number of points, or if you want explicitly the sample-variance,
+ * scale the covariance matrix with n / (n-1), where n is the number of points used to
+ * calculate the covariance matrix and is returned by this function. \note This method
+ * is theoretically exact. However using float for internal calculations reduces the
+ * accuracy but increases the efficiency. \param[in] cloud the input point cloud
+ * \param[in] indices subset of points given by their indices
+ * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+ * \return number of valid points used to determine the covariance matrix.
+ * In case of dense point clouds, this is the same as the size of input indices.
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        const pcl::PointIndices& indices,
+                        Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        const pcl::PointIndices& indices,
+                        Eigen::Matrix3f& covariance_matrix)
+{
+  return (computeCovarianceMatrix<PointT, float>(cloud, indices, covariance_matrix));
+}
+
+template <typename PointT>
+inline unsigned int
+computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
+                        const pcl::PointIndices& indices,
+                        Eigen::Matrix3d& covariance_matrix)
+{
+  return (computeCovarianceMatrix<PointT, double>(cloud, indices, covariance_matrix));
+}
+
+/** \brief Subtract a centroid from a point cloud and return the de-meaned
+ * representation \param[in] cloud_iterator an iterator over the input point cloud
+ * \param[in] centroid the centroid of the point cloud
+ * \param[out] cloud_out the resultant output point cloud
+ * \param[in] npts the number of samples guaranteed to be left in the input cloud,
+ * accessible by the iterator. If not given, it will be calculated. \ingroup common
+ */
+template <typename PointT, typename Scalar>
+void
+demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
+                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
+                 pcl::PointCloud<PointT>& cloud_out,
+                 int npts = 0);
+
+template <typename PointT>
+void
+demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
+                 const Eigen::Vector4f& centroid,
+                 pcl::PointCloud<PointT>& cloud_out,
+                 int npts = 0)
+{
+  return (demeanPointCloud<PointT, float>(cloud_iterator, centroid, cloud_out, npts));
+}
+
+template <typename PointT>
+void
+demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
+                 const Eigen::Vector4d& centroid,
+                 pcl::PointCloud<PointT>& cloud_out,
+                 int npts = 0)
+{
+  return (demeanPointCloud<PointT, double>(cloud_iterator, centroid, cloud_out, npts));
+}
+
+/** \brief Subtract a centroid from a point cloud and return the de-meaned
+ * representation \param[in] cloud_in the input point cloud \param[in] centroid the
+ * centroid of the point cloud \param[out] cloud_out the resultant output point cloud
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
+                 pcl::PointCloud<PointT>& cloud_out);
+
+template <typename PointT>
+void
+demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
+                 const Eigen::Vector4f& centroid,
+                 pcl::PointCloud<PointT>& cloud_out)
+{
+  return (demeanPointCloud<PointT, float>(cloud_iterator, centroid, cloud_out));
+}
+
+template <typename PointT>
+void
+demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
+                 const Eigen::Vector4d& centroid,
+                 pcl::PointCloud<PointT>& cloud_out)
+{
+  return (demeanPointCloud<PointT, double>(cloud_iterator, centroid, cloud_out));
+}
+
+/** \brief Subtract a centroid from a point cloud and return the de-meaned
+ * representation \param[in] cloud_in the input point cloud \param[in] indices the set
+ * of point indices to use from the input point cloud \param[out] centroid the centroid
+ * of the point cloud \param cloud_out the resultant output point cloud \ingroup common
+ */
+template <typename PointT, typename Scalar>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const Indices& indices,
+                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
+                 pcl::PointCloud<PointT>& cloud_out);
+
+template <typename PointT>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const Indices& indices,
+                 const Eigen::Vector4f& centroid,
+                 pcl::PointCloud<PointT>& cloud_out)
+{
+  return (demeanPointCloud<PointT, float>(cloud_in, indices, centroid, cloud_out));
+}
+
+template <typename PointT>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const Indices& indices,
+                 const Eigen::Vector4d& centroid,
+                 pcl::PointCloud<PointT>& cloud_out)
+{
+  return (demeanPointCloud<PointT, double>(cloud_in, indices, centroid, cloud_out));
+}
+
+/** \brief Subtract a centroid from a point cloud and return the de-meaned
+ * representation \param[in] cloud_in the input point cloud \param[in] indices the set
+ * of point indices to use from the input point cloud \param[out] centroid the centroid
+ * of the point cloud \param cloud_out the resultant output point cloud \ingroup common
+ */
+template <typename PointT, typename Scalar>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const pcl::PointIndices& indices,
+                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
+                 pcl::PointCloud<PointT>& cloud_out);
+
+template <typename PointT>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const pcl::PointIndices& indices,
+                 const Eigen::Vector4f& centroid,
+                 pcl::PointCloud<PointT>& cloud_out)
+{
+  return (demeanPointCloud<PointT, float>(cloud_in, indices, centroid, cloud_out));
+}
+
+template <typename PointT>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const pcl::PointIndices& indices,
+                 const Eigen::Vector4d& centroid,
+                 pcl::PointCloud<PointT>& cloud_out)
+{
+  return (demeanPointCloud<PointT, double>(cloud_in, indices, centroid, cloud_out));
+}
+
+/** \brief Subtract a centroid from a point cloud and return the de-meaned
+ * representation as an Eigen matrix
+ * \param[in] cloud_iterator an iterator over the input point cloud
+ * \param[in] centroid the centroid of the point cloud
+ * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
+ * an Eigen matrix (4 rows, N pts columns)
+ * \param[in] npts the number of samples guaranteed to be left in the input cloud,
+ * accessible by the iterator. If not given, it will be calculated. \ingroup common
+ */
+template <typename PointT, typename Scalar>
+void
+demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
+                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
+                 Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>& cloud_out,
+                 int npts = 0);
+
+template <typename PointT>
+void
+demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
+                 const Eigen::Vector4f& centroid,
+                 Eigen::MatrixXf& cloud_out,
+                 int npts = 0)
+{
+  return (demeanPointCloud<PointT, float>(cloud_iterator, centroid, cloud_out, npts));
+}
+
+template <typename PointT>
+void
+demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
+                 const Eigen::Vector4d& centroid,
+                 Eigen::MatrixXd& cloud_out,
+                 int npts = 0)
+{
+  return (demeanPointCloud<PointT, double>(cloud_iterator, centroid, cloud_out, npts));
+}
+
+/** \brief Subtract a centroid from a point cloud and return the de-meaned
+ * representation as an Eigen matrix
+ * \param[in] cloud_in the input point cloud
+ * \param[in] centroid the centroid of the point cloud
+ * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
+ * an Eigen matrix (4 rows, N pts columns)
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
+                 Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>& cloud_out);
+
+template <typename PointT>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const Eigen::Vector4f& centroid,
+                 Eigen::MatrixXf& cloud_out)
+{
+  return (demeanPointCloud<PointT, float>(cloud_in, centroid, cloud_out));
+}
+
+template <typename PointT>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const Eigen::Vector4d& centroid,
+                 Eigen::MatrixXd& cloud_out)
+{
+  return (demeanPointCloud<PointT, double>(cloud_in, centroid, cloud_out));
+}
+
+/** \brief Subtract a centroid from a point cloud and return the de-meaned
+ * representation as an Eigen matrix
+ * \param[in] cloud_in the input point cloud
+ * \param[in] indices the set of point indices to use from the input point cloud
+ * \param[in] centroid the centroid of the point cloud
+ * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
+ * an Eigen matrix (4 rows, N pts columns)
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const Indices& indices,
+                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
+                 Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>& cloud_out);
+
+template <typename PointT>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const Indices& indices,
+                 const Eigen::Vector4f& centroid,
+                 Eigen::MatrixXf& cloud_out)
+{
+  return (demeanPointCloud<PointT, float>(cloud_in, indices, centroid, cloud_out));
+}
+
+template <typename PointT>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const Indices& indices,
+                 const Eigen::Vector4d& centroid,
+                 Eigen::MatrixXd& cloud_out)
+{
+  return (demeanPointCloud<PointT, double>(cloud_in, indices, centroid, cloud_out));
+}
+
+/** \brief Subtract a centroid from a point cloud and return the de-meaned
+ * representation as an Eigen matrix
+ * \param[in] cloud_in the input point cloud
+ * \param[in] indices the set of point indices to use from the input point cloud
+ * \param[in] centroid the centroid of the point cloud
+ * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
+ * an Eigen matrix (4 rows, N pts columns)
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const pcl::PointIndices& indices,
+                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
+                 Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>& cloud_out);
+
+template <typename PointT>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const pcl::PointIndices& indices,
+                 const Eigen::Vector4f& centroid,
+                 Eigen::MatrixXf& cloud_out)
+{
+  return (demeanPointCloud<PointT, float>(cloud_in, indices, centroid, cloud_out));
+}
+
+template <typename PointT>
+void
+demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
+                 const pcl::PointIndices& indices,
+                 const Eigen::Vector4d& centroid,
+                 Eigen::MatrixXd& cloud_out)
+{
+  return (demeanPointCloud<PointT, double>(cloud_in, indices, centroid, cloud_out));
+}
+
+/** \brief Helper functor structure for n-D centroid estimation. */
+template <typename PointT, typename Scalar>
+struct NdCentroidFunctor {
+  using Pod = typename traits::POD<PointT>::type;
+
+  NdCentroidFunctor(const PointT& p, Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& centroid)
+  : centroid_(centroid), p_(reinterpret_cast<const Pod&>(p))
+  {}
+
+  template <typename Key>
+  inline void
+  operator()()
   {
-    return (compute3DCentroid <PointT, float> (cloud_iterator, centroid));
-  }
-
-  template <typename PointT> inline unsigned int
-  compute3DCentroid (ConstCloudIterator<PointT> &cloud_iterator,
-                     Eigen::Vector4d &centroid)
-  {
-    return (compute3DCentroid <PointT, double> (cloud_iterator, centroid));
-  }
-
-  /** \brief Compute the 3D (X-Y-Z) centroid of a set of points and return it as a 3D vector.
-    * \param[in] cloud the input point cloud
-    * \param[out] centroid the output centroid
-    * \return number of valid points used to determine the centroid. In case of dense point clouds, this is the same as the size of input cloud.
-    * \note if return value is 0, the centroid is not changed, thus not valid.
-    * The last component of the vector is set to 1, this allows to transform the centroid vector with 4x4 matrices.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  compute3DCentroid (const pcl::PointCloud<PointT> &cloud, 
-                     Eigen::Matrix<Scalar, 4, 1> &centroid);
-
-  template <typename PointT> inline unsigned int
-  compute3DCentroid (const pcl::PointCloud<PointT> &cloud, 
-                     Eigen::Vector4f &centroid)
-  {
-    return (compute3DCentroid <PointT, float> (cloud, centroid));
-  }
-
-  template <typename PointT> inline unsigned int
-  compute3DCentroid (const pcl::PointCloud<PointT> &cloud, 
-                     Eigen::Vector4d &centroid)
-  {
-    return (compute3DCentroid <PointT, double> (cloud, centroid));
-  }
-
-  /** \brief Compute the 3D (X-Y-Z) centroid of a set of points using their indices and
-    * return it as a 3D vector.
-    * \param[in] cloud the input point cloud
-    * \param[in] indices the point cloud indices that need to be used
-    * \param[out] centroid the output centroid
-    * \return number of valid points used to determine the centroid. In case of dense point clouds, this is the same as the size of input indices.
-    * \note if return value is 0, the centroid is not changed, thus not valid.
-    * The last component of the vector is set to 1, this allows to transform the centroid vector with 4x4 matrices.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
-                     const Indices &indices,
-                     Eigen::Matrix<Scalar, 4, 1> &centroid);
-
-  template <typename PointT> inline unsigned int
-  compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
-                     const Indices &indices,
-                     Eigen::Vector4f &centroid)
-  {
-    return (compute3DCentroid <PointT, float> (cloud, indices, centroid));
-  }
-
-  template <typename PointT> inline unsigned int
-  compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
-                     const Indices &indices,
-                     Eigen::Vector4d &centroid)
-  {
-    return (compute3DCentroid <PointT, double> (cloud, indices, centroid));
-  }
-
-  /** \brief Compute the 3D (X-Y-Z) centroid of a set of points using their indices and
-    * return it as a 3D vector.
-    * \param[in] cloud the input point cloud
-    * \param[in] indices the point cloud indices that need to be used
-    * \param[out] centroid the output centroid
-    * \return number of valid points used to determine the centroid. In case of dense point clouds, this is the same as the size of input indices.
-    * \note if return value is 0, the centroid is not changed, thus not valid.
-    * The last component of the vector is set to 1, this allows to transform the centroid vector with 4x4 matrices.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
-                     const pcl::PointIndices &indices,
-                     Eigen::Matrix<Scalar, 4, 1> &centroid);
-
-  template <typename PointT> inline unsigned int
-  compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
-                     const pcl::PointIndices &indices,
-                     Eigen::Vector4f &centroid)
-  {
-    return (compute3DCentroid <PointT, float> (cloud, indices, centroid));
-  }
-
-  template <typename PointT> inline unsigned int
-  compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
-                     const pcl::PointIndices &indices,
-                     Eigen::Vector4d &centroid)
-  {
-    return (compute3DCentroid <PointT, double> (cloud, indices, centroid));
-  }
-
-  /** \brief Compute the 3x3 covariance matrix of a given set of points.
-    * The result is returned as a Eigen::Matrix3f.
-    * Note: the covariance matrix is not normalized with the number of
-    * points. For a normalized covariance, please use
-    * computeCovarianceMatrixNormalized.
-    * \param[in] cloud the input point cloud
-    * \param[in] centroid the centroid of the set of points in the cloud
-    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
-    * \return number of valid points used to determine the covariance matrix.
-    * In case of dense point clouds, this is the same as the size of input cloud.
-    * \note if return value is 0, the covariance matrix is not changed, thus not valid.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                           Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           const Eigen::Vector4f &centroid,
-                           Eigen::Matrix3f &covariance_matrix)
-  {
-    return (computeCovarianceMatrix<PointT, float> (cloud, centroid, covariance_matrix));
-  }
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           const Eigen::Vector4d &centroid,
-                           Eigen::Matrix3d &covariance_matrix)
-  {
-    return (computeCovarianceMatrix<PointT, double> (cloud, centroid, covariance_matrix));
-  }
-
-  /** \brief Compute normalized the 3x3 covariance matrix of a given set of points.
-    * The result is returned as a Eigen::Matrix3f.
-    * Normalized means that every entry has been divided by the number of points in the point cloud.
-    * For small number of points, or if you want explicitly the sample-variance, use computeCovarianceMatrix
-    * and scale the covariance matrix with 1 / (n-1), where n is the number of points used to calculate
-    * the covariance matrix and is returned by the computeCovarianceMatrix function.
-    * \param[in] cloud the input point cloud
-    * \param[in] centroid the centroid of the set of points in the cloud
-    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
-    * \return number of valid points used to determine the covariance matrix.
-    * In case of dense point clouds, this is the same as the size of input cloud.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
-                                     const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                                     Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
-                                     const Eigen::Vector4f &centroid,
-                                     Eigen::Matrix3f &covariance_matrix)
-  {
-    return (computeCovarianceMatrixNormalized<PointT, float> (cloud, centroid, covariance_matrix));
-  }
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
-                                     const Eigen::Vector4d &centroid,
-                                     Eigen::Matrix3d &covariance_matrix)
-  {
-    return (computeCovarianceMatrixNormalized<PointT, double> (cloud, centroid, covariance_matrix));
-  }
-
-  /** \brief Compute the 3x3 covariance matrix of a given set of points using their indices.
-    * The result is returned as a Eigen::Matrix3f.
-    * Note: the covariance matrix is not normalized with the number of
-    * points. For a normalized covariance, please use
-    * computeCovarianceMatrixNormalized.
-    * \param[in] cloud the input point cloud
-    * \param[in] indices the point cloud indices that need to be used
-    * \param[in] centroid the centroid of the set of points in the cloud
-    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
-    * \return number of valid points used to determine the covariance matrix.
-    * In case of dense point clouds, this is the same as the size of input indices.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           const Indices &indices,
-                           const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                           Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           const Indices &indices,
-                           const Eigen::Vector4f &centroid,
-                           Eigen::Matrix3f &covariance_matrix)
-  {
-    return (computeCovarianceMatrix<PointT, float> (cloud, indices, centroid, covariance_matrix));
-  }
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           const Indices &indices,
-                           const Eigen::Vector4d &centroid,
-                           Eigen::Matrix3d &covariance_matrix)
-  {
-    return (computeCovarianceMatrix<PointT, double> (cloud, indices, centroid, covariance_matrix));
-  }
-
-  /** \brief Compute the 3x3 covariance matrix of a given set of points using their indices.
-    * The result is returned as a Eigen::Matrix3f.
-    * Note: the covariance matrix is not normalized with the number of
-    * points. For a normalized covariance, please use
-    * computeCovarianceMatrixNormalized.
-    * \param[in] cloud the input point cloud
-    * \param[in] indices the point cloud indices that need to be used
-    * \param[in] centroid the centroid of the set of points in the cloud
-    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
-    * \return number of valid points used to determine the covariance matrix.
-    * In case of dense point clouds, this is the same as the size of input indices.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           const pcl::PointIndices &indices,
-                           const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                           Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           const pcl::PointIndices &indices,
-                           const Eigen::Vector4f &centroid,
-                           Eigen::Matrix3f &covariance_matrix)
-  {
-    return (computeCovarianceMatrix<PointT, float> (cloud, indices, centroid, covariance_matrix));
-  }
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           const pcl::PointIndices &indices,
-                           const Eigen::Vector4d &centroid,
-                           Eigen::Matrix3d &covariance_matrix)
-  {
-    return (computeCovarianceMatrix<PointT, double> (cloud, indices, centroid, covariance_matrix));
-  }
-
-  /** \brief Compute the normalized 3x3 covariance matrix of a given set of points using
-    * their indices.
-    * The result is returned as a Eigen::Matrix3f.
-    * Normalized means that every entry has been divided by the number of entries in indices.
-    * For small number of points, or if you want explicitly the sample-variance, use computeCovarianceMatrix
-    * and scale the covariance matrix with 1 / (n-1), where n is the number of points used to calculate
-    * the covariance matrix and is returned by the computeCovarianceMatrix function.
-    * \param[in] cloud the input point cloud
-    * \param[in] indices the point cloud indices that need to be used
-    * \param[in] centroid the centroid of the set of points in the cloud
-    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
-    * \return number of valid points used to determine the covariance matrix.
-    * In case of dense point clouds, this is the same as the size of input indices.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
-                                     const Indices &indices,
-                                     const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                                     Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
-                                     const Indices &indices,
-                                     const Eigen::Vector4f &centroid,
-                                     Eigen::Matrix3f &covariance_matrix)
-  {
-    return (computeCovarianceMatrixNormalized<PointT, float> (cloud, indices, centroid, covariance_matrix));
-  }
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
-                                     const Indices &indices,
-                                     const Eigen::Vector4d &centroid,
-                                     Eigen::Matrix3d &covariance_matrix)
-  {
-    return (computeCovarianceMatrixNormalized<PointT, double> (cloud, indices, centroid, covariance_matrix));
-  }
-
-  /** \brief Compute the normalized 3x3 covariance matrix of a given set of points using
-    * their indices. The result is returned as a Eigen::Matrix3f.
-    * Normalized means that every entry has been divided by the number of entries in indices.
-    * For small number of points, or if you want explicitly the sample-variance, use computeCovarianceMatrix
-    * and scale the covariance matrix with 1 / (n-1), where n is the number of points used to calculate
-    * the covariance matrix and is returned by the computeCovarianceMatrix function.
-    * \param[in] cloud the input point cloud
-    * \param[in] indices the point cloud indices that need to be used
-    * \param[in] centroid the centroid of the set of points in the cloud
-    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
-    * \return number of valid points used to determine the covariance matrix.
-    * In case of dense point clouds, this is the same as the size of input indices.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
-                                     const pcl::PointIndices &indices,
-                                     const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                                     Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
-                                     const pcl::PointIndices &indices,
-                                     const Eigen::Vector4f &centroid,
-                                     Eigen::Matrix3f &covariance_matrix)
-  {
-    return (computeCovarianceMatrixNormalized<PointT, float> (cloud, indices, centroid, covariance_matrix));
-  }
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
-                                     const pcl::PointIndices &indices,
-                                     const Eigen::Vector4d &centroid,
-                                     Eigen::Matrix3d &covariance_matrix)
-  {
-    return (computeCovarianceMatrixNormalized<PointT, double> (cloud, indices, centroid, covariance_matrix));
-  }
-
-  /** \brief Compute the normalized 3x3 covariance matrix and the centroid of a given set of points in a single loop.
-    * Normalized means that every entry has been divided by the number of valid entries in the point cloud.
-    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
-    * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
-    * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
-    * \param[in] cloud the input point cloud
-    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
-    * \param[out] centroid the centroid of the set of points in the cloud
-    * \return number of valid points used to determine the covariance matrix.
-    * In case of dense point clouds, this is the same as the size of input cloud.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                                  Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
-                                  Eigen::Matrix<Scalar, 4, 1> &centroid);
-
-  template <typename PointT> inline unsigned int
-  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                                  Eigen::Matrix3f &covariance_matrix,
-                                  Eigen::Vector4f &centroid)
-  {
-    return (computeMeanAndCovarianceMatrix<PointT, float> (cloud, covariance_matrix, centroid));
-  }
-
-  template <typename PointT> inline unsigned int
-  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                                  Eigen::Matrix3d &covariance_matrix,
-                                  Eigen::Vector4d &centroid)
-  {
-    return (computeMeanAndCovarianceMatrix<PointT, double> (cloud, covariance_matrix, centroid));
-  }
-
-  /** \brief Compute the normalized 3x3 covariance matrix and the centroid of a given set of points in a single loop.
-    * Normalized means that every entry has been divided by the number of entries in indices.
-    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
-    * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
-    * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
-    * \param[in] cloud the input point cloud
-    * \param[in] indices subset of points given by their indices
-    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
-    * \param[out] centroid the centroid of the set of points in the cloud
-    * \return number of valid points used to determine the covariance matrix.
-    * In case of dense point clouds, this is the same as the size of input indices.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                                  const Indices &indices,
-                                  Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
-                                  Eigen::Matrix<Scalar, 4, 1> &centroid);
-
-  template <typename PointT> inline unsigned int
-  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                                  const Indices &indices,
-                                  Eigen::Matrix3f &covariance_matrix,
-                                  Eigen::Vector4f &centroid)
-  {
-    return (computeMeanAndCovarianceMatrix<PointT, float> (cloud, indices, covariance_matrix, centroid));
-  }
-
-  template <typename PointT> inline unsigned int
-  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                                  const Indices &indices,
-                                  Eigen::Matrix3d &covariance_matrix,
-                                  Eigen::Vector4d &centroid)
-  {
-    return (computeMeanAndCovarianceMatrix<PointT, double> (cloud, indices, covariance_matrix, centroid));
-  }
-
-  /** \brief Compute the normalized 3x3 covariance matrix and the centroid of a given set of points in a single loop.
-    * Normalized means that every entry has been divided by the number of entries in indices.
-    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
-    * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
-    * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
-    * \param[in] cloud the input point cloud
-    * \param[in] indices subset of points given by their indices
-    * \param[out] centroid the centroid of the set of points in the cloud
-    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
-    * \return number of valid points used to determine the covariance matrix.
-    * In case of dense point clouds, this is the same as the size of input indices.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                                  const pcl::PointIndices &indices,
-                                  Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
-                                  Eigen::Matrix<Scalar, 4, 1> &centroid);
-
-  template <typename PointT> inline unsigned int
-  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                                  const pcl::PointIndices &indices,
-                                  Eigen::Matrix3f &covariance_matrix,
-                                  Eigen::Vector4f &centroid)
-  {
-    return (computeMeanAndCovarianceMatrix<PointT, float> (cloud, indices, covariance_matrix, centroid));
-  }
-
-  template <typename PointT> inline unsigned int
-  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                                  const pcl::PointIndices &indices,
-                                  Eigen::Matrix3d &covariance_matrix,
-                                  Eigen::Vector4d &centroid)
-  {
-    return (computeMeanAndCovarianceMatrix<PointT, double> (cloud, indices, covariance_matrix, centroid));
-  }
-
-  /** \brief Compute the normalized 3x3 covariance matrix for a already demeaned point cloud.
-    * Normalized means that every entry has been divided by the number of entries in the input point cloud.
-    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
-    * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
-    * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
-    * \param[in] cloud the input point cloud
-    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
-    * \return number of valid points used to determine the covariance matrix.
-    * In case of dense point clouds, this is the same as the size of input cloud.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           Eigen::Matrix3f &covariance_matrix)
-  {
-    return (computeCovarianceMatrix<PointT, float> (cloud, covariance_matrix));
-  }
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           Eigen::Matrix3d &covariance_matrix)
-  {
-    return (computeCovarianceMatrix<PointT, double> (cloud, covariance_matrix));
-  }
-
-  /** \brief Compute the normalized 3x3 covariance matrix for a already demeaned point cloud.
-    * Normalized means that every entry has been divided by the number of entries in indices.
-    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
-    * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
-    * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
-    * \param[in] cloud the input point cloud
-    * \param[in] indices subset of points given by their indices
-    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
-    * \return number of valid points used to determine the covariance matrix.
-    * In case of dense point clouds, this is the same as the size of input indices.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           const Indices &indices,
-                           Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           const Indices &indices,
-                           Eigen::Matrix3f &covariance_matrix)
-  {
-    return (computeCovarianceMatrix<PointT, float> (cloud, indices, covariance_matrix));
-  }
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           const Indices &indices,
-                           Eigen::Matrix3d &covariance_matrix)
-  {
-    return (computeCovarianceMatrix<PointT, double> (cloud, indices, covariance_matrix));
-  }
-
-  /** \brief Compute the normalized 3x3 covariance matrix for a already demeaned point cloud.
-    * Normalized means that every entry has been divided by the number of entries in indices.
-    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
-    * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
-    * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
-    * \param[in] cloud the input point cloud
-    * \param[in] indices subset of points given by their indices
-    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
-    * \return number of valid points used to determine the covariance matrix.
-    * In case of dense point clouds, this is the same as the size of input indices.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           const pcl::PointIndices &indices,
-                           Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           const pcl::PointIndices &indices,
-                           Eigen::Matrix3f &covariance_matrix)
-  {
-    return (computeCovarianceMatrix<PointT, float> (cloud, indices, covariance_matrix));
-  }
-
-  template <typename PointT> inline unsigned int
-  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
-                           const pcl::PointIndices &indices,
-                           Eigen::Matrix3d &covariance_matrix)
-  {
-    return (computeCovarianceMatrix<PointT, double> (cloud, indices, covariance_matrix));
-  }
-
-  /** \brief Subtract a centroid from a point cloud and return the de-meaned representation
-    * \param[in] cloud_iterator an iterator over the input point cloud
-    * \param[in] centroid the centroid of the point cloud
-    * \param[out] cloud_out the resultant output point cloud
-    * \param[in] npts the number of samples guaranteed to be left in the input cloud, accessible by the iterator. If not given, it will be calculated.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> void
-  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
-                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                    pcl::PointCloud<PointT> &cloud_out,
-                    int npts = 0);
-
-  template <typename PointT> void
-  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
-                    const Eigen::Vector4f &centroid,
-                    pcl::PointCloud<PointT> &cloud_out,
-                    int npts = 0)
-  {
-    return (demeanPointCloud<PointT, float> (cloud_iterator, centroid, cloud_out, npts));
-  }
-
-  template <typename PointT> void
-  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
-                    const Eigen::Vector4d &centroid,
-                    pcl::PointCloud<PointT> &cloud_out,
-                    int npts = 0)
-  {
-    return (demeanPointCloud<PointT, double> (cloud_iterator, centroid, cloud_out, npts));
-  }
-
-  /** \brief Subtract a centroid from a point cloud and return the de-meaned representation
-    * \param[in] cloud_in the input point cloud
-    * \param[in] centroid the centroid of the point cloud
-    * \param[out] cloud_out the resultant output point cloud
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                    pcl::PointCloud<PointT> &cloud_out);
-
-  template <typename PointT> void
-  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
-                    const Eigen::Vector4f &centroid,
-                    pcl::PointCloud<PointT> &cloud_out)
-  {
-    return (demeanPointCloud<PointT, float> (cloud_iterator, centroid, cloud_out));
-  }
-
-  template <typename PointT> void
-  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
-                    const Eigen::Vector4d &centroid,
-                    pcl::PointCloud<PointT> &cloud_out)
-  {
-    return (demeanPointCloud<PointT, double> (cloud_iterator, centroid, cloud_out));
-  }
-
-  /** \brief Subtract a centroid from a point cloud and return the de-meaned representation
-    * \param[in] cloud_in the input point cloud
-    * \param[in] indices the set of point indices to use from the input point cloud
-    * \param[out] centroid the centroid of the point cloud
-    * \param cloud_out the resultant output point cloud
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const Indices &indices,
-                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                    pcl::PointCloud<PointT> &cloud_out);
-
-  template <typename PointT> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const Indices &indices,
-                    const Eigen::Vector4f &centroid,
-                    pcl::PointCloud<PointT> &cloud_out)
-  {
-    return (demeanPointCloud<PointT, float> (cloud_in, indices, centroid, cloud_out));
-  }
-
-  template <typename PointT> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const Indices &indices,
-                    const Eigen::Vector4d &centroid,
-                    pcl::PointCloud<PointT> &cloud_out)
-  {
-    return (demeanPointCloud<PointT, double> (cloud_in, indices, centroid, cloud_out));
-  }
-
-  /** \brief Subtract a centroid from a point cloud and return the de-meaned representation
-    * \param[in] cloud_in the input point cloud
-    * \param[in] indices the set of point indices to use from the input point cloud
-    * \param[out] centroid the centroid of the point cloud
-    * \param cloud_out the resultant output point cloud
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const pcl::PointIndices& indices,
-                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                    pcl::PointCloud<PointT> &cloud_out);
-
-  template <typename PointT> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const pcl::PointIndices& indices,
-                    const Eigen::Vector4f &centroid,
-                    pcl::PointCloud<PointT> &cloud_out)
-  {
-    return (demeanPointCloud<PointT, float> (cloud_in, indices, centroid, cloud_out));
-  }
-
-  template <typename PointT> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const pcl::PointIndices& indices,
-                    const Eigen::Vector4d &centroid,
-                    pcl::PointCloud<PointT> &cloud_out)
-  {
-    return (demeanPointCloud<PointT, double> (cloud_in, indices, centroid, cloud_out));
-  }
-
-  /** \brief Subtract a centroid from a point cloud and return the de-meaned
-    * representation as an Eigen matrix
-    * \param[in] cloud_iterator an iterator over the input point cloud
-    * \param[in] centroid the centroid of the point cloud
-    * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
-    * an Eigen matrix (4 rows, N pts columns)
-    * \param[in] npts the number of samples guaranteed to be left in the input cloud, accessible by the iterator. If not given, it will be calculated.
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> void
-  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
-                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                    Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out,
-                    int npts = 0);
-
-  template <typename PointT> void
-  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
-                    const Eigen::Vector4f &centroid,
-                    Eigen::MatrixXf &cloud_out,
-                    int npts = 0)
-  {
-    return (demeanPointCloud<PointT, float> (cloud_iterator, centroid, cloud_out, npts));
-  }
-
-  template <typename PointT> void
-  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
-                    const Eigen::Vector4d &centroid,
-                    Eigen::MatrixXd &cloud_out,
-                    int npts = 0)
-  {
-    return (demeanPointCloud<PointT, double> (cloud_iterator, centroid, cloud_out, npts));
-  }
-
-  /** \brief Subtract a centroid from a point cloud and return the de-meaned
-    * representation as an Eigen matrix
-    * \param[in] cloud_in the input point cloud
-    * \param[in] centroid the centroid of the point cloud
-    * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
-    * an Eigen matrix (4 rows, N pts columns)
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                    Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out);
-
-  template <typename PointT> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const Eigen::Vector4f &centroid,
-                    Eigen::MatrixXf &cloud_out)
-  {
-    return (demeanPointCloud<PointT, float> (cloud_in, centroid, cloud_out));
-  }
-
-  template <typename PointT> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const Eigen::Vector4d &centroid,
-                    Eigen::MatrixXd &cloud_out)
-  {
-    return (demeanPointCloud<PointT, double> (cloud_in, centroid, cloud_out));
-  }
-
-  /** \brief Subtract a centroid from a point cloud and return the de-meaned
-    * representation as an Eigen matrix
-    * \param[in] cloud_in the input point cloud
-    * \param[in] indices the set of point indices to use from the input point cloud
-    * \param[in] centroid the centroid of the point cloud
-    * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
-    * an Eigen matrix (4 rows, N pts columns)
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const Indices &indices,
-                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                    Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out);
-
-  template <typename PointT> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const Indices &indices,
-                    const Eigen::Vector4f &centroid,
-                    Eigen::MatrixXf &cloud_out)
-  {
-    return (demeanPointCloud<PointT, float> (cloud_in, indices, centroid, cloud_out));
-  }
-
-  template <typename PointT> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const Indices &indices,
-                    const Eigen::Vector4d &centroid,
-                    Eigen::MatrixXd &cloud_out)
-  {
-    return (demeanPointCloud<PointT, double> (cloud_in, indices, centroid, cloud_out));
-  }
-
-  /** \brief Subtract a centroid from a point cloud and return the de-meaned
-    * representation as an Eigen matrix
-    * \param[in] cloud_in the input point cloud
-    * \param[in] indices the set of point indices to use from the input point cloud
-    * \param[in] centroid the centroid of the point cloud
-    * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
-    * an Eigen matrix (4 rows, N pts columns)
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const pcl::PointIndices& indices,
-                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
-                    Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out);
-
-  template <typename PointT> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const pcl::PointIndices& indices,
-                    const Eigen::Vector4f &centroid,
-                    Eigen::MatrixXf &cloud_out)
-  {
-    return (demeanPointCloud<PointT, float> (cloud_in, indices, centroid, cloud_out));
-  }
-
-  template <typename PointT> void
-  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
-                    const pcl::PointIndices& indices,
-                    const Eigen::Vector4d &centroid,
-                    Eigen::MatrixXd &cloud_out)
-  {
-    return (demeanPointCloud<PointT, double> (cloud_in, indices, centroid, cloud_out));
-  }
-
-  /** \brief Helper functor structure for n-D centroid estimation. */
-  template<typename PointT, typename Scalar>
-  struct NdCentroidFunctor
-  {
-    using Pod = typename traits::POD<PointT>::type;
-
-    NdCentroidFunctor (const PointT &p, Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid)
-      : f_idx_ (0),
-        centroid_ (centroid),
-        p_ (reinterpret_cast<const Pod&>(p)) { }
-
-    template<typename Key> inline void operator() ()
-    {
-      using T = typename pcl::traits::datatype<PointT, Key>::type;
-      const std::uint8_t* raw_ptr = reinterpret_cast<const std::uint8_t*>(&p_) + pcl::traits::offset<PointT, Key>::value;
-      const T* data_ptr = reinterpret_cast<const T*>(raw_ptr);
-
-      // Check if the value is invalid
-      if (!std::isfinite (*data_ptr))
-      {
-        f_idx_++;
-        return;
-      }
-
-      centroid_[f_idx_++] += *data_ptr;
+    using T = typename pcl::traits::datatype<PointT, Key>::type;
+    const std::uint8_t* raw_ptr = reinterpret_cast<const std::uint8_t*>(&p_) +
+                                  pcl::traits::offset<PointT, Key>::value;
+    const T* data_ptr = reinterpret_cast<const T*>(raw_ptr);
+
+    // Check if the value is invalid
+    if (!std::isfinite(*data_ptr)) {
+      f_idx_++;
+      return;
     }
 
-    private:
-      int f_idx_;
-      Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid_;
-      const Pod &p_;
-  };
-
-  /** \brief General, all purpose nD centroid estimation for a set of points using their
-    * indices.
-    * \param cloud the input point cloud
-    * \param centroid the output centroid
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline void
-  computeNDCentroid (const pcl::PointCloud<PointT> &cloud, 
-                     Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid);
-
-  template <typename PointT> inline void
-  computeNDCentroid (const pcl::PointCloud<PointT> &cloud, 
-                     Eigen::VectorXf &centroid)
-  {
-    return (computeNDCentroid<PointT, float> (cloud, centroid));
+    centroid_[f_idx_++] += *data_ptr;
   }
 
-  template <typename PointT> inline void
-  computeNDCentroid (const pcl::PointCloud<PointT> &cloud, 
-                     Eigen::VectorXd &centroid)
-  {
-    return (computeNDCentroid<PointT, double> (cloud, centroid));
-  }
+private:
+  int f_idx_{0};
+  Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& centroid_;
+  const Pod& p_;
+};
 
-  /** \brief General, all purpose nD centroid estimation for a set of points using their
-    * indices.
-    * \param cloud the input point cloud
-    * \param indices the point cloud indices that need to be used
-    * \param centroid the output centroid
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline void
-  computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
-                     const Indices &indices,
-                     Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid);
+/** \brief General, all purpose nD centroid estimation for a set of points using their
+ * indices.
+ * \param cloud the input point cloud
+ * \param centroid the output centroid
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline void
+computeNDCentroid(const pcl::PointCloud<PointT>& cloud,
+                  Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& centroid);
 
-  template <typename PointT> inline void
-  computeNDCentroid (const pcl::PointCloud<PointT> &cloud, 
-                     const Indices &indices,
-                     Eigen::VectorXf &centroid)
-  {
-    return (computeNDCentroid<PointT, float> (cloud, indices, centroid));
-  }
-
-  template <typename PointT> inline void
-  computeNDCentroid (const pcl::PointCloud<PointT> &cloud, 
-                     const Indices &indices,
-                     Eigen::VectorXd &centroid)
-  {
-    return (computeNDCentroid<PointT, double> (cloud, indices, centroid));
-  }
-
-  /** \brief General, all purpose nD centroid estimation for a set of points using their
-    * indices.
-    * \param cloud the input point cloud
-    * \param indices the point cloud indices that need to be used
-    * \param centroid the output centroid
-    * \ingroup common
-    */
-  template <typename PointT, typename Scalar> inline void
-  computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
-                     const pcl::PointIndices &indices,
-                     Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid);
-
-  template <typename PointT> inline void
-  computeNDCentroid (const pcl::PointCloud<PointT> &cloud, 
-                     const pcl::PointIndices &indices,
-                     Eigen::VectorXf &centroid)
-  {
-    return (computeNDCentroid<PointT, float> (cloud, indices, centroid));
-  }
-
-  template <typename PointT> inline void
-  computeNDCentroid (const pcl::PointCloud<PointT> &cloud, 
-                     const pcl::PointIndices &indices,
-                     Eigen::VectorXd &centroid)
-  {
-    return (computeNDCentroid<PointT, double> (cloud, indices, centroid));
-  }
-
+template <typename PointT>
+inline void
+computeNDCentroid(const pcl::PointCloud<PointT>& cloud, Eigen::VectorXf& centroid)
+{
+  return (computeNDCentroid<PointT, float>(cloud, centroid));
 }
+
+template <typename PointT>
+inline void
+computeNDCentroid(const pcl::PointCloud<PointT>& cloud, Eigen::VectorXd& centroid)
+{
+  return (computeNDCentroid<PointT, double>(cloud, centroid));
+}
+
+/** \brief General, all purpose nD centroid estimation for a set of points using their
+ * indices.
+ * \param cloud the input point cloud
+ * \param indices the point cloud indices that need to be used
+ * \param centroid the output centroid
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline void
+computeNDCentroid(const pcl::PointCloud<PointT>& cloud,
+                  const Indices& indices,
+                  Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& centroid);
+
+template <typename PointT>
+inline void
+computeNDCentroid(const pcl::PointCloud<PointT>& cloud,
+                  const Indices& indices,
+                  Eigen::VectorXf& centroid)
+{
+  return (computeNDCentroid<PointT, float>(cloud, indices, centroid));
+}
+
+template <typename PointT>
+inline void
+computeNDCentroid(const pcl::PointCloud<PointT>& cloud,
+                  const Indices& indices,
+                  Eigen::VectorXd& centroid)
+{
+  return (computeNDCentroid<PointT, double>(cloud, indices, centroid));
+}
+
+/** \brief General, all purpose nD centroid estimation for a set of points using their
+ * indices.
+ * \param cloud the input point cloud
+ * \param indices the point cloud indices that need to be used
+ * \param centroid the output centroid
+ * \ingroup common
+ */
+template <typename PointT, typename Scalar>
+inline void
+computeNDCentroid(const pcl::PointCloud<PointT>& cloud,
+                  const pcl::PointIndices& indices,
+                  Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& centroid);
+
+template <typename PointT>
+inline void
+computeNDCentroid(const pcl::PointCloud<PointT>& cloud,
+                  const pcl::PointIndices& indices,
+                  Eigen::VectorXf& centroid)
+{
+  return (computeNDCentroid<PointT, float>(cloud, indices, centroid));
+}
+
+template <typename PointT>
+inline void
+computeNDCentroid(const pcl::PointCloud<PointT>& cloud,
+                  const pcl::PointIndices& indices,
+                  Eigen::VectorXd& centroid)
+{
+  return (computeNDCentroid<PointT, double>(cloud, indices, centroid));
+}
+
+} // namespace pcl
 
 #include <pcl/common/impl/accumulators.hpp>
 
-namespace pcl
-{
+namespace pcl {
 
-  /** A generic class that computes the centroid of points fed to it.
-    *
-    * Here by "centroid" we denote not just the mean of 3D point coordinates,
-    * but also mean of values in the other data fields. The general-purpose
-    * \ref computeNDCentroid() function also implements this sort of
-    * functionality, however it does it in a "dumb" way, i.e. regardless of the
-    * semantics of the data inside a field it simply averages the values. In
-    * certain cases (e.g. for \c x, \c y, \c z, \c intensity fields) this
-    * behavior is reasonable, however in other cases (e.g. \c rgb, \c rgba,
-    * \c label fields) this does not lead to meaningful results.
-    *
-    * This class is capable of computing the centroid in a "smart" way, i.e.
-    * taking into account the meaning of the data inside fields. Currently the
-    * following fields are supported:
-    *
-    *  Data      | Point fields                          | Algorithm
-    *  --------- | ------------------------------------- | -------------------------------------------------------------------------------------------
-    *  XYZ       | \c x, \c y, \c z                      | Average (separate for each field)
-    *  Normal    | \c normal_x, \c normal_y, \c normal_z | Average (separate for each field), resulting vector is normalized
-    *  Curvature | \c curvature                          | Average
-    *  Color     | \c rgb or \c rgba                     | Average (separate for R, G, B, and alpha channels)
-    *  Intensity | \c intensity                          | Average
-    *  Label     | \c label                              | Majority vote; if several labels have the same largest support then the  smaller label wins
-    *
-    * The template parameter defines the type of points that may be accumulated
-    * with this class. This may be an arbitrary PCL point type, and centroid
-    * computation will happen only for the fields that are present in it and are
-    * supported.
-    *
-    * Current centroid may be retrieved at any time using get(). Note that the
-    * function is templated on point type, so it is possible to fetch the
-    * centroid into a point type that differs from the type of points that are
-    * being accumulated. All the "extra" fields for which the centroid is not
-    * being calculated will be left untouched.
-    *
-    * Example usage:
-    *
-    * \code
-    * // Create and accumulate points
-    * CentroidPoint<pcl::PointXYZ> centroid;
-    * centroid.add (pcl::PointXYZ (1, 2, 3);
-    * centroid.add (pcl::PointXYZ (5, 6, 7);
-    * // Fetch centroid using `get()`
-    * pcl::PointXYZ c1;
-    * centroid.get (c1);
-    * // The expected result is: c1.x == 3, c1.y == 4, c1.z == 5
-    * // It is also okay to use `get()` with a different point type
-    * pcl::PointXYZRGB c2;
-    * centroid.get (c2);
-    * // The expected result is: c2.x == 3, c2.y == 4, c2.z == 5,
-    * // and c2.rgb is left untouched
-    * \endcode
-    *
-    * \note Assumes that the points being inserted are valid.
-    *
-    * \note This class template can be successfully instantiated for *any*
-    * PCL point type. Of course, each of the field averages is computed only if
-    * the point type has the corresponding field.
-    *
-    * \ingroup common
-    * \author Sergey Alexandrov */
-  template <typename PointT>
-  class CentroidPoint
+/** A generic class that computes the centroid of points fed to it.
+ *
+ * Here by "centroid" we denote not just the mean of 3D point coordinates,
+ * but also mean of values in the other data fields. The general-purpose
+ * \ref computeNDCentroid() function also implements this sort of
+ * functionality, however it does it in a "dumb" way, i.e. regardless of the
+ * semantics of the data inside a field it simply averages the values. In
+ * certain cases (e.g. for \c x, \c y, \c z, \c intensity fields) this
+ * behavior is reasonable, however in other cases (e.g. \c rgb, \c rgba,
+ * \c label fields) this does not lead to meaningful results.
+ *
+ * This class is capable of computing the centroid in a "smart" way, i.e.
+ * taking into account the meaning of the data inside fields. Currently the
+ * following fields are supported:
+ *
+ *  Data      | Point fields                          | Algorithm
+ *  --------- | ------------------------------------- |
+ * -------------------------------------------------------------------------------------------
+ *  XYZ       | \c x, \c y, \c z                      | Average (separate for each
+ * field) Normal    | \c normal_x, \c normal_y, \c normal_z | Average (separate for each
+ * field), resulting vector is normalized Curvature | \c curvature | Average Color     |
+ * \c rgb or \c rgba                     | Average (separate for R, G, B, and alpha
+ * channels) Intensity | \c intensity                          | Average Label     | \c
+ * label                              | Majority vote; if several labels have the same
+ * largest support then the  smaller label wins
+ *
+ * The template parameter defines the type of points that may be accumulated
+ * with this class. This may be an arbitrary PCL point type, and centroid
+ * computation will happen only for the fields that are present in it and are
+ * supported.
+ *
+ * Current centroid may be retrieved at any time using get(). Note that the
+ * function is templated on point type, so it is possible to fetch the
+ * centroid into a point type that differs from the type of points that are
+ * being accumulated. All the "extra" fields for which the centroid is not
+ * being calculated will be left untouched.
+ *
+ * Example usage:
+ *
+ * \code
+ * // Create and accumulate points
+ * CentroidPoint<pcl::PointXYZ> centroid;
+ * centroid.add (pcl::PointXYZ (1, 2, 3);
+ * centroid.add (pcl::PointXYZ (5, 6, 7);
+ * // Fetch centroid using `get()`
+ * pcl::PointXYZ c1;
+ * centroid.get (c1);
+ * // The expected result is: c1.x == 3, c1.y == 4, c1.z == 5
+ * // It is also okay to use `get()` with a different point type
+ * pcl::PointXYZRGB c2;
+ * centroid.get (c2);
+ * // The expected result is: c2.x == 3, c2.y == 4, c2.z == 5,
+ * // and c2.rgb is left untouched
+ * \endcode
+ *
+ * \note Assumes that the points being inserted are valid.
+ *
+ * \note This class template can be successfully instantiated for *any*
+ * PCL point type. Of course, each of the field averages is computed only if
+ * the point type has the corresponding field.
+ *
+ * \ingroup common
+ * \author Sergey Alexandrov */
+template <typename PointT>
+class CentroidPoint {
+
+public:
+  CentroidPoint() = default;
+
+  /** Add a new point to the centroid computation.
+   *
+   * In this function only the accumulators and point counter are updated,
+   * actual centroid computation does not happen until get() is called. */
+  void
+  add(const PointT& point);
+
+  /** Retrieve the current centroid.
+   *
+   * Computation (division of accumulated values by the number of points
+   * and normalization where applicable) happens here. The result is not
+   * cached, so any subsequent call to this function will trigger
+   * re-computation.
+   *
+   * If the number of accumulated points is zero, then the point will be
+   * left untouched. */
+  template <typename PointOutT>
+  void
+  get(PointOutT& point) const;
+
+  /** Get the total number of points that were added. */
+  inline std::size_t
+  getSize() const
   {
+    return (num_points_);
+  }
 
-    public:
+  PCL_MAKE_ALIGNED_OPERATOR_NEW
 
-      CentroidPoint () = default;
+private:
+  std::size_t num_points_ = 0;
+  typename pcl::detail::Accumulators<PointT>::type accumulators_;
+};
 
-      /** Add a new point to the centroid computation.
-        *
-        * In this function only the accumulators and point counter are updated,
-        * actual centroid computation does not happen until get() is called. */
-      void
-      add (const PointT& point);
+/** Compute the centroid of a set of points and return it as a point.
+ *
+ * Implementation leverages \ref CentroidPoint class and therefore behaves
+ * differently from \ref compute3DCentroid() and \ref computeNDCentroid().
+ * See \ref CentroidPoint documentation for explanation.
+ *
+ * \param[in] cloud input point cloud
+ * \param[out] centroid output centroid
+ *
+ * \return number of valid points used to determine the centroid (will be the
+ * same as the size of the cloud if it is dense)
+ *
+ * \note If return value is \c 0, then the centroid is not changed, thus is
+ * not valid.
+ *
+ * \ingroup common */
+template <typename PointInT, typename PointOutT>
+std::size_t
+computeCentroid(const pcl::PointCloud<PointInT>& cloud, PointOutT& centroid);
 
-      /** Retrieve the current centroid.
-        *
-        * Computation (division of accumulated values by the number of points
-        * and normalization where applicable) happens here. The result is not
-        * cached, so any subsequent call to this function will trigger
-        * re-computation.
-        *
-        * If the number of accumulated points is zero, then the point will be
-        * left untouched. */
-      template <typename PointOutT> void
-      get (PointOutT& point) const;
+/** Compute the centroid of a set of points and return it as a point.
+ * \param[in] cloud
+ * \param[in] indices point cloud indices that need to be used
+ * \param[out] centroid
+ * This is an overloaded function provided for convenience. See the
+ * documentation for computeCentroid().
+ *
+ * \ingroup common */
+template <typename PointInT, typename PointOutT>
+std::size_t
+computeCentroid(const pcl::PointCloud<PointInT>& cloud,
+                const Indices& indices,
+                PointOutT& centroid);
 
-      /** Get the total number of points that were added. */
-      inline std::size_t
-      getSize () const
-      {
-        return (num_points_);
-      }
-
-      PCL_MAKE_ALIGNED_OPERATOR_NEW
-
-    private:
-
-      std::size_t num_points_ = 0;
-      typename pcl::detail::Accumulators<PointT>::type accumulators_;
-
-  };
-
-  /** Compute the centroid of a set of points and return it as a point.
-    *
-    * Implementation leverages \ref CentroidPoint class and therefore behaves
-    * differently from \ref compute3DCentroid() and \ref computeNDCentroid().
-    * See \ref CentroidPoint documentation for explanation.
-    *
-    * \param[in] cloud input point cloud
-    * \param[out] centroid output centroid
-    *
-    * \return number of valid points used to determine the centroid (will be the
-    * same as the size of the cloud if it is dense)
-    *
-    * \note If return value is \c 0, then the centroid is not changed, thus is
-    * not valid.
-    *
-    * \ingroup common */
-  template <typename PointInT, typename PointOutT> std::size_t
-  computeCentroid (const pcl::PointCloud<PointInT>& cloud,
-                   PointOutT& centroid);
-
-  /** Compute the centroid of a set of points and return it as a point.
-    * \param[in] cloud
-    * \param[in] indices point cloud indices that need to be used
-    * \param[out] centroid
-    * This is an overloaded function provided for convenience. See the
-    * documentation for computeCentroid().
-    *
-    * \ingroup common */
-  template <typename PointInT, typename PointOutT> std::size_t
-  computeCentroid (const pcl::PointCloud<PointInT>& cloud,
-                   const Indices& indices,
-                   PointOutT& centroid);
-
-}
+} // namespace pcl
 /*@}*/
 #include <pcl/common/impl/centroid.hpp>

--- a/common/include/pcl/common/centroid.h
+++ b/common/include/pcl/common/centroid.h
@@ -38,1150 +38,1061 @@
 
 #pragma once
 
-#include <pcl/PointIndices.h>
-#include <pcl/cloud_iterator.h>
 #include <pcl/memory.h>
 #include <pcl/pcl_macros.h>
 #include <pcl/point_cloud.h>
 #include <pcl/type_traits.h>
+#include <pcl/PointIndices.h>
+#include <pcl/cloud_iterator.h>
 
 /**
- * \file pcl/common/centroid.h
- * Define methods for centroid estimation and covariance matrix calculus
- * \ingroup common
- */
+  * \file pcl/common/centroid.h
+  * Define methods for centroid estimation and covariance matrix calculus
+  * \ingroup common
+  */
 
 /*@{*/
-namespace pcl {
-/** \brief Compute the 3D (X-Y-Z) centroid of a set of points and return it as a 3D
- * vector. \param[in] cloud_iterator an iterator over the input point cloud \param[out]
- * centroid the output centroid \return number of valid points used to determine the
- * centroid. In case of dense point clouds, this is the same as the size of input cloud.
- * \note if return value is 0, the centroid is not changed, thus not valid.
- * The last component of the vector is set to 1, this allows to transform the centroid
- * vector with 4x4 matrices. \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-compute3DCentroid(ConstCloudIterator<PointT>& cloud_iterator,
-                  Eigen::Matrix<Scalar, 4, 1>& centroid);
-
-template <typename PointT>
-inline unsigned int
-compute3DCentroid(ConstCloudIterator<PointT>& cloud_iterator, Eigen::Vector4f& centroid)
+namespace pcl
 {
-  return (compute3DCentroid<PointT, float>(cloud_iterator, centroid));
-}
-
-template <typename PointT>
-inline unsigned int
-compute3DCentroid(ConstCloudIterator<PointT>& cloud_iterator, Eigen::Vector4d& centroid)
-{
-  return (compute3DCentroid<PointT, double>(cloud_iterator, centroid));
-}
-
-/** \brief Compute the 3D (X-Y-Z) centroid of a set of points and return it as a 3D
- * vector. \param[in] cloud the input point cloud \param[out] centroid the output
- * centroid \return number of valid points used to determine the centroid. In case of
- * dense point clouds, this is the same as the size of input cloud. \note if return
- * value is 0, the centroid is not changed, thus not valid. The last component of the
- * vector is set to 1, this allows to transform the centroid vector with 4x4 matrices.
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-compute3DCentroid(const pcl::PointCloud<PointT>& cloud,
-                  Eigen::Matrix<Scalar, 4, 1>& centroid);
-
-template <typename PointT>
-inline unsigned int
-compute3DCentroid(const pcl::PointCloud<PointT>& cloud, Eigen::Vector4f& centroid)
-{
-  return (compute3DCentroid<PointT, float>(cloud, centroid));
-}
-
-template <typename PointT>
-inline unsigned int
-compute3DCentroid(const pcl::PointCloud<PointT>& cloud, Eigen::Vector4d& centroid)
-{
-  return (compute3DCentroid<PointT, double>(cloud, centroid));
-}
-
-/** \brief Compute the 3D (X-Y-Z) centroid of a set of points using their indices and
- * return it as a 3D vector.
- * \param[in] cloud the input point cloud
- * \param[in] indices the point cloud indices that need to be used
- * \param[out] centroid the output centroid
- * \return number of valid points used to determine the centroid. In case of dense point
- * clouds, this is the same as the size of input indices. \note if return value is 0,
- * the centroid is not changed, thus not valid. The last component of the vector is set
- * to 1, this allows to transform the centroid vector with 4x4 matrices. \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-compute3DCentroid(const pcl::PointCloud<PointT>& cloud,
-                  const Indices& indices,
-                  Eigen::Matrix<Scalar, 4, 1>& centroid);
-
-template <typename PointT>
-inline unsigned int
-compute3DCentroid(const pcl::PointCloud<PointT>& cloud,
-                  const Indices& indices,
-                  Eigen::Vector4f& centroid)
-{
-  return (compute3DCentroid<PointT, float>(cloud, indices, centroid));
-}
-
-template <typename PointT>
-inline unsigned int
-compute3DCentroid(const pcl::PointCloud<PointT>& cloud,
-                  const Indices& indices,
-                  Eigen::Vector4d& centroid)
-{
-  return (compute3DCentroid<PointT, double>(cloud, indices, centroid));
-}
-
-/** \brief Compute the 3D (X-Y-Z) centroid of a set of points using their indices and
- * return it as a 3D vector.
- * \param[in] cloud the input point cloud
- * \param[in] indices the point cloud indices that need to be used
- * \param[out] centroid the output centroid
- * \return number of valid points used to determine the centroid. In case of dense point
- * clouds, this is the same as the size of input indices. \note if return value is 0,
- * the centroid is not changed, thus not valid. The last component of the vector is set
- * to 1, this allows to transform the centroid vector with 4x4 matrices. \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-compute3DCentroid(const pcl::PointCloud<PointT>& cloud,
-                  const pcl::PointIndices& indices,
-                  Eigen::Matrix<Scalar, 4, 1>& centroid);
-
-template <typename PointT>
-inline unsigned int
-compute3DCentroid(const pcl::PointCloud<PointT>& cloud,
-                  const pcl::PointIndices& indices,
-                  Eigen::Vector4f& centroid)
-{
-  return (compute3DCentroid<PointT, float>(cloud, indices, centroid));
-}
-
-template <typename PointT>
-inline unsigned int
-compute3DCentroid(const pcl::PointCloud<PointT>& cloud,
-                  const pcl::PointIndices& indices,
-                  Eigen::Vector4d& centroid)
-{
-  return (compute3DCentroid<PointT, double>(cloud, indices, centroid));
-}
-
-/** \brief Compute the 3x3 covariance matrix of a given set of points.
- * The result is returned as a Eigen::Matrix3f.
- * Note: the covariance matrix is not normalized with the number of
- * points. For a normalized covariance, please use
- * computeCovarianceMatrixNormalized.
- * \param[in] cloud the input point cloud
- * \param[in] centroid the centroid of the set of points in the cloud
- * \param[out] covariance_matrix the resultant 3x3 covariance matrix
- * \return number of valid points used to determine the covariance matrix.
- * In case of dense point clouds, this is the same as the size of input cloud.
- * \note if return value is 0, the covariance matrix is not changed, thus not valid.
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        const Eigen::Matrix<Scalar, 4, 1>& centroid,
-                        Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        const Eigen::Vector4f& centroid,
-                        Eigen::Matrix3f& covariance_matrix)
-{
-  return (computeCovarianceMatrix<PointT, float>(cloud, centroid, covariance_matrix));
-}
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        const Eigen::Vector4d& centroid,
-                        Eigen::Matrix3d& covariance_matrix)
-{
-  return (computeCovarianceMatrix<PointT, double>(cloud, centroid, covariance_matrix));
-}
-
-/** \brief Compute normalized the 3x3 covariance matrix of a given set of points.
- * The result is returned as a Eigen::Matrix3f.
- * Normalized means that every entry has been divided by the number of points in the
- * point cloud. For small number of points, or if you want explicitly the
- * sample-variance, use computeCovarianceMatrix and scale the covariance matrix with 1 /
- * (n-1), where n is the number of points used to calculate the covariance matrix and is
- * returned by the computeCovarianceMatrix function. \param[in] cloud the input point
- * cloud \param[in] centroid the centroid of the set of points in the cloud \param[out]
- * covariance_matrix the resultant 3x3 covariance matrix \return number of valid points
- * used to determine the covariance matrix. In case of dense point clouds, this is the
- * same as the size of input cloud. \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
-                                  const Eigen::Matrix<Scalar, 4, 1>& centroid,
-                                  Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
-                                  const Eigen::Vector4f& centroid,
-                                  Eigen::Matrix3f& covariance_matrix)
-{
-  return (computeCovarianceMatrixNormalized<PointT, float>(
-      cloud, centroid, covariance_matrix));
-}
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
-                                  const Eigen::Vector4d& centroid,
-                                  Eigen::Matrix3d& covariance_matrix)
-{
-  return (computeCovarianceMatrixNormalized<PointT, double>(
-      cloud, centroid, covariance_matrix));
-}
-
-/** \brief Compute the 3x3 covariance matrix of a given set of points using their
- * indices. The result is returned as a Eigen::Matrix3f. Note: the covariance matrix is
- * not normalized with the number of points. For a normalized covariance, please use
- * computeCovarianceMatrixNormalized.
- * \param[in] cloud the input point cloud
- * \param[in] indices the point cloud indices that need to be used
- * \param[in] centroid the centroid of the set of points in the cloud
- * \param[out] covariance_matrix the resultant 3x3 covariance matrix
- * \return number of valid points used to determine the covariance matrix.
- * In case of dense point clouds, this is the same as the size of input indices.
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        const Indices& indices,
-                        const Eigen::Matrix<Scalar, 4, 1>& centroid,
-                        Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        const Indices& indices,
-                        const Eigen::Vector4f& centroid,
-                        Eigen::Matrix3f& covariance_matrix)
-{
-  return (computeCovarianceMatrix<PointT, float>(
-      cloud, indices, centroid, covariance_matrix));
-}
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        const Indices& indices,
-                        const Eigen::Vector4d& centroid,
-                        Eigen::Matrix3d& covariance_matrix)
-{
-  return (computeCovarianceMatrix<PointT, double>(
-      cloud, indices, centroid, covariance_matrix));
-}
-
-/** \brief Compute the 3x3 covariance matrix of a given set of points using their
- * indices. The result is returned as a Eigen::Matrix3f. Note: the covariance matrix is
- * not normalized with the number of points. For a normalized covariance, please use
- * computeCovarianceMatrixNormalized.
- * \param[in] cloud the input point cloud
- * \param[in] indices the point cloud indices that need to be used
- * \param[in] centroid the centroid of the set of points in the cloud
- * \param[out] covariance_matrix the resultant 3x3 covariance matrix
- * \return number of valid points used to determine the covariance matrix.
- * In case of dense point clouds, this is the same as the size of input indices.
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        const pcl::PointIndices& indices,
-                        const Eigen::Matrix<Scalar, 4, 1>& centroid,
-                        Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        const pcl::PointIndices& indices,
-                        const Eigen::Vector4f& centroid,
-                        Eigen::Matrix3f& covariance_matrix)
-{
-  return (computeCovarianceMatrix<PointT, float>(
-      cloud, indices, centroid, covariance_matrix));
-}
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        const pcl::PointIndices& indices,
-                        const Eigen::Vector4d& centroid,
-                        Eigen::Matrix3d& covariance_matrix)
-{
-  return (computeCovarianceMatrix<PointT, double>(
-      cloud, indices, centroid, covariance_matrix));
-}
-
-/** \brief Compute the normalized 3x3 covariance matrix of a given set of points using
- * their indices.
- * The result is returned as a Eigen::Matrix3f.
- * Normalized means that every entry has been divided by the number of entries in
- * indices. For small number of points, or if you want explicitly the sample-variance,
- * use computeCovarianceMatrix and scale the covariance matrix with 1 / (n-1), where n
- * is the number of points used to calculate the covariance matrix and is returned by
- * the computeCovarianceMatrix function. \param[in] cloud the input point cloud
- * \param[in] indices the point cloud indices that need to be used
- * \param[in] centroid the centroid of the set of points in the cloud
- * \param[out] covariance_matrix the resultant 3x3 covariance matrix
- * \return number of valid points used to determine the covariance matrix.
- * In case of dense point clouds, this is the same as the size of input indices.
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
-                                  const Indices& indices,
-                                  const Eigen::Matrix<Scalar, 4, 1>& centroid,
-                                  Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
-                                  const Indices& indices,
-                                  const Eigen::Vector4f& centroid,
-                                  Eigen::Matrix3f& covariance_matrix)
-{
-  return (computeCovarianceMatrixNormalized<PointT, float>(
-      cloud, indices, centroid, covariance_matrix));
-}
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
-                                  const Indices& indices,
-                                  const Eigen::Vector4d& centroid,
-                                  Eigen::Matrix3d& covariance_matrix)
-{
-  return (computeCovarianceMatrixNormalized<PointT, double>(
-      cloud, indices, centroid, covariance_matrix));
-}
-
-/** \brief Compute the normalized 3x3 covariance matrix of a given set of points using
- * their indices. The result is returned as a Eigen::Matrix3f.
- * Normalized means that every entry has been divided by the number of entries in
- * indices. For small number of points, or if you want explicitly the sample-variance,
- * use computeCovarianceMatrix and scale the covariance matrix with 1 / (n-1), where n
- * is the number of points used to calculate the covariance matrix and is returned by
- * the computeCovarianceMatrix function. \param[in] cloud the input point cloud
- * \param[in] indices the point cloud indices that need to be used
- * \param[in] centroid the centroid of the set of points in the cloud
- * \param[out] covariance_matrix the resultant 3x3 covariance matrix
- * \return number of valid points used to determine the covariance matrix.
- * In case of dense point clouds, this is the same as the size of input indices.
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
-                                  const pcl::PointIndices& indices,
-                                  const Eigen::Matrix<Scalar, 4, 1>& centroid,
-                                  Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
-                                  const pcl::PointIndices& indices,
-                                  const Eigen::Vector4f& centroid,
-                                  Eigen::Matrix3f& covariance_matrix)
-{
-  return (computeCovarianceMatrixNormalized<PointT, float>(
-      cloud, indices, centroid, covariance_matrix));
-}
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrixNormalized(const pcl::PointCloud<PointT>& cloud,
-                                  const pcl::PointIndices& indices,
-                                  const Eigen::Vector4d& centroid,
-                                  Eigen::Matrix3d& covariance_matrix)
-{
-  return (computeCovarianceMatrixNormalized<PointT, double>(
-      cloud, indices, centroid, covariance_matrix));
-}
-
-/** \brief Compute the normalized 3x3 covariance matrix and the centroid of a given set
- * of points in a single loop. Normalized means that every entry has been divided by the
- * number of valid entries in the point cloud. For small number of points, or if you
- * want explicitly the sample-variance, scale the covariance matrix with n / (n-1),
- * where n is the number of points used to calculate the covariance matrix and is
- * returned by this function. \note This method is theoretically exact. However using
- * float for internal calculations reduces the accuracy but increases the efficiency.
- * \param[in] cloud the input point cloud
- * \param[out] covariance_matrix the resultant 3x3 covariance matrix
- * \param[out] centroid the centroid of the set of points in the cloud
- * \return number of valid points used to determine the covariance matrix.
- * In case of dense point clouds, this is the same as the size of input cloud.
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                               Eigen::Matrix<Scalar, 3, 3>& covariance_matrix,
-                               Eigen::Matrix<Scalar, 4, 1>& centroid);
-
-template <typename PointT>
-inline unsigned int
-computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                               Eigen::Matrix3f& covariance_matrix,
-                               Eigen::Vector4f& centroid)
-{
-  return (computeMeanAndCovarianceMatrix<PointT, float>(
-      cloud, covariance_matrix, centroid));
-}
-
-template <typename PointT>
-inline unsigned int
-computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                               Eigen::Matrix3d& covariance_matrix,
-                               Eigen::Vector4d& centroid)
-{
-  return (computeMeanAndCovarianceMatrix<PointT, double>(
-      cloud, covariance_matrix, centroid));
-}
-
-/** \brief Compute the normalized 3x3 covariance matrix and the centroid of a given set
- * of points in a single loop. Normalized means that every entry has been divided by the
- * number of entries in indices. For small number of points, or if you want explicitly
- * the sample-variance, scale the covariance matrix with n / (n-1), where n is the
- * number of points used to calculate the covariance matrix and is returned by this
- * function. \note This method is theoretically exact. However using float for internal
- * calculations reduces the accuracy but increases the efficiency. \param[in] cloud the
- * input point cloud \param[in] indices subset of points given by their indices
- * \param[out] covariance_matrix the resultant 3x3 covariance matrix
- * \param[out] centroid the centroid of the set of points in the cloud
- * \return number of valid points used to determine the covariance matrix.
- * In case of dense point clouds, this is the same as the size of input indices.
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                               const Indices& indices,
-                               Eigen::Matrix<Scalar, 3, 3>& covariance_matrix,
-                               Eigen::Matrix<Scalar, 4, 1>& centroid);
-
-template <typename PointT>
-inline unsigned int
-computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                               const Indices& indices,
-                               Eigen::Matrix3f& covariance_matrix,
-                               Eigen::Vector4f& centroid)
-{
-  return (computeMeanAndCovarianceMatrix<PointT, float>(
-      cloud, indices, covariance_matrix, centroid));
-}
-
-template <typename PointT>
-inline unsigned int
-computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                               const Indices& indices,
-                               Eigen::Matrix3d& covariance_matrix,
-                               Eigen::Vector4d& centroid)
-{
-  return (computeMeanAndCovarianceMatrix<PointT, double>(
-      cloud, indices, covariance_matrix, centroid));
-}
-
-/** \brief Compute the normalized 3x3 covariance matrix and the centroid of a given set
- * of points in a single loop. Normalized means that every entry has been divided by the
- * number of entries in indices. For small number of points, or if you want explicitly
- * the sample-variance, scale the covariance matrix with n / (n-1), where n is the
- * number of points used to calculate the covariance matrix and is returned by this
- * function. \note This method is theoretically exact. However using float for internal
- * calculations reduces the accuracy but increases the efficiency. \param[in] cloud the
- * input point cloud \param[in] indices subset of points given by their indices
- * \param[out] centroid the centroid of the set of points in the cloud
- * \param[out] covariance_matrix the resultant 3x3 covariance matrix
- * \return number of valid points used to determine the covariance matrix.
- * In case of dense point clouds, this is the same as the size of input indices.
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                               const pcl::PointIndices& indices,
-                               Eigen::Matrix<Scalar, 3, 3>& covariance_matrix,
-                               Eigen::Matrix<Scalar, 4, 1>& centroid);
-
-template <typename PointT>
-inline unsigned int
-computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                               const pcl::PointIndices& indices,
-                               Eigen::Matrix3f& covariance_matrix,
-                               Eigen::Vector4f& centroid)
-{
-  return (computeMeanAndCovarianceMatrix<PointT, float>(
-      cloud, indices, covariance_matrix, centroid));
-}
-
-template <typename PointT>
-inline unsigned int
-computeMeanAndCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                               const pcl::PointIndices& indices,
-                               Eigen::Matrix3d& covariance_matrix,
-                               Eigen::Vector4d& centroid)
-{
-  return (computeMeanAndCovarianceMatrix<PointT, double>(
-      cloud, indices, covariance_matrix, centroid));
-}
-
-/** \brief Compute the normalized 3x3 covariance matrix for a already demeaned point
- * cloud. Normalized means that every entry has been divided by the number of entries in
- * the input point cloud. For small number of points, or if you want explicitly the
- * sample-variance, scale the covariance matrix with n / (n-1), where n is the number of
- * points used to calculate the covariance matrix and is returned by this function.
- * \note This method is theoretically exact. However using float for internal
- * calculations reduces the accuracy but increases the efficiency. \param[in] cloud the
- * input point cloud \param[out] covariance_matrix the resultant 3x3 covariance matrix
- * \return number of valid points used to determine the covariance matrix.
- * In case of dense point clouds, this is the same as the size of input cloud.
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        Eigen::Matrix3f& covariance_matrix)
-{
-  return (computeCovarianceMatrix<PointT, float>(cloud, covariance_matrix));
-}
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        Eigen::Matrix3d& covariance_matrix)
-{
-  return (computeCovarianceMatrix<PointT, double>(cloud, covariance_matrix));
-}
-
-/** \brief Compute the normalized 3x3 covariance matrix for a already demeaned point
- * cloud. Normalized means that every entry has been divided by the number of entries in
- * indices. For small number of points, or if you want explicitly the sample-variance,
- * scale the covariance matrix with n / (n-1), where n is the number of points used to
- * calculate the covariance matrix and is returned by this function. \note This method
- * is theoretically exact. However using float for internal calculations reduces the
- * accuracy but increases the efficiency. \param[in] cloud the input point cloud
- * \param[in] indices subset of points given by their indices
- * \param[out] covariance_matrix the resultant 3x3 covariance matrix
- * \return number of valid points used to determine the covariance matrix.
- * In case of dense point clouds, this is the same as the size of input indices.
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        const Indices& indices,
-                        Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        const Indices& indices,
-                        Eigen::Matrix3f& covariance_matrix)
-{
-  return (computeCovarianceMatrix<PointT, float>(cloud, indices, covariance_matrix));
-}
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        const Indices& indices,
-                        Eigen::Matrix3d& covariance_matrix)
-{
-  return (computeCovarianceMatrix<PointT, double>(cloud, indices, covariance_matrix));
-}
-
-/** \brief Compute the normalized 3x3 covariance matrix for a already demeaned point
- * cloud. Normalized means that every entry has been divided by the number of entries in
- * indices. For small number of points, or if you want explicitly the sample-variance,
- * scale the covariance matrix with n / (n-1), where n is the number of points used to
- * calculate the covariance matrix and is returned by this function. \note This method
- * is theoretically exact. However using float for internal calculations reduces the
- * accuracy but increases the efficiency. \param[in] cloud the input point cloud
- * \param[in] indices subset of points given by their indices
- * \param[out] covariance_matrix the resultant 3x3 covariance matrix
- * \return number of valid points used to determine the covariance matrix.
- * In case of dense point clouds, this is the same as the size of input indices.
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        const pcl::PointIndices& indices,
-                        Eigen::Matrix<Scalar, 3, 3>& covariance_matrix);
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        const pcl::PointIndices& indices,
-                        Eigen::Matrix3f& covariance_matrix)
-{
-  return (computeCovarianceMatrix<PointT, float>(cloud, indices, covariance_matrix));
-}
-
-template <typename PointT>
-inline unsigned int
-computeCovarianceMatrix(const pcl::PointCloud<PointT>& cloud,
-                        const pcl::PointIndices& indices,
-                        Eigen::Matrix3d& covariance_matrix)
-{
-  return (computeCovarianceMatrix<PointT, double>(cloud, indices, covariance_matrix));
-}
-
-/** \brief Subtract a centroid from a point cloud and return the de-meaned
- * representation \param[in] cloud_iterator an iterator over the input point cloud
- * \param[in] centroid the centroid of the point cloud
- * \param[out] cloud_out the resultant output point cloud
- * \param[in] npts the number of samples guaranteed to be left in the input cloud,
- * accessible by the iterator. If not given, it will be calculated. \ingroup common
- */
-template <typename PointT, typename Scalar>
-void
-demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
-                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
-                 pcl::PointCloud<PointT>& cloud_out,
-                 int npts = 0);
-
-template <typename PointT>
-void
-demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
-                 const Eigen::Vector4f& centroid,
-                 pcl::PointCloud<PointT>& cloud_out,
-                 int npts = 0)
-{
-  return (demeanPointCloud<PointT, float>(cloud_iterator, centroid, cloud_out, npts));
-}
-
-template <typename PointT>
-void
-demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
-                 const Eigen::Vector4d& centroid,
-                 pcl::PointCloud<PointT>& cloud_out,
-                 int npts = 0)
-{
-  return (demeanPointCloud<PointT, double>(cloud_iterator, centroid, cloud_out, npts));
-}
-
-/** \brief Subtract a centroid from a point cloud and return the de-meaned
- * representation \param[in] cloud_in the input point cloud \param[in] centroid the
- * centroid of the point cloud \param[out] cloud_out the resultant output point cloud
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
-                 pcl::PointCloud<PointT>& cloud_out);
-
-template <typename PointT>
-void
-demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
-                 const Eigen::Vector4f& centroid,
-                 pcl::PointCloud<PointT>& cloud_out)
-{
-  return (demeanPointCloud<PointT, float>(cloud_iterator, centroid, cloud_out));
-}
-
-template <typename PointT>
-void
-demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
-                 const Eigen::Vector4d& centroid,
-                 pcl::PointCloud<PointT>& cloud_out)
-{
-  return (demeanPointCloud<PointT, double>(cloud_iterator, centroid, cloud_out));
-}
-
-/** \brief Subtract a centroid from a point cloud and return the de-meaned
- * representation \param[in] cloud_in the input point cloud \param[in] indices the set
- * of point indices to use from the input point cloud \param[out] centroid the centroid
- * of the point cloud \param cloud_out the resultant output point cloud \ingroup common
- */
-template <typename PointT, typename Scalar>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const Indices& indices,
-                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
-                 pcl::PointCloud<PointT>& cloud_out);
-
-template <typename PointT>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const Indices& indices,
-                 const Eigen::Vector4f& centroid,
-                 pcl::PointCloud<PointT>& cloud_out)
-{
-  return (demeanPointCloud<PointT, float>(cloud_in, indices, centroid, cloud_out));
-}
-
-template <typename PointT>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const Indices& indices,
-                 const Eigen::Vector4d& centroid,
-                 pcl::PointCloud<PointT>& cloud_out)
-{
-  return (demeanPointCloud<PointT, double>(cloud_in, indices, centroid, cloud_out));
-}
-
-/** \brief Subtract a centroid from a point cloud and return the de-meaned
- * representation \param[in] cloud_in the input point cloud \param[in] indices the set
- * of point indices to use from the input point cloud \param[out] centroid the centroid
- * of the point cloud \param cloud_out the resultant output point cloud \ingroup common
- */
-template <typename PointT, typename Scalar>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const pcl::PointIndices& indices,
-                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
-                 pcl::PointCloud<PointT>& cloud_out);
-
-template <typename PointT>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const pcl::PointIndices& indices,
-                 const Eigen::Vector4f& centroid,
-                 pcl::PointCloud<PointT>& cloud_out)
-{
-  return (demeanPointCloud<PointT, float>(cloud_in, indices, centroid, cloud_out));
-}
-
-template <typename PointT>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const pcl::PointIndices& indices,
-                 const Eigen::Vector4d& centroid,
-                 pcl::PointCloud<PointT>& cloud_out)
-{
-  return (demeanPointCloud<PointT, double>(cloud_in, indices, centroid, cloud_out));
-}
-
-/** \brief Subtract a centroid from a point cloud and return the de-meaned
- * representation as an Eigen matrix
- * \param[in] cloud_iterator an iterator over the input point cloud
- * \param[in] centroid the centroid of the point cloud
- * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
- * an Eigen matrix (4 rows, N pts columns)
- * \param[in] npts the number of samples guaranteed to be left in the input cloud,
- * accessible by the iterator. If not given, it will be calculated. \ingroup common
- */
-template <typename PointT, typename Scalar>
-void
-demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
-                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
-                 Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>& cloud_out,
-                 int npts = 0);
-
-template <typename PointT>
-void
-demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
-                 const Eigen::Vector4f& centroid,
-                 Eigen::MatrixXf& cloud_out,
-                 int npts = 0)
-{
-  return (demeanPointCloud<PointT, float>(cloud_iterator, centroid, cloud_out, npts));
-}
-
-template <typename PointT>
-void
-demeanPointCloud(ConstCloudIterator<PointT>& cloud_iterator,
-                 const Eigen::Vector4d& centroid,
-                 Eigen::MatrixXd& cloud_out,
-                 int npts = 0)
-{
-  return (demeanPointCloud<PointT, double>(cloud_iterator, centroid, cloud_out, npts));
-}
-
-/** \brief Subtract a centroid from a point cloud and return the de-meaned
- * representation as an Eigen matrix
- * \param[in] cloud_in the input point cloud
- * \param[in] centroid the centroid of the point cloud
- * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
- * an Eigen matrix (4 rows, N pts columns)
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
-                 Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>& cloud_out);
-
-template <typename PointT>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const Eigen::Vector4f& centroid,
-                 Eigen::MatrixXf& cloud_out)
-{
-  return (demeanPointCloud<PointT, float>(cloud_in, centroid, cloud_out));
-}
-
-template <typename PointT>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const Eigen::Vector4d& centroid,
-                 Eigen::MatrixXd& cloud_out)
-{
-  return (demeanPointCloud<PointT, double>(cloud_in, centroid, cloud_out));
-}
-
-/** \brief Subtract a centroid from a point cloud and return the de-meaned
- * representation as an Eigen matrix
- * \param[in] cloud_in the input point cloud
- * \param[in] indices the set of point indices to use from the input point cloud
- * \param[in] centroid the centroid of the point cloud
- * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
- * an Eigen matrix (4 rows, N pts columns)
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const Indices& indices,
-                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
-                 Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>& cloud_out);
-
-template <typename PointT>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const Indices& indices,
-                 const Eigen::Vector4f& centroid,
-                 Eigen::MatrixXf& cloud_out)
-{
-  return (demeanPointCloud<PointT, float>(cloud_in, indices, centroid, cloud_out));
-}
-
-template <typename PointT>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const Indices& indices,
-                 const Eigen::Vector4d& centroid,
-                 Eigen::MatrixXd& cloud_out)
-{
-  return (demeanPointCloud<PointT, double>(cloud_in, indices, centroid, cloud_out));
-}
-
-/** \brief Subtract a centroid from a point cloud and return the de-meaned
- * representation as an Eigen matrix
- * \param[in] cloud_in the input point cloud
- * \param[in] indices the set of point indices to use from the input point cloud
- * \param[in] centroid the centroid of the point cloud
- * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
- * an Eigen matrix (4 rows, N pts columns)
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const pcl::PointIndices& indices,
-                 const Eigen::Matrix<Scalar, 4, 1>& centroid,
-                 Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic>& cloud_out);
-
-template <typename PointT>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const pcl::PointIndices& indices,
-                 const Eigen::Vector4f& centroid,
-                 Eigen::MatrixXf& cloud_out)
-{
-  return (demeanPointCloud<PointT, float>(cloud_in, indices, centroid, cloud_out));
-}
-
-template <typename PointT>
-void
-demeanPointCloud(const pcl::PointCloud<PointT>& cloud_in,
-                 const pcl::PointIndices& indices,
-                 const Eigen::Vector4d& centroid,
-                 Eigen::MatrixXd& cloud_out)
-{
-  return (demeanPointCloud<PointT, double>(cloud_in, indices, centroid, cloud_out));
-}
-
-/** \brief Helper functor structure for n-D centroid estimation. */
-template <typename PointT, typename Scalar>
-struct NdCentroidFunctor {
-  using Pod = typename traits::POD<PointT>::type;
-
-  NdCentroidFunctor(const PointT& p, Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& centroid)
-  : centroid_(centroid), p_(reinterpret_cast<const Pod&>(p))
-  {}
-
-  template <typename Key>
-  inline void
-  operator()()
+  /** \brief Compute the 3D (X-Y-Z) centroid of a set of points and return it as a 3D vector.
+    * \param[in] cloud_iterator an iterator over the input point cloud
+    * \param[out] centroid the output centroid
+    * \return number of valid points used to determine the centroid. In case of dense point clouds, this is the same as the size of input cloud.
+    * \note if return value is 0, the centroid is not changed, thus not valid.
+    * The last component of the vector is set to 1, this allows to transform the centroid vector with 4x4 matrices.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  compute3DCentroid (ConstCloudIterator<PointT> &cloud_iterator,
+                     Eigen::Matrix<Scalar, 4, 1> &centroid);
+
+  template <typename PointT> inline unsigned int
+  compute3DCentroid (ConstCloudIterator<PointT> &cloud_iterator,
+                     Eigen::Vector4f &centroid)
   {
-    using T = typename pcl::traits::datatype<PointT, Key>::type;
-    const std::uint8_t* raw_ptr = reinterpret_cast<const std::uint8_t*>(&p_) +
-                                  pcl::traits::offset<PointT, Key>::value;
-    const T* data_ptr = reinterpret_cast<const T*>(raw_ptr);
-
-    // Check if the value is invalid
-    if (!std::isfinite(*data_ptr)) {
-      f_idx_++;
-      return;
-    }
-
-    centroid_[f_idx_++] += *data_ptr;
+    return (compute3DCentroid <PointT, float> (cloud_iterator, centroid));
   }
 
-private:
-  int f_idx_{0};
-  Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& centroid_;
-  const Pod& p_;
-};
+  template <typename PointT> inline unsigned int
+  compute3DCentroid (ConstCloudIterator<PointT> &cloud_iterator,
+                     Eigen::Vector4d &centroid)
+  {
+    return (compute3DCentroid <PointT, double> (cloud_iterator, centroid));
+  }
 
-/** \brief General, all purpose nD centroid estimation for a set of points using their
- * indices.
- * \param cloud the input point cloud
- * \param centroid the output centroid
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline void
-computeNDCentroid(const pcl::PointCloud<PointT>& cloud,
-                  Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& centroid);
+  /** \brief Compute the 3D (X-Y-Z) centroid of a set of points and return it as a 3D vector.
+    * \param[in] cloud the input point cloud
+    * \param[out] centroid the output centroid
+    * \return number of valid points used to determine the centroid. In case of dense point clouds, this is the same as the size of input cloud.
+    * \note if return value is 0, the centroid is not changed, thus not valid.
+    * The last component of the vector is set to 1, this allows to transform the centroid vector with 4x4 matrices.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
+                     Eigen::Matrix<Scalar, 4, 1> &centroid);
 
-template <typename PointT>
-inline void
-computeNDCentroid(const pcl::PointCloud<PointT>& cloud, Eigen::VectorXf& centroid)
-{
-  return (computeNDCentroid<PointT, float>(cloud, centroid));
+  template <typename PointT> inline unsigned int
+  compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
+                     Eigen::Vector4f &centroid)
+  {
+    return (compute3DCentroid <PointT, float> (cloud, centroid));
+  }
+
+  template <typename PointT> inline unsigned int
+  compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
+                     Eigen::Vector4d &centroid)
+  {
+    return (compute3DCentroid <PointT, double> (cloud, centroid));
+  }
+
+  /** \brief Compute the 3D (X-Y-Z) centroid of a set of points using their indices and
+    * return it as a 3D vector.
+    * \param[in] cloud the input point cloud
+    * \param[in] indices the point cloud indices that need to be used
+    * \param[out] centroid the output centroid
+    * \return number of valid points used to determine the centroid. In case of dense point clouds, this is the same as the size of input indices.
+    * \note if return value is 0, the centroid is not changed, thus not valid.
+    * The last component of the vector is set to 1, this allows to transform the centroid vector with 4x4 matrices.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
+                     const Indices &indices,
+                     Eigen::Matrix<Scalar, 4, 1> &centroid);
+
+  template <typename PointT> inline unsigned int
+  compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
+                     const Indices &indices,
+                     Eigen::Vector4f &centroid)
+  {
+    return (compute3DCentroid <PointT, float> (cloud, indices, centroid));
+  }
+
+  template <typename PointT> inline unsigned int
+  compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
+                     const Indices &indices,
+                     Eigen::Vector4d &centroid)
+  {
+    return (compute3DCentroid <PointT, double> (cloud, indices, centroid));
+  }
+
+  /** \brief Compute the 3D (X-Y-Z) centroid of a set of points using their indices and
+    * return it as a 3D vector.
+    * \param[in] cloud the input point cloud
+    * \param[in] indices the point cloud indices that need to be used
+    * \param[out] centroid the output centroid
+    * \return number of valid points used to determine the centroid. In case of dense point clouds, this is the same as the size of input indices.
+    * \note if return value is 0, the centroid is not changed, thus not valid.
+    * The last component of the vector is set to 1, this allows to transform the centroid vector with 4x4 matrices.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
+                     const pcl::PointIndices &indices,
+                     Eigen::Matrix<Scalar, 4, 1> &centroid);
+
+  template <typename PointT> inline unsigned int
+  compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
+                     const pcl::PointIndices &indices,
+                     Eigen::Vector4f &centroid)
+  {
+    return (compute3DCentroid <PointT, float> (cloud, indices, centroid));
+  }
+
+  template <typename PointT> inline unsigned int
+  compute3DCentroid (const pcl::PointCloud<PointT> &cloud,
+                     const pcl::PointIndices &indices,
+                     Eigen::Vector4d &centroid)
+  {
+    return (compute3DCentroid <PointT, double> (cloud, indices, centroid));
+  }
+
+  /** \brief Compute the 3x3 covariance matrix of a given set of points.
+    * The result is returned as a Eigen::Matrix3f.
+    * Note: the covariance matrix is not normalized with the number of
+    * points. For a normalized covariance, please use
+    * computeCovarianceMatrixNormalized.
+    * \param[in] cloud the input point cloud
+    * \param[in] centroid the centroid of the set of points in the cloud
+    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+    * \return number of valid points used to determine the covariance matrix.
+    * In case of dense point clouds, this is the same as the size of input cloud.
+    * \note if return value is 0, the covariance matrix is not changed, thus not valid.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                           Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           const Eigen::Vector4f &centroid,
+                           Eigen::Matrix3f &covariance_matrix)
+  {
+    return (computeCovarianceMatrix<PointT, float> (cloud, centroid, covariance_matrix));
+  }
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           const Eigen::Vector4d &centroid,
+                           Eigen::Matrix3d &covariance_matrix)
+  {
+    return (computeCovarianceMatrix<PointT, double> (cloud, centroid, covariance_matrix));
+  }
+
+  /** \brief Compute normalized the 3x3 covariance matrix of a given set of points.
+    * The result is returned as a Eigen::Matrix3f.
+    * Normalized means that every entry has been divided by the number of points in the point cloud.
+    * For small number of points, or if you want explicitly the sample-variance, use computeCovarianceMatrix
+    * and scale the covariance matrix with 1 / (n-1), where n is the number of points used to calculate
+    * the covariance matrix and is returned by the computeCovarianceMatrix function.
+    * \param[in] cloud the input point cloud
+    * \param[in] centroid the centroid of the set of points in the cloud
+    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+    * \return number of valid points used to determine the covariance matrix.
+    * In case of dense point clouds, this is the same as the size of input cloud.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
+                                     const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                                     Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
+                                     const Eigen::Vector4f &centroid,
+                                     Eigen::Matrix3f &covariance_matrix)
+  {
+    return (computeCovarianceMatrixNormalized<PointT, float> (cloud, centroid, covariance_matrix));
+  }
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
+                                     const Eigen::Vector4d &centroid,
+                                     Eigen::Matrix3d &covariance_matrix)
+  {
+    return (computeCovarianceMatrixNormalized<PointT, double> (cloud, centroid, covariance_matrix));
+  }
+
+  /** \brief Compute the 3x3 covariance matrix of a given set of points using their indices.
+    * The result is returned as a Eigen::Matrix3f.
+    * Note: the covariance matrix is not normalized with the number of
+    * points. For a normalized covariance, please use
+    * computeCovarianceMatrixNormalized.
+    * \param[in] cloud the input point cloud
+    * \param[in] indices the point cloud indices that need to be used
+    * \param[in] centroid the centroid of the set of points in the cloud
+    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+    * \return number of valid points used to determine the covariance matrix.
+    * In case of dense point clouds, this is the same as the size of input indices.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           const Indices &indices,
+                           const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                           Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           const Indices &indices,
+                           const Eigen::Vector4f &centroid,
+                           Eigen::Matrix3f &covariance_matrix)
+  {
+    return (computeCovarianceMatrix<PointT, float> (cloud, indices, centroid, covariance_matrix));
+  }
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           const Indices &indices,
+                           const Eigen::Vector4d &centroid,
+                           Eigen::Matrix3d &covariance_matrix)
+  {
+    return (computeCovarianceMatrix<PointT, double> (cloud, indices, centroid, covariance_matrix));
+  }
+
+  /** \brief Compute the 3x3 covariance matrix of a given set of points using their indices.
+    * The result is returned as a Eigen::Matrix3f.
+    * Note: the covariance matrix is not normalized with the number of
+    * points. For a normalized covariance, please use
+    * computeCovarianceMatrixNormalized.
+    * \param[in] cloud the input point cloud
+    * \param[in] indices the point cloud indices that need to be used
+    * \param[in] centroid the centroid of the set of points in the cloud
+    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+    * \return number of valid points used to determine the covariance matrix.
+    * In case of dense point clouds, this is the same as the size of input indices.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           const pcl::PointIndices &indices,
+                           const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                           Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           const pcl::PointIndices &indices,
+                           const Eigen::Vector4f &centroid,
+                           Eigen::Matrix3f &covariance_matrix)
+  {
+    return (computeCovarianceMatrix<PointT, float> (cloud, indices, centroid, covariance_matrix));
+  }
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           const pcl::PointIndices &indices,
+                           const Eigen::Vector4d &centroid,
+                           Eigen::Matrix3d &covariance_matrix)
+  {
+    return (computeCovarianceMatrix<PointT, double> (cloud, indices, centroid, covariance_matrix));
+  }
+
+  /** \brief Compute the normalized 3x3 covariance matrix of a given set of points using
+    * their indices.
+    * The result is returned as a Eigen::Matrix3f.
+    * Normalized means that every entry has been divided by the number of entries in indices.
+    * For small number of points, or if you want explicitly the sample-variance, use computeCovarianceMatrix
+    * and scale the covariance matrix with 1 / (n-1), where n is the number of points used to calculate
+    * the covariance matrix and is returned by the computeCovarianceMatrix function.
+    * \param[in] cloud the input point cloud
+    * \param[in] indices the point cloud indices that need to be used
+    * \param[in] centroid the centroid of the set of points in the cloud
+    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+    * \return number of valid points used to determine the covariance matrix.
+    * In case of dense point clouds, this is the same as the size of input indices.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
+                                     const Indices &indices,
+                                     const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                                     Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
+                                     const Indices &indices,
+                                     const Eigen::Vector4f &centroid,
+                                     Eigen::Matrix3f &covariance_matrix)
+  {
+    return (computeCovarianceMatrixNormalized<PointT, float> (cloud, indices, centroid, covariance_matrix));
+  }
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
+                                     const Indices &indices,
+                                     const Eigen::Vector4d &centroid,
+                                     Eigen::Matrix3d &covariance_matrix)
+  {
+    return (computeCovarianceMatrixNormalized<PointT, double> (cloud, indices, centroid, covariance_matrix));
+  }
+
+  /** \brief Compute the normalized 3x3 covariance matrix of a given set of points using
+    * their indices. The result is returned as a Eigen::Matrix3f.
+    * Normalized means that every entry has been divided by the number of entries in indices.
+    * For small number of points, or if you want explicitly the sample-variance, use computeCovarianceMatrix
+    * and scale the covariance matrix with 1 / (n-1), where n is the number of points used to calculate
+    * the covariance matrix and is returned by the computeCovarianceMatrix function.
+    * \param[in] cloud the input point cloud
+    * \param[in] indices the point cloud indices that need to be used
+    * \param[in] centroid the centroid of the set of points in the cloud
+    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+    * \return number of valid points used to determine the covariance matrix.
+    * In case of dense point clouds, this is the same as the size of input indices.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
+                                     const pcl::PointIndices &indices,
+                                     const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                                     Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
+                                     const pcl::PointIndices &indices,
+                                     const Eigen::Vector4f &centroid,
+                                     Eigen::Matrix3f &covariance_matrix)
+  {
+    return (computeCovarianceMatrixNormalized<PointT, float> (cloud, indices, centroid, covariance_matrix));
+  }
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrixNormalized (const pcl::PointCloud<PointT> &cloud,
+                                     const pcl::PointIndices &indices,
+                                     const Eigen::Vector4d &centroid,
+                                     Eigen::Matrix3d &covariance_matrix)
+  {
+    return (computeCovarianceMatrixNormalized<PointT, double> (cloud, indices, centroid, covariance_matrix));
+  }
+
+  /** \brief Compute the normalized 3x3 covariance matrix and the centroid of a given set of points in a single loop.
+    * Normalized means that every entry has been divided by the number of valid entries in the point cloud.
+    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
+    * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
+    * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
+    * \param[in] cloud the input point cloud
+    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+    * \param[out] centroid the centroid of the set of points in the cloud
+    * \return number of valid points used to determine the covariance matrix.
+    * In case of dense point clouds, this is the same as the size of input cloud.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                                  Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
+                                  Eigen::Matrix<Scalar, 4, 1> &centroid);
+
+  template <typename PointT> inline unsigned int
+  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                                  Eigen::Matrix3f &covariance_matrix,
+                                  Eigen::Vector4f &centroid)
+  {
+    return (computeMeanAndCovarianceMatrix<PointT, float> (cloud, covariance_matrix, centroid));
+  }
+
+  template <typename PointT> inline unsigned int
+  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                                  Eigen::Matrix3d &covariance_matrix,
+                                  Eigen::Vector4d &centroid)
+  {
+    return (computeMeanAndCovarianceMatrix<PointT, double> (cloud, covariance_matrix, centroid));
+  }
+
+  /** \brief Compute the normalized 3x3 covariance matrix and the centroid of a given set of points in a single loop.
+    * Normalized means that every entry has been divided by the number of entries in indices.
+    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
+    * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
+    * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
+    * \param[in] cloud the input point cloud
+    * \param[in] indices subset of points given by their indices
+    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+    * \param[out] centroid the centroid of the set of points in the cloud
+    * \return number of valid points used to determine the covariance matrix.
+    * In case of dense point clouds, this is the same as the size of input indices.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                                  const Indices &indices,
+                                  Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
+                                  Eigen::Matrix<Scalar, 4, 1> &centroid);
+
+  template <typename PointT> inline unsigned int
+  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                                  const Indices &indices,
+                                  Eigen::Matrix3f &covariance_matrix,
+                                  Eigen::Vector4f &centroid)
+  {
+    return (computeMeanAndCovarianceMatrix<PointT, float> (cloud, indices, covariance_matrix, centroid));
+  }
+
+  template <typename PointT> inline unsigned int
+  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                                  const Indices &indices,
+                                  Eigen::Matrix3d &covariance_matrix,
+                                  Eigen::Vector4d &centroid)
+  {
+    return (computeMeanAndCovarianceMatrix<PointT, double> (cloud, indices, covariance_matrix, centroid));
+  }
+
+  /** \brief Compute the normalized 3x3 covariance matrix and the centroid of a given set of points in a single loop.
+    * Normalized means that every entry has been divided by the number of entries in indices.
+    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
+    * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
+    * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
+    * \param[in] cloud the input point cloud
+    * \param[in] indices subset of points given by their indices
+    * \param[out] centroid the centroid of the set of points in the cloud
+    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+    * \return number of valid points used to determine the covariance matrix.
+    * In case of dense point clouds, this is the same as the size of input indices.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                                  const pcl::PointIndices &indices,
+                                  Eigen::Matrix<Scalar, 3, 3> &covariance_matrix,
+                                  Eigen::Matrix<Scalar, 4, 1> &centroid);
+
+  template <typename PointT> inline unsigned int
+  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                                  const pcl::PointIndices &indices,
+                                  Eigen::Matrix3f &covariance_matrix,
+                                  Eigen::Vector4f &centroid)
+  {
+    return (computeMeanAndCovarianceMatrix<PointT, float> (cloud, indices, covariance_matrix, centroid));
+  }
+
+  template <typename PointT> inline unsigned int
+  computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                                  const pcl::PointIndices &indices,
+                                  Eigen::Matrix3d &covariance_matrix,
+                                  Eigen::Vector4d &centroid)
+  {
+    return (computeMeanAndCovarianceMatrix<PointT, double> (cloud, indices, covariance_matrix, centroid));
+  }
+
+  /** \brief Compute the normalized 3x3 covariance matrix for a already demeaned point cloud.
+    * Normalized means that every entry has been divided by the number of entries in the input point cloud.
+    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
+    * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
+    * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
+    * \param[in] cloud the input point cloud
+    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+    * \return number of valid points used to determine the covariance matrix.
+    * In case of dense point clouds, this is the same as the size of input cloud.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           Eigen::Matrix3f &covariance_matrix)
+  {
+    return (computeCovarianceMatrix<PointT, float> (cloud, covariance_matrix));
+  }
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           Eigen::Matrix3d &covariance_matrix)
+  {
+    return (computeCovarianceMatrix<PointT, double> (cloud, covariance_matrix));
+  }
+
+  /** \brief Compute the normalized 3x3 covariance matrix for a already demeaned point cloud.
+    * Normalized means that every entry has been divided by the number of entries in indices.
+    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
+    * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
+    * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
+    * \param[in] cloud the input point cloud
+    * \param[in] indices subset of points given by their indices
+    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+    * \return number of valid points used to determine the covariance matrix.
+    * In case of dense point clouds, this is the same as the size of input indices.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           const Indices &indices,
+                           Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           const Indices &indices,
+                           Eigen::Matrix3f &covariance_matrix)
+  {
+    return (computeCovarianceMatrix<PointT, float> (cloud, indices, covariance_matrix));
+  }
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           const Indices &indices,
+                           Eigen::Matrix3d &covariance_matrix)
+  {
+    return (computeCovarianceMatrix<PointT, double> (cloud, indices, covariance_matrix));
+  }
+
+  /** \brief Compute the normalized 3x3 covariance matrix for a already demeaned point cloud.
+    * Normalized means that every entry has been divided by the number of entries in indices.
+    * For small number of points, or if you want explicitly the sample-variance, scale the covariance matrix
+    * with n / (n-1), where n is the number of points used to calculate the covariance matrix and is returned by this function.
+    * \note This method is theoretically exact. However using float for internal calculations reduces the accuracy but increases the efficiency.
+    * \param[in] cloud the input point cloud
+    * \param[in] indices subset of points given by their indices
+    * \param[out] covariance_matrix the resultant 3x3 covariance matrix
+    * \return number of valid points used to determine the covariance matrix.
+    * In case of dense point clouds, this is the same as the size of input indices.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           const pcl::PointIndices &indices,
+                           Eigen::Matrix<Scalar, 3, 3> &covariance_matrix);
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           const pcl::PointIndices &indices,
+                           Eigen::Matrix3f &covariance_matrix)
+  {
+    return (computeCovarianceMatrix<PointT, float> (cloud, indices, covariance_matrix));
+  }
+
+  template <typename PointT> inline unsigned int
+  computeCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
+                           const pcl::PointIndices &indices,
+                           Eigen::Matrix3d &covariance_matrix)
+  {
+    return (computeCovarianceMatrix<PointT, double> (cloud, indices, covariance_matrix));
+  }
+
+  /** \brief Subtract a centroid from a point cloud and return the de-meaned representation
+    * \param[in] cloud_iterator an iterator over the input point cloud
+    * \param[in] centroid the centroid of the point cloud
+    * \param[out] cloud_out the resultant output point cloud
+    * \param[in] npts the number of samples guaranteed to be left in the input cloud, accessible by the iterator. If not given, it will be calculated.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> void
+  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
+                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                    pcl::PointCloud<PointT> &cloud_out,
+                    int npts = 0);
+
+  template <typename PointT> void
+  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
+                    const Eigen::Vector4f &centroid,
+                    pcl::PointCloud<PointT> &cloud_out,
+                    int npts = 0)
+  {
+    return (demeanPointCloud<PointT, float> (cloud_iterator, centroid, cloud_out, npts));
+  }
+
+  template <typename PointT> void
+  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
+                    const Eigen::Vector4d &centroid,
+                    pcl::PointCloud<PointT> &cloud_out,
+                    int npts = 0)
+  {
+    return (demeanPointCloud<PointT, double> (cloud_iterator, centroid, cloud_out, npts));
+  }
+
+  /** \brief Subtract a centroid from a point cloud and return the de-meaned representation
+    * \param[in] cloud_in the input point cloud
+    * \param[in] centroid the centroid of the point cloud
+    * \param[out] cloud_out the resultant output point cloud
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                    pcl::PointCloud<PointT> &cloud_out);
+
+  template <typename PointT> void
+  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
+                    const Eigen::Vector4f &centroid,
+                    pcl::PointCloud<PointT> &cloud_out)
+  {
+    return (demeanPointCloud<PointT, float> (cloud_iterator, centroid, cloud_out));
+  }
+
+  template <typename PointT> void
+  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
+                    const Eigen::Vector4d &centroid,
+                    pcl::PointCloud<PointT> &cloud_out)
+  {
+    return (demeanPointCloud<PointT, double> (cloud_iterator, centroid, cloud_out));
+  }
+
+  /** \brief Subtract a centroid from a point cloud and return the de-meaned representation
+    * \param[in] cloud_in the input point cloud
+    * \param[in] indices the set of point indices to use from the input point cloud
+    * \param[out] centroid the centroid of the point cloud
+    * \param cloud_out the resultant output point cloud
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const Indices &indices,
+                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                    pcl::PointCloud<PointT> &cloud_out);
+
+  template <typename PointT> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const Indices &indices,
+                    const Eigen::Vector4f &centroid,
+                    pcl::PointCloud<PointT> &cloud_out)
+  {
+    return (demeanPointCloud<PointT, float> (cloud_in, indices, centroid, cloud_out));
+  }
+
+  template <typename PointT> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const Indices &indices,
+                    const Eigen::Vector4d &centroid,
+                    pcl::PointCloud<PointT> &cloud_out)
+  {
+    return (demeanPointCloud<PointT, double> (cloud_in, indices, centroid, cloud_out));
+  }
+
+  /** \brief Subtract a centroid from a point cloud and return the de-meaned representation
+    * \param[in] cloud_in the input point cloud
+    * \param[in] indices the set of point indices to use from the input point cloud
+    * \param[out] centroid the centroid of the point cloud
+    * \param cloud_out the resultant output point cloud
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const pcl::PointIndices& indices,
+                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                    pcl::PointCloud<PointT> &cloud_out);
+
+  template <typename PointT> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const pcl::PointIndices& indices,
+                    const Eigen::Vector4f &centroid,
+                    pcl::PointCloud<PointT> &cloud_out)
+  {
+    return (demeanPointCloud<PointT, float> (cloud_in, indices, centroid, cloud_out));
+  }
+
+  template <typename PointT> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const pcl::PointIndices& indices,
+                    const Eigen::Vector4d &centroid,
+                    pcl::PointCloud<PointT> &cloud_out)
+  {
+    return (demeanPointCloud<PointT, double> (cloud_in, indices, centroid, cloud_out));
+  }
+
+  /** \brief Subtract a centroid from a point cloud and return the de-meaned
+    * representation as an Eigen matrix
+    * \param[in] cloud_iterator an iterator over the input point cloud
+    * \param[in] centroid the centroid of the point cloud
+    * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
+    * an Eigen matrix (4 rows, N pts columns)
+    * \param[in] npts the number of samples guaranteed to be left in the input cloud, accessible by the iterator. If not given, it will be calculated.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> void
+  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
+                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                    Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out,
+                    int npts = 0);
+
+  template <typename PointT> void
+  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
+                    const Eigen::Vector4f &centroid,
+                    Eigen::MatrixXf &cloud_out,
+                    int npts = 0)
+  {
+    return (demeanPointCloud<PointT, float> (cloud_iterator, centroid, cloud_out, npts));
+  }
+
+  template <typename PointT> void
+  demeanPointCloud (ConstCloudIterator<PointT> &cloud_iterator,
+                    const Eigen::Vector4d &centroid,
+                    Eigen::MatrixXd &cloud_out,
+                    int npts = 0)
+  {
+    return (demeanPointCloud<PointT, double> (cloud_iterator, centroid, cloud_out, npts));
+  }
+
+  /** \brief Subtract a centroid from a point cloud and return the de-meaned
+    * representation as an Eigen matrix
+    * \param[in] cloud_in the input point cloud
+    * \param[in] centroid the centroid of the point cloud
+    * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
+    * an Eigen matrix (4 rows, N pts columns)
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                    Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out);
+
+  template <typename PointT> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const Eigen::Vector4f &centroid,
+                    Eigen::MatrixXf &cloud_out)
+  {
+    return (demeanPointCloud<PointT, float> (cloud_in, centroid, cloud_out));
+  }
+
+  template <typename PointT> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const Eigen::Vector4d &centroid,
+                    Eigen::MatrixXd &cloud_out)
+  {
+    return (demeanPointCloud<PointT, double> (cloud_in, centroid, cloud_out));
+  }
+
+  /** \brief Subtract a centroid from a point cloud and return the de-meaned
+    * representation as an Eigen matrix
+    * \param[in] cloud_in the input point cloud
+    * \param[in] indices the set of point indices to use from the input point cloud
+    * \param[in] centroid the centroid of the point cloud
+    * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
+    * an Eigen matrix (4 rows, N pts columns)
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const Indices &indices,
+                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                    Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out);
+
+  template <typename PointT> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const Indices &indices,
+                    const Eigen::Vector4f &centroid,
+                    Eigen::MatrixXf &cloud_out)
+  {
+    return (demeanPointCloud<PointT, float> (cloud_in, indices, centroid, cloud_out));
+  }
+
+  template <typename PointT> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const Indices &indices,
+                    const Eigen::Vector4d &centroid,
+                    Eigen::MatrixXd &cloud_out)
+  {
+    return (demeanPointCloud<PointT, double> (cloud_in, indices, centroid, cloud_out));
+  }
+
+  /** \brief Subtract a centroid from a point cloud and return the de-meaned
+    * representation as an Eigen matrix
+    * \param[in] cloud_in the input point cloud
+    * \param[in] indices the set of point indices to use from the input point cloud
+    * \param[in] centroid the centroid of the point cloud
+    * \param[out] cloud_out the resultant output XYZ0 dimensions of \a cloud_in as
+    * an Eigen matrix (4 rows, N pts columns)
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const pcl::PointIndices& indices,
+                    const Eigen::Matrix<Scalar, 4, 1> &centroid,
+                    Eigen::Matrix<Scalar, Eigen::Dynamic, Eigen::Dynamic> &cloud_out);
+
+  template <typename PointT> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const pcl::PointIndices& indices,
+                    const Eigen::Vector4f &centroid,
+                    Eigen::MatrixXf &cloud_out)
+  {
+    return (demeanPointCloud<PointT, float> (cloud_in, indices, centroid, cloud_out));
+  }
+
+  template <typename PointT> void
+  demeanPointCloud (const pcl::PointCloud<PointT> &cloud_in,
+                    const pcl::PointIndices& indices,
+                    const Eigen::Vector4d &centroid,
+                    Eigen::MatrixXd &cloud_out)
+  {
+    return (demeanPointCloud<PointT, double> (cloud_in, indices, centroid, cloud_out));
+  }
+
+  /** \brief Helper functor structure for n-D centroid estimation. */
+  template<typename PointT, typename Scalar>
+  struct NdCentroidFunctor
+  {
+    using Pod = typename traits::POD<PointT>::type;
+
+    NdCentroidFunctor (const PointT &p, Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid)
+      : centroid_ (centroid),
+        p_ (reinterpret_cast<const Pod&>(p)) { }
+
+    template<typename Key> inline void operator() ()
+    {
+      using T = typename pcl::traits::datatype<PointT, Key>::type;
+      const std::uint8_t* raw_ptr = reinterpret_cast<const std::uint8_t*>(&p_) + pcl::traits::offset<PointT, Key>::value;
+      const T* data_ptr = reinterpret_cast<const T*>(raw_ptr);
+
+      // Check if the value is invalid
+      if (!std::isfinite (*data_ptr))
+      {
+        f_idx_++;
+        return;
+      }
+
+      centroid_[f_idx_++] += *data_ptr;
+    }
+
+    private:
+      int f_idx_{0};
+      Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid_;
+      const Pod &p_;
+  };
+
+  /** \brief General, all purpose nD centroid estimation for a set of points using their
+    * indices.
+    * \param cloud the input point cloud
+    * \param centroid the output centroid
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline void
+  computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
+                     Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid);
+
+  template <typename PointT> inline void
+  computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
+                     Eigen::VectorXf &centroid)
+  {
+    return (computeNDCentroid<PointT, float> (cloud, centroid));
+  }
+
+  template <typename PointT> inline void
+  computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
+                     Eigen::VectorXd &centroid)
+  {
+    return (computeNDCentroid<PointT, double> (cloud, centroid));
+  }
+
+  /** \brief General, all purpose nD centroid estimation for a set of points using their
+    * indices.
+    * \param cloud the input point cloud
+    * \param indices the point cloud indices that need to be used
+    * \param centroid the output centroid
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline void
+  computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
+                     const Indices &indices,
+                     Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid);
+
+  template <typename PointT> inline void
+  computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
+                     const Indices &indices,
+                     Eigen::VectorXf &centroid)
+  {
+    return (computeNDCentroid<PointT, float> (cloud, indices, centroid));
+  }
+
+  template <typename PointT> inline void
+  computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
+                     const Indices &indices,
+                     Eigen::VectorXd &centroid)
+  {
+    return (computeNDCentroid<PointT, double> (cloud, indices, centroid));
+  }
+
+  /** \brief General, all purpose nD centroid estimation for a set of points using their
+    * indices.
+    * \param cloud the input point cloud
+    * \param indices the point cloud indices that need to be used
+    * \param centroid the output centroid
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline void
+  computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
+                     const pcl::PointIndices &indices,
+                     Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &centroid);
+
+  template <typename PointT> inline void
+  computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
+                     const pcl::PointIndices &indices,
+                     Eigen::VectorXf &centroid)
+  {
+    return (computeNDCentroid<PointT, float> (cloud, indices, centroid));
+  }
+
+  template <typename PointT> inline void
+  computeNDCentroid (const pcl::PointCloud<PointT> &cloud,
+                     const pcl::PointIndices &indices,
+                     Eigen::VectorXd &centroid)
+  {
+    return (computeNDCentroid<PointT, double> (cloud, indices, centroid));
+  }
+
 }
-
-template <typename PointT>
-inline void
-computeNDCentroid(const pcl::PointCloud<PointT>& cloud, Eigen::VectorXd& centroid)
-{
-  return (computeNDCentroid<PointT, double>(cloud, centroid));
-}
-
-/** \brief General, all purpose nD centroid estimation for a set of points using their
- * indices.
- * \param cloud the input point cloud
- * \param indices the point cloud indices that need to be used
- * \param centroid the output centroid
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline void
-computeNDCentroid(const pcl::PointCloud<PointT>& cloud,
-                  const Indices& indices,
-                  Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& centroid);
-
-template <typename PointT>
-inline void
-computeNDCentroid(const pcl::PointCloud<PointT>& cloud,
-                  const Indices& indices,
-                  Eigen::VectorXf& centroid)
-{
-  return (computeNDCentroid<PointT, float>(cloud, indices, centroid));
-}
-
-template <typename PointT>
-inline void
-computeNDCentroid(const pcl::PointCloud<PointT>& cloud,
-                  const Indices& indices,
-                  Eigen::VectorXd& centroid)
-{
-  return (computeNDCentroid<PointT, double>(cloud, indices, centroid));
-}
-
-/** \brief General, all purpose nD centroid estimation for a set of points using their
- * indices.
- * \param cloud the input point cloud
- * \param indices the point cloud indices that need to be used
- * \param centroid the output centroid
- * \ingroup common
- */
-template <typename PointT, typename Scalar>
-inline void
-computeNDCentroid(const pcl::PointCloud<PointT>& cloud,
-                  const pcl::PointIndices& indices,
-                  Eigen::Matrix<Scalar, Eigen::Dynamic, 1>& centroid);
-
-template <typename PointT>
-inline void
-computeNDCentroid(const pcl::PointCloud<PointT>& cloud,
-                  const pcl::PointIndices& indices,
-                  Eigen::VectorXf& centroid)
-{
-  return (computeNDCentroid<PointT, float>(cloud, indices, centroid));
-}
-
-template <typename PointT>
-inline void
-computeNDCentroid(const pcl::PointCloud<PointT>& cloud,
-                  const pcl::PointIndices& indices,
-                  Eigen::VectorXd& centroid)
-{
-  return (computeNDCentroid<PointT, double>(cloud, indices, centroid));
-}
-
-} // namespace pcl
 
 #include <pcl/common/impl/accumulators.hpp>
 
-namespace pcl {
+namespace pcl
+{
 
-/** A generic class that computes the centroid of points fed to it.
- *
- * Here by "centroid" we denote not just the mean of 3D point coordinates,
- * but also mean of values in the other data fields. The general-purpose
- * \ref computeNDCentroid() function also implements this sort of
- * functionality, however it does it in a "dumb" way, i.e. regardless of the
- * semantics of the data inside a field it simply averages the values. In
- * certain cases (e.g. for \c x, \c y, \c z, \c intensity fields) this
- * behavior is reasonable, however in other cases (e.g. \c rgb, \c rgba,
- * \c label fields) this does not lead to meaningful results.
- *
- * This class is capable of computing the centroid in a "smart" way, i.e.
- * taking into account the meaning of the data inside fields. Currently the
- * following fields are supported:
- *
- *  Data      | Point fields                          | Algorithm
- *  --------- | ------------------------------------- |
- * -------------------------------------------------------------------------------------------
- *  XYZ       | \c x, \c y, \c z                      | Average (separate for each
- * field) Normal    | \c normal_x, \c normal_y, \c normal_z | Average (separate for each
- * field), resulting vector is normalized Curvature | \c curvature | Average Color     |
- * \c rgb or \c rgba                     | Average (separate for R, G, B, and alpha
- * channels) Intensity | \c intensity                          | Average Label     | \c
- * label                              | Majority vote; if several labels have the same
- * largest support then the  smaller label wins
- *
- * The template parameter defines the type of points that may be accumulated
- * with this class. This may be an arbitrary PCL point type, and centroid
- * computation will happen only for the fields that are present in it and are
- * supported.
- *
- * Current centroid may be retrieved at any time using get(). Note that the
- * function is templated on point type, so it is possible to fetch the
- * centroid into a point type that differs from the type of points that are
- * being accumulated. All the "extra" fields for which the centroid is not
- * being calculated will be left untouched.
- *
- * Example usage:
- *
- * \code
- * // Create and accumulate points
- * CentroidPoint<pcl::PointXYZ> centroid;
- * centroid.add (pcl::PointXYZ (1, 2, 3);
- * centroid.add (pcl::PointXYZ (5, 6, 7);
- * // Fetch centroid using `get()`
- * pcl::PointXYZ c1;
- * centroid.get (c1);
- * // The expected result is: c1.x == 3, c1.y == 4, c1.z == 5
- * // It is also okay to use `get()` with a different point type
- * pcl::PointXYZRGB c2;
- * centroid.get (c2);
- * // The expected result is: c2.x == 3, c2.y == 4, c2.z == 5,
- * // and c2.rgb is left untouched
- * \endcode
- *
- * \note Assumes that the points being inserted are valid.
- *
- * \note This class template can be successfully instantiated for *any*
- * PCL point type. Of course, each of the field averages is computed only if
- * the point type has the corresponding field.
- *
- * \ingroup common
- * \author Sergey Alexandrov */
-template <typename PointT>
-class CentroidPoint {
-
-public:
-  CentroidPoint() = default;
-
-  /** Add a new point to the centroid computation.
-   *
-   * In this function only the accumulators and point counter are updated,
-   * actual centroid computation does not happen until get() is called. */
-  void
-  add(const PointT& point);
-
-  /** Retrieve the current centroid.
-   *
-   * Computation (division of accumulated values by the number of points
-   * and normalization where applicable) happens here. The result is not
-   * cached, so any subsequent call to this function will trigger
-   * re-computation.
-   *
-   * If the number of accumulated points is zero, then the point will be
-   * left untouched. */
-  template <typename PointOutT>
-  void
-  get(PointOutT& point) const;
-
-  /** Get the total number of points that were added. */
-  inline std::size_t
-  getSize() const
+  /** A generic class that computes the centroid of points fed to it.
+    *
+    * Here by "centroid" we denote not just the mean of 3D point coordinates,
+    * but also mean of values in the other data fields. The general-purpose
+    * \ref computeNDCentroid() function also implements this sort of
+    * functionality, however it does it in a "dumb" way, i.e. regardless of the
+    * semantics of the data inside a field it simply averages the values. In
+    * certain cases (e.g. for \c x, \c y, \c z, \c intensity fields) this
+    * behavior is reasonable, however in other cases (e.g. \c rgb, \c rgba,
+    * \c label fields) this does not lead to meaningful results.
+    *
+    * This class is capable of computing the centroid in a "smart" way, i.e.
+    * taking into account the meaning of the data inside fields. Currently the
+    * following fields are supported:
+    *
+    *  Data      | Point fields                          | Algorithm
+    *  --------- | ------------------------------------- | -------------------------------------------------------------------------------------------
+    *  XYZ       | \c x, \c y, \c z                      | Average (separate for each field)
+    *  Normal    | \c normal_x, \c normal_y, \c normal_z | Average (separate for each field), resulting vector is normalized
+    *  Curvature | \c curvature                          | Average
+    *  Color     | \c rgb or \c rgba                     | Average (separate for R, G, B, and alpha channels)
+    *  Intensity | \c intensity                          | Average
+    *  Label     | \c label                              | Majority vote; if several labels have the same largest support then the  smaller label wins
+    *
+    * The template parameter defines the type of points that may be accumulated
+    * with this class. This may be an arbitrary PCL point type, and centroid
+    * computation will happen only for the fields that are present in it and are
+    * supported.
+    *
+    * Current centroid may be retrieved at any time using get(). Note that the
+    * function is templated on point type, so it is possible to fetch the
+    * centroid into a point type that differs from the type of points that are
+    * being accumulated. All the "extra" fields for which the centroid is not
+    * being calculated will be left untouched.
+    *
+    * Example usage:
+    *
+    * \code
+    * // Create and accumulate points
+    * CentroidPoint<pcl::PointXYZ> centroid;
+    * centroid.add (pcl::PointXYZ (1, 2, 3);
+    * centroid.add (pcl::PointXYZ (5, 6, 7);
+    * // Fetch centroid using `get()`
+    * pcl::PointXYZ c1;
+    * centroid.get (c1);
+    * // The expected result is: c1.x == 3, c1.y == 4, c1.z == 5
+    * // It is also okay to use `get()` with a different point type
+    * pcl::PointXYZRGB c2;
+    * centroid.get (c2);
+    * // The expected result is: c2.x == 3, c2.y == 4, c2.z == 5,
+    * // and c2.rgb is left untouched
+    * \endcode
+    *
+    * \note Assumes that the points being inserted are valid.
+    *
+    * \note This class template can be successfully instantiated for *any*
+    * PCL point type. Of course, each of the field averages is computed only if
+    * the point type has the corresponding field.
+    *
+    * \ingroup common
+    * \author Sergey Alexandrov */
+  template <typename PointT>
+  class CentroidPoint
   {
-    return (num_points_);
-  }
 
-  PCL_MAKE_ALIGNED_OPERATOR_NEW
+    public:
 
-private:
-  std::size_t num_points_ = 0;
-  typename pcl::detail::Accumulators<PointT>::type accumulators_;
-};
+      CentroidPoint () = default;
 
-/** Compute the centroid of a set of points and return it as a point.
- *
- * Implementation leverages \ref CentroidPoint class and therefore behaves
- * differently from \ref compute3DCentroid() and \ref computeNDCentroid().
- * See \ref CentroidPoint documentation for explanation.
- *
- * \param[in] cloud input point cloud
- * \param[out] centroid output centroid
- *
- * \return number of valid points used to determine the centroid (will be the
- * same as the size of the cloud if it is dense)
- *
- * \note If return value is \c 0, then the centroid is not changed, thus is
- * not valid.
- *
- * \ingroup common */
-template <typename PointInT, typename PointOutT>
-std::size_t
-computeCentroid(const pcl::PointCloud<PointInT>& cloud, PointOutT& centroid);
+      /** Add a new point to the centroid computation.
+        *
+        * In this function only the accumulators and point counter are updated,
+        * actual centroid computation does not happen until get() is called. */
+      void
+      add (const PointT& point);
 
-/** Compute the centroid of a set of points and return it as a point.
- * \param[in] cloud
- * \param[in] indices point cloud indices that need to be used
- * \param[out] centroid
- * This is an overloaded function provided for convenience. See the
- * documentation for computeCentroid().
- *
- * \ingroup common */
-template <typename PointInT, typename PointOutT>
-std::size_t
-computeCentroid(const pcl::PointCloud<PointInT>& cloud,
-                const Indices& indices,
-                PointOutT& centroid);
+      /** Retrieve the current centroid.
+        *
+        * Computation (division of accumulated values by the number of points
+        * and normalization where applicable) happens here. The result is not
+        * cached, so any subsequent call to this function will trigger
+        * re-computation.
+        *
+        * If the number of accumulated points is zero, then the point will be
+        * left untouched. */
+      template <typename PointOutT> void
+      get (PointOutT& point) const;
 
-} // namespace pcl
+      /** Get the total number of points that were added. */
+      inline std::size_t
+      getSize () const
+      {
+        return (num_points_);
+      }
+
+      PCL_MAKE_ALIGNED_OPERATOR_NEW
+
+    private:
+
+      std::size_t num_points_ = 0;
+      typename pcl::detail::Accumulators<PointT>::type accumulators_;
+
+  };
+
+  /** Compute the centroid of a set of points and return it as a point.
+    *
+    * Implementation leverages \ref CentroidPoint class and therefore behaves
+    * differently from \ref compute3DCentroid() and \ref computeNDCentroid().
+    * See \ref CentroidPoint documentation for explanation.
+    *
+    * \param[in] cloud input point cloud
+    * \param[out] centroid output centroid
+    *
+    * \return number of valid points used to determine the centroid (will be the
+    * same as the size of the cloud if it is dense)
+    *
+    * \note If return value is \c 0, then the centroid is not changed, thus is
+    * not valid.
+    *
+    * \ingroup common */
+  template <typename PointInT, typename PointOutT> std::size_t
+  computeCentroid (const pcl::PointCloud<PointInT>& cloud,
+                   PointOutT& centroid);
+
+  /** Compute the centroid of a set of points and return it as a point.
+    * \param[in] cloud
+    * \param[in] indices point cloud indices that need to be used
+    * \param[out] centroid
+    * This is an overloaded function provided for convenience. See the
+    * documentation for computeCentroid().
+    *
+    * \ingroup common */
+  template <typename PointInT, typename PointOutT> std::size_t
+  computeCentroid (const pcl::PointCloud<PointInT>& cloud,
+                   const Indices& indices,
+                   PointOutT& centroid);
+
+}
 /*@}*/
 #include <pcl/common/impl/centroid.hpp>

--- a/common/include/pcl/common/impl/bivariate_polynomial.hpp
+++ b/common/include/pcl/common/impl/bivariate_polynomial.hpp
@@ -52,16 +52,14 @@ namespace pcl
 {
 
 template<typename real>
-BivariatePolynomialT<real>::BivariatePolynomialT (int new_degree) :
-   parameters(nullptr), gradient_x(nullptr), gradient_y(nullptr)
+BivariatePolynomialT<real>::BivariatePolynomialT (int new_degree)
 {
   setDegree(new_degree);
 }
 
 
 template<typename real>
-BivariatePolynomialT<real>::BivariatePolynomialT (const BivariatePolynomialT& other) :
-   parameters(nullptr), gradient_x(nullptr), gradient_y(nullptr)
+BivariatePolynomialT<real>::BivariatePolynomialT (const BivariatePolynomialT& other)
 {
   deepCopy (other);
 }

--- a/common/include/pcl/common/impl/bivariate_polynomial.hpp
+++ b/common/include/pcl/common/impl/bivariate_polynomial.hpp
@@ -53,7 +53,7 @@ namespace pcl
 
 template<typename real>
 BivariatePolynomialT<real>::BivariatePolynomialT (int new_degree) :
-  degree(0), parameters(nullptr), gradient_x(nullptr), gradient_y(nullptr)
+   parameters(nullptr), gradient_x(nullptr), gradient_y(nullptr)
 {
   setDegree(new_degree);
 }
@@ -61,7 +61,7 @@ BivariatePolynomialT<real>::BivariatePolynomialT (int new_degree) :
 
 template<typename real>
 BivariatePolynomialT<real>::BivariatePolynomialT (const BivariatePolynomialT& other) :
-  degree(0), parameters(NULL), gradient_x(NULL), gradient_y(NULL)
+   parameters(nullptr), gradient_x(nullptr), gradient_y(nullptr)
 {
   deepCopy (other);
 }
@@ -140,11 +140,11 @@ BivariatePolynomialT<real>::deepCopy (const pcl::BivariatePolynomialT<real>& oth
 template<typename real> void
 BivariatePolynomialT<real>::calculateGradient (bool forceRecalc)
 {
-  if (gradient_x!=NULL && !forceRecalc) return;
+  if (gradient_x!=nullptr && !forceRecalc) return;
 
-  if (gradient_x == NULL)
+  if (gradient_x == nullptr)
     gradient_x = new pcl::BivariatePolynomialT<real> (degree-1);
-  if (gradient_y == NULL)
+  if (gradient_y == nullptr)
     gradient_y = new pcl::BivariatePolynomialT<real> (degree-1);
 
   unsigned int parameterPosDx=0, parameterPosDy=0;

--- a/common/include/pcl/common/pca.h
+++ b/common/include/pcl/common/pca.h
@@ -41,17 +41,17 @@
 #include <pcl/pcl_base.h>
 #include <pcl/pcl_macros.h>
 
-namespace pcl 
+namespace pcl
 {
   /** Principal Component analysis (PCA) class.\n
-    *  Principal components are extracted by singular values decomposition on the 
-    * covariance matrix of the centered input cloud. Available data after pca computation 
+    *  Principal components are extracted by singular values decomposition on the
+    * covariance matrix of the centered input cloud. Available data after pca computation
     * are:\n
     * - The Mean of the input data\n
     * - The Eigenvectors: Ordered set of vectors representing the resultant principal components and the eigenspace cartesian basis (right-handed coordinate system).\n
     * - The Eigenvalues: Eigenvectors correspondent loadings ordered in descending order.\n\n
-    * Other methods allow projection in the eigenspace, reconstruction from eigenspace and 
-    *  update of the eigenspace with a new datum (according Matej Artec, Matjaz Jogan and 
+    * Other methods allow projection in the eigenspace, reconstruction from eigenspace and
+    *  update of the eigenspace with a new datum (according Matej Artec, Matjaz Jogan and
     * Ales Leonardis: "Incremental PCA for On-line Visual Learning and Recognition").
     *
     * \author Nizar Sallem
@@ -74,30 +74,29 @@ namespace pcl
       using Base::setInputCloud;
 
       /** Updating method flag */
-      enum FLAG 
+      enum FLAG
       {
         /** keep the new basis vectors if possible */
-        increase, 
+        increase,
         /** preserve subspace dimension */
         preserve
       };
-    
+
       /** \brief Default Constructor
         * \param basis_only flag to compute only the PCA basis
         */
       PCA (bool basis_only = false)
         : Base ()
-        , compute_done_ (false)
-        , basis_only_ (basis_only) 
+        , basis_only_ (basis_only)
       {}
 
       /** Copy Constructor
         * \param[in] pca PCA object
         */
-      PCA (PCA const & pca) 
+      PCA (PCA const & pca)
         : Base (pca)
         , compute_done_ (pca.compute_done_)
-        , basis_only_ (pca.basis_only_) 
+        , basis_only_ (pca.basis_only_)
         , eigenvectors_ (pca.eigenvectors_)
         , coefficients_ (pca.coefficients_)
         , mean_ (pca.mean_)
@@ -107,8 +106,8 @@ namespace pcl
       /** Assignment operator
         * \param[in] pca PCA object
         */
-      inline PCA& 
-      operator= (PCA const & pca) 
+      inline PCA&
+      operator= (PCA const & pca)
       {
         eigenvectors_ = pca.eigenvectors_;
         coefficients_ = pca.coefficients_;
@@ -116,13 +115,13 @@ namespace pcl
         mean_         = pca.mean_;
         return (*this);
       }
-      
+
       /** \brief Provide a pointer to the input dataset
         * \param cloud the const boost shared pointer to a PointCloud message
         */
-      inline void 
-      setInputCloud (const PointCloudConstPtr &cloud) override 
-      { 
+      inline void
+      setInputCloud (const PointCloudConstPtr &cloud) override
+      {
         Base::setInputCloud (cloud);
         compute_done_ = false;
       }
@@ -175,74 +174,74 @@ namespace pcl
       /** \brief Mean accessor
         * \throw InitFailedException
         */
-      inline Eigen::Vector4f& 
-      getMean () 
+      inline Eigen::Vector4f&
+      getMean ()
       {
         if (!compute_done_)
           initCompute ();
         if (!compute_done_)
-          PCL_THROW_EXCEPTION (InitFailedException, 
+          PCL_THROW_EXCEPTION (InitFailedException,
                                "[pcl::PCA::getMean] PCA initCompute failed");
         return (mean_);
       }
 
       /** Eigen Vectors accessor
-        * \return Column ordered eigenvectors, representing the eigenspace cartesian basis (right-handed coordinate system).        
+        * \return Column ordered eigenvectors, representing the eigenspace cartesian basis (right-handed coordinate system).
         * \throw InitFailedException
         */
-      inline Eigen::Matrix3f& 
-      getEigenVectors () 
+      inline Eigen::Matrix3f&
+      getEigenVectors ()
       {
         if (!compute_done_)
           initCompute ();
         if (!compute_done_)
-          PCL_THROW_EXCEPTION (InitFailedException, 
+          PCL_THROW_EXCEPTION (InitFailedException,
                                "[pcl::PCA::getEigenVectors] PCA initCompute failed");
         return (eigenvectors_);
       }
-      
+
       /** Eigen Values accessor
         * \throw InitFailedException
         */
-      inline Eigen::Vector3f& 
+      inline Eigen::Vector3f&
       getEigenValues ()
       {
         if (!compute_done_)
           initCompute ();
         if (!compute_done_)
-          PCL_THROW_EXCEPTION (InitFailedException, 
+          PCL_THROW_EXCEPTION (InitFailedException,
                                "[pcl::PCA::getEigenVectors] PCA getEigenValues failed");
         return (eigenvalues_);
       }
-      
+
       /** Coefficients accessor
         * \throw InitFailedException
         */
-      inline Eigen::MatrixXf& 
-      getCoefficients () 
+      inline Eigen::MatrixXf&
+      getCoefficients ()
       {
         if (!compute_done_)
           initCompute ();
         if (!compute_done_)
-          PCL_THROW_EXCEPTION (InitFailedException, 
+          PCL_THROW_EXCEPTION (InitFailedException,
                                "[pcl::PCA::getEigenVectors] PCA getCoefficients failed");
         return (coefficients_);
       }
-            
+
       /** update PCA with a new point
-        * \param[in] input input point 
+        * \param[in] input input point
         * \param[in] flag update flag
         * \throw InitFailedException
         */
-      inline void 
+      inline void
       update (const PointT& input, FLAG flag = preserve);
-      
+
       /** Project point on the eigenspace.
         * \param[in] input point from original dataset
         * \param[out] projection the point in eigen vectors space
         * \throw InitFailedException
         */
-      inline void 
+      inline void
       project (const PointT& input, PointT& projection);
 
       /** Project cloud on the eigenspace.
@@ -252,13 +251,13 @@ namespace pcl
         */
       inline void
       project (const PointCloud& input, PointCloud& projection);
-      
+
       /** Reconstruct point from its projection
         * \param[in] projection point from eigenvector space
         * \param[out] input reconstructed point
         * \throw InitFailedException
         */
-      inline void 
+      inline void
       reconstruct (const PointT& projection, PointT& input);
 
       /** Reconstruct cloud from its projection
@@ -272,7 +271,7 @@ namespace pcl
       inline bool
       initCompute ();
 
-      bool compute_done_;
+      bool compute_done_{false};
       bool basis_only_;
       Eigen::Matrix3f eigenvectors_;
       Eigen::MatrixXf coefficients_;

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -754,7 +754,7 @@ namespace pcl
     };
 
     inline constexpr PointXY(float _x, float _y): x(_x), y(_y) {}
-    inline constexpr PointXY(): x(0.0), y(0.0) {}
+    inline constexpr PointXY(): x(0.0f), y(0.0f) {}
 
     inline pcl::Vector2fMap getVector2fMap () { return (pcl::Vector2fMap (data)); }
     inline pcl::Vector2fMapConst getVector2fMap () const { return (pcl::Vector2fMapConst (data)); }

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -740,26 +740,28 @@ namespace pcl
   /** \brief A 2D point structure representing Euclidean xy coordinates.
     * \ingroup common
     */
+  // NOLINTBEGIN(modernize-use-default-member-init)
   struct PointXY
   {
     union 
     { 
       float data[2]; 
       struct 
-      { 
-        float x; 
-        float y; 
+      {
+        float x;
+        float y;
       };
     };
 
     inline constexpr PointXY(float _x, float _y): x(_x), y(_y) {}
-    inline constexpr PointXY(): x(0.0f), y(0.0f) {}
-    
+    inline constexpr PointXY(): x(0.0), y(0.0) {}
+
     inline pcl::Vector2fMap getVector2fMap () { return (pcl::Vector2fMap (data)); }
     inline pcl::Vector2fMapConst getVector2fMap () const { return (pcl::Vector2fMapConst (data)); }
     
     friend std::ostream& operator << (std::ostream& os, const PointXY& p);
   };
+  // NOLINTEND(modernize-use-default-member-init)
 
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointUV& p);
   /** \brief A 2D point structure representing pixel image coordinates.

--- a/common/include/pcl/point_representation.h
+++ b/common/include/pcl/point_representation.h
@@ -245,7 +245,7 @@ namespace pcl
       using Pod = typename traits::POD<PointDefault>::type;
 
       NdCopyPointFunctor (const PointDefault &p1, float * p2)
-        : p1_ (reinterpret_cast<const Pod&>(p1)), p2_ (p2), f_idx_ (0) { }
+        : p1_ (reinterpret_cast<const Pod&>(p1)), p2_ (p2) {}
 
       template<typename Key> inline void operator() ()
       {
@@ -285,7 +285,7 @@ namespace pcl
     private:
       const Pod &p1_;
       float * p2_;
-      int f_idx_;
+      int f_idx_{0};
     };
 
     public:

--- a/common/include/pcl/range_image/range_image.h
+++ b/common/include/pcl/range_image/range_image.h
@@ -767,13 +767,13 @@ namespace pcl
       // =====PROTECTED MEMBER VARIABLES=====
       Eigen::Affine3f to_range_image_system_;  /**< Inverse of to_world_system_ */
       Eigen::Affine3f to_world_system_;        /**< Inverse of to_range_image_system_ */
-      float angular_resolution_x_;             /**< Angular resolution of the range image in x direction in radians per pixel */
-      float angular_resolution_y_;             /**< Angular resolution of the range image in y direction in radians per pixel */
-      float angular_resolution_x_reciprocal_;  /**< 1.0/angular_resolution_x_ - provided for better performance of
+      float angular_resolution_x_{0};             /**< Angular resolution of the range image in x direction in radians per pixel */
+      float angular_resolution_y_{0};             /**< Angular resolution of the range image in y direction in radians per pixel */
+      float angular_resolution_x_reciprocal_{0};  /**< 1.0/angular_resolution_x_ - provided for better performance of
                                                 *   multiplication compared to division */
-      float angular_resolution_y_reciprocal_;  /**< 1.0/angular_resolution_y_ - provided for better performance of
+      float angular_resolution_y_reciprocal_{0};  /**< 1.0/angular_resolution_y_ - provided for better performance of
                                                 *   multiplication compared to division */
-      int image_offset_x_, image_offset_y_;    /**< Position of the top left corner of the range image compared to
+      int image_offset_x_{0}, image_offset_y_{0};    /**< Position of the top left corner of the range image compared to
                                                 *   an image of full size (360x180 degrees) */
       PointWithRange unobserved_point;         /**< This point is used to be able to return
                                                 *   a reference to a non-existing point */

--- a/common/include/pcl/range_image/range_image_planar.h
+++ b/common/include/pcl/range_image/range_image_planar.h
@@ -206,9 +206,9 @@ namespace pcl
 
 
     protected:
-      float focal_length_x_, focal_length_y_; //!< The focal length of the image in pixels
-      float focal_length_x_reciprocal_, focal_length_y_reciprocal_;  //!< 1/focal_length -> for internal use
-      float center_x_, center_y_;      //!< The principle point of the image
+      float focal_length_x_{0.0f}, focal_length_y_{0.0f}; //!< The focal length of the image in pixels
+      float focal_length_x_reciprocal_{0.0f}, focal_length_y_reciprocal_{0.0f};  //!< 1/focal_length -> for internal use
+      float center_x_{0.0f}, center_y_{0.0f};      //!< The principle point of the image
   };
 }  // namespace end
 

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -105,10 +105,7 @@ RangeImage::getCoordinateFrameTransformation (RangeImage::CoordinateFrame coordi
 /////////////////////////////////////////////////////////////////////////
 RangeImage::RangeImage () : 
   to_range_image_system_ (Eigen::Affine3f::Identity ()),
-  to_world_system_ (Eigen::Affine3f::Identity ()),
-  angular_resolution_x_ (0), angular_resolution_y_ (0),
-  angular_resolution_x_reciprocal_ (0), angular_resolution_y_reciprocal_ (0),
-  image_offset_x_ (0), image_offset_y_ (0)
+  to_world_system_ (Eigen::Affine3f::Identity ())
 {
   createLookupTables ();
   reset ();

--- a/common/src/range_image_planar.cpp
+++ b/common/src/range_image_planar.cpp
@@ -43,11 +43,7 @@ using std::cerr;
 namespace pcl 
 {
   /////////////////////////////////////////////////////////////////////////
-  RangeImagePlanar::RangeImagePlanar () : focal_length_x_ (0.0f), focal_length_y_ (0.0f),
-                                          focal_length_x_reciprocal_ (0.0f), focal_length_y_reciprocal_ (0.0f),
-                                          center_x_ (0.0f), center_y_ (0.0f)
-  {
-  }
+  RangeImagePlanar::RangeImagePlanar () = default;
 
   /////////////////////////////////////////////////////////////////////////
   RangeImagePlanar::~RangeImagePlanar () = default;


### PR DESCRIPTION
Added these checks to `clang-tidy`:

- [modernize-use-default-member-init](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-default-member-init.html)
- [modernize-use-bool-literals](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-bool-literals.html)

Per @larshg, this is the first of several PRs that apply `modernize-use-default-member-init` without having the check actually present in `.clang-tidy`, in order to keep the sizes of the PRs manageable.