### PR TITLE
Point Cloud Editor: fix select2D after switch to QOpenGLWidget

### DIFF
--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudEditorWidget.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/cloudEditorWidget.h
@@ -319,5 +319,9 @@ class CloudEditorWidget : public QOpenGLWidget
     /// a dialog displaying the statistics of the cloud editor
     StatisticsDialog stat_dialog_;
 
+    /// the viewport, set by resizeGL
+    std::array<GLint, 4> viewport_;
 
+    /// the projection matrix, set by resizeGL
+    std::array<GLfloat, 16> projection_matrix_;
 };

--- a/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/select2DTool.h
+++ b/apps/point_cloud_editor/include/pcl/apps/point_cloud_editor/select2DTool.h
@@ -57,7 +57,8 @@ class Select2DTool : public ToolInterface
     /// @brief Constructor
     /// @param selection_ptr a shared pointer pointing to the selection object.
     /// @param cloud_ptr a shared pointer pointing to the cloud object.
-    Select2DTool (SelectionPtr selection_ptr, CloudPtr cloud_ptr);
+    /// @param get_viewport_and_projection_mat a function that can be used to get the viewport and the projection matrix
+    Select2DTool (SelectionPtr selection_ptr, CloudPtr cloud_ptr, std::function<void(GLint*,GLfloat*)> get_viewport_and_projection_mat);
 
     /// @brief Destructor
     ~Select2DTool () override;
@@ -154,4 +155,6 @@ class Select2DTool : public ToolInterface
     /// switch for selection box rendering
     bool display_box_;
 
+    /// function to get the viewport and the projection matrix (initialized by ctor)
+    std::function<void(GLint*,GLfloat*)> get_viewport_and_projection_mat_;
 };

--- a/apps/point_cloud_editor/src/cloudEditorWidget.cpp
+++ b/apps/point_cloud_editor/src/cloudEditorWidget.cpp
@@ -47,6 +47,9 @@
 #ifdef OPENGL_IS_A_FRAMEWORK
 # include <OpenGL/glu.h>
 #else
+# ifdef _WIN32
+#  include <windows.h>
+# endif // _WIN32
 # include <GL/glu.h>
 #endif
 

--- a/apps/point_cloud_editor/src/cloudEditorWidget.cpp
+++ b/apps/point_cloud_editor/src/cloudEditorWidget.cpp
@@ -475,6 +475,9 @@ CloudEditorWidget::paintGL ()
 void
 CloudEditorWidget::resizeGL (int width, int height)
 {
+  const auto ratio = this->devicePixelRatio();
+  width = static_cast<int>(width*ratio);
+  height = static_cast<int>(height*ratio);
   glViewport(0, 0, width, height);
   viewport_ = {0, 0, width, height};
   cam_aspect_ = double(width) / double(height);

--- a/apps/point_cloud_editor/src/cloudEditorWidget.cpp
+++ b/apps/point_cloud_editor/src/cloudEditorWidget.cpp
@@ -201,7 +201,7 @@ CloudEditorWidget::select2D ()
   if (!cloud_ptr_)
     return;
   tool_ptr_ = std::shared_ptr<Select2DTool>(new Select2DTool(selection_ptr_,
-                                                               cloud_ptr_));
+                                                               cloud_ptr_, [this](GLint * viewport, GLfloat * projection_matrix){ std::copy_n(this->viewport_.begin(), 4, viewport); std::copy_n(this->projection_matrix_.begin(), 16, projection_matrix); }));
   update();
 }
 
@@ -473,10 +473,12 @@ void
 CloudEditorWidget::resizeGL (int width, int height)
 {
   glViewport(0, 0, width, height);
+  viewport_ = {0, 0, width, height};
   cam_aspect_ = double(width) / double(height);
   glMatrixMode(GL_PROJECTION);
   glLoadIdentity();
   gluPerspective(cam_fov_, cam_aspect_, cam_near_, cam_far_);
+  glGetFloatv(GL_PROJECTION_MATRIX, projection_matrix_.data());
   glMatrixMode(GL_MODELVIEW);
   glLoadIdentity();
 }

--- a/apps/point_cloud_editor/src/select2DTool.cpp
+++ b/apps/point_cloud_editor/src/select2DTool.cpp
@@ -48,8 +48,8 @@ const float Select2DTool::DEFAULT_TOOL_DISPLAY_COLOR_GREEN_ = 1.0f;
 const float Select2DTool::DEFAULT_TOOL_DISPLAY_COLOR_BLUE_ = 1.0f;
 
 
-Select2DTool::Select2DTool (SelectionPtr selection_ptr, CloudPtr cloud_ptr)
-  : selection_ptr_(std::move(selection_ptr)), cloud_ptr_(std::move(cloud_ptr)), display_box_(false)
+Select2DTool::Select2DTool (SelectionPtr selection_ptr, CloudPtr cloud_ptr, std::function<void(GLint*,GLfloat*)> get_viewport_and_projection_mat)
+  : selection_ptr_(std::move(selection_ptr)), cloud_ptr_(std::move(cloud_ptr)), display_box_(false), get_viewport_and_projection_mat_(get_viewport_and_projection_mat)
 {
 }
 
@@ -88,10 +88,9 @@ Select2DTool::end (int x, int y, BitMask modifiers, BitMask)
     return;
 
   GLint viewport[4];
-  glGetIntegerv(GL_VIEWPORT,viewport);
   IndexVector indices;
   GLfloat project[16];
-  glGetFloatv(GL_PROJECTION_MATRIX, project);
+  get_viewport_and_projection_mat_(viewport, project);
 
   Point3DVector ptsvec;
   cloud_ptr_->getDisplaySpacePoints(ptsvec);


### PR DESCRIPTION
In commit https://github.com/PointCloudLibrary/pcl/commit/38cbd621d0632895e1bed04841a612f97f574abc the CloudEditorWidget was switched from QGLWidget to QOpenGLWidget to be compatible with Qt6. The select2D tool needs the viewport and the projection matrix, which are loaded with `glGetIntegerv(GL_VIEWPORT,viewport)` and `glGetFloatv(GL_PROJECTION_MATRIX, project)` (they are set in `CloudEditorWidget::resizeGL`). However, since the switch to QOpenGLWidget, the received projection matrix is just the identity matrix, and the viewport does not look correct either. It seems that QOpenGLWidget overwrites them. These changes introduce variables in CloudEditorWidget to safely store the viewport and projection matrix, and passes a function to the select2D tool to ask for them when needed.