### PR TITLE
ConvexHull verbouse info on stdout enabled only by pcl::console::L_DEBUG

### DIFF
--- a/surface/include/pcl/surface/impl/convex_hull.hpp
+++ b/surface/include/pcl/surface/impl/convex_hull.hpp
@@ -136,7 +136,7 @@ pcl::ConvexHull<PointInT>::performReconstruction2D (PointCloud &hull, std::vecto
   // output from qh_produce_output(), use NULL to skip qh_produce_output()
   FILE *outfile = nullptr;
 
-  if (compute_area_)
+  if (compute_area_ && pcl::console::isVerbosityLevelEnabled(pcl::console::L_DEBUG))
     outfile = stderr;
 
   // option flags for qhull, see qh_opt.htm
@@ -299,7 +299,7 @@ pcl::ConvexHull<PointInT>::performReconstruction3D (
   // output from qh_produce_output(), use NULL to skip qh_produce_output()
   FILE *outfile = nullptr;
 
-  if (compute_area_)
+  if (compute_area_ && pcl::console::isVerbosityLevelEnabled(pcl::console::L_DEBUG))
     outfile = stderr;
 
   // option flags for qhull, see qh_opt.htm


### PR DESCRIPTION
ConvexHull used to print a lot of info on stdout (when compute area is set) which was not necessary and slowed down the elaboration time of 20%. Now only if VerbosityLevel(pcl::console::L_DEBUG) (so disabled by default). The results are not affected, only 20% faster.