### PR TITLE
fix MSVS not supporting unsigned int in for loop with openMP

### DIFF
--- a/io/src/real_sense_2_grabber.cpp
+++ b/io/src/real_sense_2_grabber.cpp
@@ -299,7 +299,7 @@ namespace pcl
   default(none) \
   shared(cloud, cloud_texture_ptr, cloud_vertices_ptr, mapColorFunc)
 #endif
-    for (std::size_t index = 0; index < cloud->size (); ++index)
+    for (std::ptrdiff_t index = 0; index < static_cast<std::ptrdiff_t>(cloud->size()); ++index)
     {
       const auto ptr = cloud_vertices_ptr + index;
       const auto uvptr = cloud_texture_ptr + index;


### PR DESCRIPTION
fix MSVS not supporting unsigned int in for loop with openMP. ref. issue #5664