### PR TITLE
Add explicit instantiations to icp

### DIFF
--- a/registration/include/pcl/registration/icp.h
+++ b/registration/include/pcl/registration/icp.h
@@ -455,4 +455,6 @@ protected:
 
 } // namespace pcl
 
+#ifdef PCL_NO_PRECOMPILE
 #include <pcl/registration/impl/icp.hpp>
+#endif

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -42,6 +42,7 @@
 #define PCL_REGISTRATION_IMPL_GICP_HPP_
 
 #include <pcl/registration/exceptions.h>
+#include <pcl/registration/impl/icp.hpp>
 
 namespace pcl {
 

--- a/registration/include/pcl/registration/impl/icp.hpp
+++ b/registration/include/pcl/registration/impl/icp.hpp
@@ -42,6 +42,7 @@
 #define PCL_REGISTRATION_IMPL_ICP_HPP_
 
 #include <pcl/correspondence.h>
+#include <pcl/registration/icp.h>
 
 namespace pcl {
 // NOLINTBEGIN(readability-container-data-pointer)
@@ -321,5 +322,7 @@ IterativeClosestPointWithNormals<PointSource, PointTarget, Scalar>::transformClo
 // NOLINTEND(readability-container-data-pointer)
 
 } // namespace pcl
+
+#define PCL_INSTANTIATE_IterativeClosestPoint(T1) template class PCL_EXPORTS pcl::IterativeClosestPoint<T1,T1>;
 
 #endif /* PCL_REGISTRATION_IMPL_ICP_HPP_ */

--- a/registration/src/icp.cpp
+++ b/registration/src/icp.cpp
@@ -37,4 +37,15 @@
  *
  */
 
-#include <pcl/registration/icp.h>
+#include <pcl/registration/impl/icp.hpp>
+
+#ifndef PCL_NO_PRECOMPILE
+#include <pcl/point_types.h>
+#include <pcl/impl/instantiate.hpp>
+// Instantiations of specific point types
+#ifdef PCL_ONLY_CORE_POINT_TYPES
+  PCL_INSTANTIATE(IterativeClosestPoint, (pcl::PointXYZ)(pcl::PointXYZI)(pcl::PointXYZRGB))
+#else
+  PCL_INSTANTIATE(IterativeClosestPoint, PCL_XYZ_POINT_TYPES)
+#endif
+#endif    // PCL_NO_PRECOMPILE


### PR DESCRIPTION
This adds precompiled instantiations for `IterativeClosestPoint`, which takes significant compilation time otherwise. 

I tried it with `PCL_INSTANTIATE_PRODUCT` first, but it seems that many combinations of the two template parameters don't actually compile, i.e. `PointXYZ` and `PointXYZI`, so I just made them the same for now.