### PR TITLE
function computeCentroidAndOBB

### DIFF
--- a/common/include/pcl/common/centroid.h
+++ b/common/include/pcl/common/centroid.h
@@ -589,6 +589,61 @@ namespace pcl
     return (computeCovarianceMatrix<PointT, double> (cloud, indices, covariance_matrix));
   }
 
+
+  /** \brief Compute centroid, OBB, PCA axes of a given set of points.
+  * OBB is oriented like the three axes (major, middle and minor) with
+  * major_axis  = obb_rotational_matrix.col(0)
+  * middle_axis = obb_rotational_matrix.col(1)
+  * minor_axis  = obb_rotational_matrix.col(2)
+  * one way to visualize OBB when Scalar is float:
+  * Eigen::Vector3f position(obb_position(0), obb_position(1), obb_position(2));
+  * Eigen::Quaternionf quat(obb_rotational_matrix);
+  * viewer->addCube(position, quat, obb_dimensions(0), obb_dimensions(1), obb_dimensions(2), .....);
+  * \param[in] cloud the input point cloud
+  * \param[out] centroid the centroid of the set of points in the cloud
+  * \param[out] obb_center position of the centroid of the OBB (Oriented Bounding Box)
+  * \param[out] obb_dimensions (width, height and depth) of the OBB (Oriented Bounding Box)
+  * \param[out] obb_rotational_matrix rotational matrix of the OBB (Oriented Bounding Box)
+  * \return number of valid points used to determine the output.
+  * In case of dense point clouds, this is the same as the size of the input cloud.
+  * \ingroup common
+  */
+  template <typename PointT, typename Scalar> inline unsigned int
+    computeCentroidAndOBB(const pcl::PointCloud<PointT>& cloud,
+                    Eigen::Matrix<Scalar, 3, 1>& centroid,
+                    Eigen::Matrix<Scalar, 3, 1>& obb_center,
+                    Eigen::Matrix<Scalar, 3, 1>& obb_dimensions,
+                    Eigen::Matrix<Scalar, 3, 3>& obb_rotational_matrix);
+
+
+    /** \brief Compute centroid, OBB, PCA axes of a given set of points.
+    * OBB is oriented like the three axes (major, middle and minor) with
+    * major_axis  = obb_rotational_matrix.col(0)
+    * middle_axis = obb_rotational_matrix.col(1)
+    * minor_axis  = obb_rotational_matrix.col(2)
+    * one way to visualize OBB when Scalar is float:
+    * Eigen::Vector3f position(obb_position(0), obb_position(1), obb_position(2));
+    * Eigen::Quaternionf quat(obb_rotational_matrix);
+    * viewer->addCube(position, quat, obb_dimensions(0), obb_dimensions(1), obb_dimensions(2), .....);
+    * \param[in] cloud the input point cloud
+    * \param[in] indices subset of points given by their indices 
+    * \param[out] centroid the centroid of the set of points in the cloud
+    * \param[out] obb_center position of the centroid of the OBB (Oriented Bounding Box)
+    * \param[out] obb_dimensions (width, height and depth) of the OBB (Oriented Bounding Box)
+    * \param[out] obb_rotational_matrix rotational matrix of the OBB (Oriented Bounding Box)
+    * \return number of valid points used to determine the output.
+    * In case of dense point clouds, this is the same as the size of the input cloud.
+    * \ingroup common
+    */
+  template <typename PointT, typename Scalar> inline unsigned int
+    computeCentroidAndOBB(const pcl::PointCloud<PointT>& cloud,
+                    const Indices &indices,
+                    Eigen::Matrix<Scalar, 3, 1>& centroid,
+                    Eigen::Matrix<Scalar, 3, 1>& obb_center,
+                    Eigen::Matrix<Scalar, 3, 1>& obb_dimensions,
+                    Eigen::Matrix<Scalar, 3, 3>& obb_rotational_matrix);
+
+
   /** \brief Subtract a centroid from a point cloud and return the de-meaned representation
     * \param[in] cloud_iterator an iterator over the input point cloud
     * \param[in] centroid the centroid of the point cloud

--- a/common/include/pcl/common/centroid.h
+++ b/common/include/pcl/common/centroid.h
@@ -601,7 +601,7 @@ namespace pcl
   * viewer->addCube(position, quat, obb_dimensions(0), obb_dimensions(1), obb_dimensions(2), .....);
   * \param[in] cloud the input point cloud
   * \param[out] centroid the centroid (mean value of the XYZ coordinates) of the set of points in the cloud
-  * \param[out] obb_center position of the centre of the OBB (it is the same as centroid if the cloud is centrally symmetric)
+  * \param[out] obb_center position of the center of the OBB (it is the same as centroid if the cloud is centrally symmetric)
   * \param[out] obb_dimensions (width, height and depth) of the OBB 
   * \param[out] obb_rotational_matrix rotational matrix of the OBB 
   * \return number of valid points used to determine the output.
@@ -628,7 +628,7 @@ namespace pcl
   * \param[in] cloud the input point cloud
   * \param[in] indices subset of points given by their indices 
   * \param[out] centroid the centroid (mean value of the XYZ coordinates) of the set of points in the cloud
-  * \param[out] obb_center position of the centre of the OBB (it is the same as centroid if the cloud is centrally symmetric)
+  * \param[out] obb_center position of the center of the OBB (it is the same as centroid if the cloud is centrally symmetric)
   * \param[out] obb_dimensions (width, height and depth) of the OBB 
   * \param[out] obb_rotational_matrix rotational matrix of the OBB 
   * \return number of valid points used to determine the output.

--- a/common/include/pcl/common/centroid.h
+++ b/common/include/pcl/common/centroid.h
@@ -590,7 +590,7 @@ namespace pcl
   }
 
 
-  /** \brief Compute centroid, OBB, PCA axes of a given set of points.
+  /** \brief Compute centroid, OBB (Oriented Bounding Box), PCA axes of a given set of points.
   * OBB is oriented like the three axes (major, middle and minor) with
   * major_axis  = obb_rotational_matrix.col(0)
   * middle_axis = obb_rotational_matrix.col(1)
@@ -600,10 +600,10 @@ namespace pcl
   * Eigen::Quaternionf quat(obb_rotational_matrix);
   * viewer->addCube(position, quat, obb_dimensions(0), obb_dimensions(1), obb_dimensions(2), .....);
   * \param[in] cloud the input point cloud
-  * \param[out] centroid the centroid of the set of points in the cloud
-  * \param[out] obb_center position of the centroid of the OBB (Oriented Bounding Box)
-  * \param[out] obb_dimensions (width, height and depth) of the OBB (Oriented Bounding Box)
-  * \param[out] obb_rotational_matrix rotational matrix of the OBB (Oriented Bounding Box)
+  * \param[out] centroid the centroid (mean value of the XYZ coordinates) of the set of points in the cloud
+  * \param[out] obb_center position of the centre of the OBB (it is the same as centroid if the cloud is centrally symmetric)
+  * \param[out] obb_dimensions (width, height and depth) of the OBB 
+  * \param[out] obb_rotational_matrix rotational matrix of the OBB 
   * \return number of valid points used to determine the output.
   * In case of dense point clouds, this is the same as the size of the input cloud.
   * \ingroup common
@@ -616,25 +616,25 @@ namespace pcl
                     Eigen::Matrix<Scalar, 3, 3>& obb_rotational_matrix);
 
 
-    /** \brief Compute centroid, OBB, PCA axes of a given set of points.
-    * OBB is oriented like the three axes (major, middle and minor) with
-    * major_axis  = obb_rotational_matrix.col(0)
-    * middle_axis = obb_rotational_matrix.col(1)
-    * minor_axis  = obb_rotational_matrix.col(2)
-    * one way to visualize OBB when Scalar is float:
-    * Eigen::Vector3f position(obb_position(0), obb_position(1), obb_position(2));
-    * Eigen::Quaternionf quat(obb_rotational_matrix);
-    * viewer->addCube(position, quat, obb_dimensions(0), obb_dimensions(1), obb_dimensions(2), .....);
-    * \param[in] cloud the input point cloud
-    * \param[in] indices subset of points given by their indices 
-    * \param[out] centroid the centroid of the set of points in the cloud
-    * \param[out] obb_center position of the centroid of the OBB (Oriented Bounding Box)
-    * \param[out] obb_dimensions (width, height and depth) of the OBB (Oriented Bounding Box)
-    * \param[out] obb_rotational_matrix rotational matrix of the OBB (Oriented Bounding Box)
-    * \return number of valid points used to determine the output.
-    * In case of dense point clouds, this is the same as the size of the input cloud.
-    * \ingroup common
-    */
+  /** \brief Compute centroid, OBB (Oriented Bounding Box), PCA axes of a given set of points.
+  * OBB is oriented like the three axes (major, middle and minor) with
+  * major_axis  = obb_rotational_matrix.col(0)
+  * middle_axis = obb_rotational_matrix.col(1)
+  * minor_axis  = obb_rotational_matrix.col(2)
+  * one way to visualize OBB when Scalar is float:
+  * Eigen::Vector3f position(obb_position(0), obb_position(1), obb_position(2));
+  * Eigen::Quaternionf quat(obb_rotational_matrix);
+  * viewer->addCube(position, quat, obb_dimensions(0), obb_dimensions(1), obb_dimensions(2), .....);
+  * \param[in] cloud the input point cloud
+  * \param[in] indices subset of points given by their indices 
+  * \param[out] centroid the centroid (mean value of the XYZ coordinates) of the set of points in the cloud
+  * \param[out] obb_center position of the centre of the OBB (it is the same as centroid if the cloud is centrally symmetric)
+  * \param[out] obb_dimensions (width, height and depth) of the OBB 
+  * \param[out] obb_rotational_matrix rotational matrix of the OBB 
+  * \return number of valid points used to determine the output.
+  * In case of dense point clouds, this is the same as the size of the input cloud.
+  * \ingroup common
+  */
   template <typename PointT, typename Scalar> inline unsigned int
     computeCentroidAndOBB(const pcl::PointCloud<PointT>& cloud,
                     const Indices &indices,

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -721,7 +721,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
     obb_min_pointy = obb_max_pointy = P(1);
     obb_min_pointz = obb_max_pointz = P(2);
 
-    for (size_t i=1; i<cloud.points.size();++i)
+    for (size_t i=1; i<cloud.size();++i)
     {
       auto point = cloud[i];
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
@@ -744,7 +744,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   else
   {
     size_t i = 0;
-    for (; i < cloud.points.size(); ++i)
+    for (; i < cloud.size(); ++i)
     {
       auto point = cloud[i];
       if (!isFinite(point))
@@ -759,7 +759,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
       break;
     }
 
-    for (; i<cloud.points.size();++i)
+    for (; i<cloud.size();++i)
     {
       auto point = cloud[i];
       if (!isFinite(point))
@@ -783,7 +783,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
   }
 
-  Eigen::Matrix<Scalar, 3, 1>  //shift between point cloud centroid and OBB centroid (position of the OBB centroid relative to (p.c.centroid, major_axis, middle_axis, minor_axis))
+  Eigen::Matrix<Scalar, 3, 1>  //shift between point cloud centroid and OBB center (position of the OBB center relative to (p.c.centroid, major_axis, middle_axis, minor_axis))
     shift((obb_max_pointx + obb_min_pointx) / 2.0f,
       (obb_max_pointy + obb_min_pointy) / 2.0f,
       (obb_max_pointz + obb_min_pointz) / 2.0f);
@@ -792,7 +792,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   obb_dimensions(1) = obb_max_pointy - obb_min_pointy;
   obb_dimensions(2) = obb_max_pointz - obb_min_pointz;
 
-  obb_center = centroid+ obb_rotational_matrix * shift;//position of the OBB centroid in the same reference Oxyz of the point cloud
+  obb_center = centroid+ obb_rotational_matrix * shift;//position of the OBB center in the same reference Oxyz of the point cloud
 
   return ( point_count);
 }
@@ -924,7 +924,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
   }
 
-  Eigen::Matrix<Scalar, 3, 1>  //shift between point cloud centroid and OBB centroid (position of the OBB centroid relative to (p.c.centroid, major_axis, middle_axis, minor_axis))
+  Eigen::Matrix<Scalar, 3, 1>  //shift between point cloud centroid and OBB center (position of the OBB center relative to (p.c.centroid, major_axis, middle_axis, minor_axis))
     shift((obb_max_pointx + obb_min_pointx) / 2.0f,
       (obb_max_pointy + obb_min_pointy) / 2.0f,
       (obb_max_pointz + obb_min_pointz) / 2.0f);
@@ -933,7 +933,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   obb_dimensions(1) = obb_max_pointy - obb_min_pointy;
   obb_dimensions(2) = obb_max_pointz - obb_min_pointz;
 
-  obb_center = centroid+ obb_rotational_matrix * shift;//position of the OBB centroid in the same reference Oxyz of the point cloud
+  obb_center = centroid+ obb_rotational_matrix * shift;//position of the OBB center in the same reference Oxyz of the point cloud
 
   return ( point_count);
 }

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -715,7 +715,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   if (cloud.is_dense)
   {
     auto point = cloud.points[0];
-    Eigen::Matrix<Scalar, 4, 1> P0((Scalar)(point.x),(Scalar)(point.y) , (Scalar)(point.z), 1.0);
+    Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
     Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
     obb_min_pointx = obb_max_pointx = P(0);
@@ -725,7 +725,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
     for (size_t i=1; i<cloud.points.size();++i)
     {
       auto point = cloud.points[i];
-      Eigen::Matrix<Scalar, 4, 1> P0((Scalar)(point.x),(Scalar)(point.y) , (Scalar)(point.z), 1.0);
+      Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
       Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
       if (P(0) <= obb_min_pointx)
@@ -750,7 +750,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
       auto point = cloud.points[i];
       if (!isFinite(point))
         continue;
-      Eigen::Matrix<Scalar, 4, 1> P0((Scalar)(point.x), (Scalar)(point.y), (Scalar)(point.z), 1.0);
+      Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
       Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
       obb_min_pointx = obb_max_pointx = P(0);
@@ -763,7 +763,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
     for (; i<cloud.points.size();++i)
     {
       auto point = cloud.points[i];
-      Eigen::Matrix<Scalar, 4, 1> P0((Scalar)(point.x),(Scalar)(point.y) , (Scalar)(point.z), 1.0);
+      Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
       Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
       if (P(0) <= obb_min_pointx)
@@ -860,7 +860,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   if (cloud.is_dense)
   {
     auto point = cloud.points[indices[0]];
-    Eigen::Matrix<Scalar, 4, 1> P0((Scalar)(point.x), (Scalar)(point.y), (Scalar)(point.z), 1.0);
+    Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
     Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
     obb_min_pointx = obb_max_pointx = P(0);
@@ -871,7 +871,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
     {
       auto point = cloud.points[indices[i]];
 
-      Eigen::Matrix<Scalar, 4, 1> P0((Scalar)(point.x), (Scalar)(point.y), (Scalar)(point.z), 1.0);
+      Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
       Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
       if (P(0) <= obb_min_pointx)
@@ -896,7 +896,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
       auto point = cloud.points[indices[i]];
       if (!isFinite(point))
         continue;
-      Eigen::Matrix<Scalar, 4, 1> P0((Scalar)(point.x), (Scalar)(point.y), (Scalar)(point.z), 1.0);
+      Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
       Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
       obb_min_pointx = obb_max_pointx = P(0);
@@ -910,7 +910,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
     {
       auto point = cloud.points[indices[i]];
 
-      Eigen::Matrix<Scalar, 4, 1> P0((Scalar)(point.x), (Scalar)(point.y), (Scalar)(point.z), 1.0);
+      Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
       Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
       if (P(0) <= obb_min_pointx)

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -713,7 +713,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
   if (cloud.is_dense)
   {
-    auto point = cloud.points[0];
+    auto point = cloud[0];
     Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
     Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
@@ -723,21 +723,21 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
     for (size_t i=1; i<cloud.points.size();++i)
     {
-      auto point = cloud.points[i];
+      auto point = cloud[i];
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
       Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
-      if (P(0) <= obb_min_pointx)
+      if (P(0) < obb_min_pointx)
         obb_min_pointx = P(0);
-      else if (P(0) >= obb_max_pointx)
+      else if (P(0) > obb_max_pointx)
         obb_max_pointx = P(0);
-      if (P(1) <= obb_min_pointy)
+      if (P(1) < obb_min_pointy)
         obb_min_pointy = P(1);
-      else if (P(1) >= obb_max_pointy)
+      else if (P(1) > obb_max_pointy)
         obb_max_pointy = P(1);
-      if (P(2) <= obb_min_pointz)
+      if (P(2) < obb_min_pointz)
         obb_min_pointz = P(2);
-      else if (P(2) >= obb_max_pointz)
+      else if (P(2) > obb_max_pointz)
         obb_max_pointz = P(2);
     }
   }
@@ -746,7 +746,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
     size_t i = 0;
     for (; i < cloud.points.size(); ++i)
     {
-      auto point = cloud.points[i];
+      auto point = cloud[i];
       if (!isFinite(point))
         continue;
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
@@ -761,21 +761,23 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
     for (; i<cloud.points.size();++i)
     {
-      auto point = cloud.points[i];
+      auto point = cloud[i];
+      if (!isFinite(point))
+        continue;
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
       Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
-      if (P(0) <= obb_min_pointx)
+      if (P(0) < obb_min_pointx)
         obb_min_pointx = P(0);
-      else if (P(0) >= obb_max_pointx)
+      else if (P(0) > obb_max_pointx)
         obb_max_pointx = P(0);
-      if (P(1) <= obb_min_pointy)
+      if (P(1) < obb_min_pointy)
         obb_min_pointy = P(1);
-      else if (P(1) >= obb_max_pointy)
+      else if (P(1) > obb_max_pointy)
         obb_max_pointy = P(1);
-      if (P(2) <= obb_min_pointz)
+      if (P(2) < obb_min_pointz)
         obb_min_pointz = P(2);
-      else if (P(2) >= obb_max_pointz)
+      else if (P(2) > obb_max_pointz)
         obb_max_pointz = P(2);
     }
 
@@ -850,7 +852,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
   if (cloud.is_dense)
   {
-    auto point = cloud.points[indices[0]];
+    auto point = cloud[indices[0]];
     Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
     Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
@@ -860,22 +862,22 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
     for (size_t i=1; i<indices.size();++i)
     {
-      auto point = cloud.points[indices[i]];
+      auto point = cloud[indices[i]];
 
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
       Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
-      if (P(0) <= obb_min_pointx)
+      if (P(0) < obb_min_pointx)
         obb_min_pointx = P(0);
-      else if (P(0) >= obb_max_pointx)
+      else if (P(0) > obb_max_pointx)
         obb_max_pointx = P(0);
-      if (P(1) <= obb_min_pointy)
+      if (P(1) < obb_min_pointy)
         obb_min_pointy = P(1);
-      else if (P(1) >= obb_max_pointy)
+      else if (P(1) > obb_max_pointy)
         obb_max_pointy = P(1);
-      if (P(2) <= obb_min_pointz)
+      if (P(2) < obb_min_pointz)
         obb_min_pointz = P(2);
-      else if (P(2) >= obb_max_pointz)
+      else if (P(2) > obb_max_pointz)
         obb_max_pointz = P(2);
     }
   }
@@ -884,7 +886,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
     size_t i = 0;
     for (; i<indices.size();++i)
     {
-      auto point = cloud.points[indices[i]];
+      auto point = cloud[indices[i]];
       if (!isFinite(point))
         continue;
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
@@ -899,22 +901,24 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
     for (; i<indices.size();++i)
     {
-      auto point = cloud.points[indices[i]];
+      auto point = cloud[indices[i]];
+      if (!isFinite(point))
+        continue;
 
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
       Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
-      if (P(0) <= obb_min_pointx)
+      if (P(0) < obb_min_pointx)
         obb_min_pointx = P(0);
-      else if (P(0) >= obb_max_pointx)
+      else if (P(0) > obb_max_pointx)
         obb_max_pointx = P(0);
-      if (P(1) <= obb_min_pointy)
+      if (P(1) < obb_min_pointy)
         obb_min_pointy = P(1);
-      else if (P(1) >= obb_max_pointy)
+      else if (P(1) > obb_max_pointy)
         obb_max_pointy = P(1);
-      if (P(2) <= obb_min_pointz)
+      if (P(2) < obb_min_pointz)
         obb_min_pointz = P(2);
-      else if (P(2) >= obb_max_pointz)
+      else if (P(2) > obb_max_pointz)
         obb_max_pointz = P(2);
     }
 

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -43,7 +43,6 @@
 #include <pcl/common/centroid.h>
 #include <pcl/conversions.h>
 #include <pcl/common/point_tests.h> // for pcl::isFinite
-#include <pcl/common/transforms.h>
 #include <Eigen/Eigenvalues> // for EigenSolver
 
 #include <boost/fusion/algorithm/transformation/filter_if.hpp> // for boost::fusion::filter_if
@@ -787,14 +786,6 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
       (obb_max_pointy + obb_min_pointy) / 2.0f,
       (obb_max_pointz + obb_min_pointz) / 2.0f);
 
-  //obb_min_point.x -= shift(0);//position of the min OBB vertix relative to (OBB centroid, major_axis, middle_axis, minor_axis)
-  //obb_min_point.y -= shift(1);
-  //obb_min_point.z -= shift(2);
-
-  //obb_max_point.x -= shift(0);//position of the max OBB vertix relative to (OBB centroid, major_axis, middle_axis, minor_axis)
-  //obb_max_point.y -= shift(1);
-  //obb_max_point.z -= shift(2);
-
   obb_dimensions(0) = obb_max_pointx - obb_min_pointx;
   obb_dimensions(1) = obb_max_pointy - obb_min_pointy;
   obb_dimensions(2) = obb_max_pointz - obb_min_pointz;
@@ -933,14 +924,6 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
     shift((obb_max_pointx + obb_min_pointx) / 2.0f,
       (obb_max_pointy + obb_min_pointy) / 2.0f,
       (obb_max_pointz + obb_min_pointz) / 2.0f);
-
-  //obb_min_point.x -= shift(0);//position of the min OBB vertix relative to (OBB centroid, major_axis, middle_axis, minor_axis)
-  //obb_min_point.y -= shift(1);
-  //obb_min_point.z -= shift(2);
-
-  //obb_max_point.x -= shift(0);//position of the max OBB vertix relative to (OBB centroid, major_axis, middle_axis, minor_axis)
-  //obb_max_point.y -= shift(1);
-  //obb_max_point.z -= shift(2);
 
   obb_dimensions(0) = obb_max_pointx - obb_min_pointx;
   obb_dimensions(1) = obb_max_pointy - obb_min_pointy;

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -709,6 +709,8 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   //if you substitute the following Scalars with floats you get a 20% worse processing time, if with 2 PointT 55% worse
   Scalar obb_min_pointx, obb_min_pointy, obb_min_pointz;
   Scalar obb_max_pointx, obb_max_pointy, obb_max_pointz;
+  obb_min_pointx = obb_min_pointy = obb_min_pointz = std::numeric_limits<Scalar>::max();
+  obb_max_pointx = obb_max_pointy = obb_max_pointz = std::numeric_limits<Scalar>::min();
 
   if (cloud.is_dense)
   {
@@ -852,6 +854,8 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   //if you substitute the following Scalars with floats you get a 20% worse processing time, if with 2 PointT 55% worse
   Scalar obb_min_pointx, obb_min_pointy, obb_min_pointz;
   Scalar obb_max_pointx, obb_max_pointy, obb_max_pointz;
+  obb_min_pointx = obb_min_pointy = obb_min_pointz = std::numeric_limits<Scalar>::max();
+  obb_max_pointx = obb_max_pointy = obb_max_pointz = std::numeric_limits<Scalar>::min();
 
   if (cloud.is_dense)
   {

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -668,7 +668,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 {
   Eigen::Matrix<Scalar, 3, 3> covariance_matrix;
   Eigen::Matrix<Scalar, 4, 1> centroid4;
-  const auto point_count= computeMeanAndCovarianceMatrix(cloud, covariance_matrix, centroid4);
+  const auto point_count = computeMeanAndCovarianceMatrix(cloud, covariance_matrix, centroid4);
   if (!point_count)
     return (0);
   centroid(0) = centroid4(0);
@@ -707,7 +707,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
   if (cloud.is_dense)
   {
-    const auto & point = cloud[0];
+    const auto& point = cloud[0];
     Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
     Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
@@ -717,7 +717,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
     for (size_t i=1; i<cloud.size();++i)
     {
-      const auto &  point = cloud[i];
+      const auto&  point = cloud[i];
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
       Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
@@ -740,7 +740,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
     size_t i = 0;
     for (; i < cloud.size(); ++i)
     {
-      const auto &  point = cloud[i];
+      const auto&  point = cloud[i];
       if (!isFinite(point))
         continue;
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
@@ -755,7 +755,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
     for (; i<cloud.size();++i)
     {
-      const auto &  point = cloud[i];
+      const auto&  point = cloud[i];
       if (!isFinite(point))
         continue;
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
@@ -802,7 +802,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 {
   Eigen::Matrix<Scalar, 3, 3> covariance_matrix;
   Eigen::Matrix<Scalar, 4, 1> centroid4;
-  const auto point_count= computeMeanAndCovarianceMatrix(cloud, indices, covariance_matrix, centroid4);
+  const auto point_count = computeMeanAndCovarianceMatrix(cloud, indices, covariance_matrix, centroid4);
   if (!point_count)
     return (0);
   centroid(0) = centroid4(0);
@@ -841,7 +841,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
   if (cloud.is_dense)
   {
-    const auto &  point = cloud[indices[0]];
+    const auto&  point = cloud[indices[0]];
     Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
     Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
@@ -875,7 +875,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
     size_t i = 0;
     for (; i<indices.size();++i)
     {
-      const auto &  point = cloud[indices[i]];
+      const auto&  point = cloud[indices[i]];
       if (!isFinite(point))
         continue;
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
@@ -890,7 +890,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
     for (; i<indices.size();++i)
     {
-      const auto &  point = cloud[indices[i]];
+      const auto&  point = cloud[indices[i]];
       if (!isFinite(point))
         continue;
 

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -53,7 +53,6 @@
 namespace pcl
 {
 
-
 template <typename PointT, typename Scalar> inline unsigned int
 compute3DCentroid (ConstCloudIterator<PointT> &cloud_iterator,
                    Eigen::Matrix<Scalar, 4, 1> &centroid)
@@ -669,24 +668,19 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 {
   Eigen::Matrix<Scalar, 3, 3> covariance_matrix;
   Eigen::Matrix<Scalar, 4, 1> centroid4;
-  unsigned int point_count= computeMeanAndCovarianceMatrix(cloud, covariance_matrix, centroid4);
+  const auto point_count= computeMeanAndCovarianceMatrix(cloud, covariance_matrix, centroid4);
   if (!point_count)
     return (0);
   centroid(0) = centroid4(0);
   centroid(1) = centroid4(1);
   centroid(2) = centroid4(2);
 
-  Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Scalar, 3, 3>> evd(covariance_matrix);
-
-  Eigen::Matrix<Scalar, 3, 3> eigenvectors_ = evd.eigenvectors();
-  Eigen::Matrix<Scalar, 3, 1> major_axis;
-  Eigen::Matrix<Scalar, 3, 1> middle_axis;
-  Eigen::Matrix<Scalar, 3, 1> minor_axis;
-
-  minor_axis = eigenvectors_.col(0);//the eigenvectors do not need to be normalized (they are already)
-  middle_axis = eigenvectors_.col(1);
-  // Enforce right hand rule
-  major_axis = middle_axis.cross(minor_axis);
+  const Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Scalar, 3, 3>> evd(covariance_matrix);
+  const Eigen::Matrix<Scalar, 3, 3> eigenvectors_ = evd.eigenvectors();
+  const Eigen::Matrix<Scalar, 3, 1> minor_axis = eigenvectors_.col(0);//the eigenvectors do not need to be normalized (they are already)
+  const Eigen::Matrix<Scalar, 3, 1> middle_axis = eigenvectors_.col(1);
+  // Enforce right hand rule:
+  const Eigen::Matrix<Scalar, 3, 1> major_axis = middle_axis.cross(minor_axis);
 
   obb_rotational_matrix <<
     major_axis(0), middle_axis(0), minor_axis(0),
@@ -713,7 +707,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
   if (cloud.is_dense)
   {
-    auto point = cloud[0];
+    const auto & point = cloud[0];
     Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
     Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
@@ -723,7 +717,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
     for (size_t i=1; i<cloud.size();++i)
     {
-      auto point = cloud[i];
+      const auto &  point = cloud[i];
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
       Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
@@ -746,7 +740,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
     size_t i = 0;
     for (; i < cloud.size(); ++i)
     {
-      auto point = cloud[i];
+      const auto &  point = cloud[i];
       if (!isFinite(point))
         continue;
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
@@ -761,7 +755,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
     for (; i<cloud.size();++i)
     {
-      auto point = cloud[i];
+      const auto &  point = cloud[i];
       if (!isFinite(point))
         continue;
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
@@ -783,7 +777,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
   }
 
-  Eigen::Matrix<Scalar, 3, 1>  //shift between point cloud centroid and OBB center (position of the OBB center relative to (p.c.centroid, major_axis, middle_axis, minor_axis))
+  const Eigen::Matrix<Scalar, 3, 1>  //shift between point cloud centroid and OBB center (position of the OBB center relative to (p.c.centroid, major_axis, middle_axis, minor_axis))
     shift((obb_max_pointx + obb_min_pointx) / 2.0f,
       (obb_max_pointy + obb_min_pointy) / 2.0f,
       (obb_max_pointz + obb_min_pointz) / 2.0f);
@@ -792,9 +786,9 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   obb_dimensions(1) = obb_max_pointy - obb_min_pointy;
   obb_dimensions(2) = obb_max_pointz - obb_min_pointz;
 
-  obb_center = centroid+ obb_rotational_matrix * shift;//position of the OBB center in the same reference Oxyz of the point cloud
+  obb_center = centroid + obb_rotational_matrix * shift;//position of the OBB center in the same reference Oxyz of the point cloud
 
-  return ( point_count);
+  return (point_count);
 }
 
 
@@ -808,24 +802,19 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 {
   Eigen::Matrix<Scalar, 3, 3> covariance_matrix;
   Eigen::Matrix<Scalar, 4, 1> centroid4;
-  unsigned int point_count= computeMeanAndCovarianceMatrix(cloud, indices, covariance_matrix, centroid4);
+  const auto point_count= computeMeanAndCovarianceMatrix(cloud, indices, covariance_matrix, centroid4);
   if (!point_count)
     return (0);
   centroid(0) = centroid4(0);
   centroid(1) = centroid4(1);
   centroid(2) = centroid4(2);
 
-  Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Scalar, 3, 3>> evd(covariance_matrix);
-
-  Eigen::Matrix<Scalar, 3, 3> eigenvectors_ = evd.eigenvectors();
-  Eigen::Matrix<Scalar, 3, 1> major_axis;
-  Eigen::Matrix<Scalar, 3, 1> middle_axis;
-  Eigen::Matrix<Scalar, 3, 1> minor_axis;
-
-  minor_axis = eigenvectors_.col(0);//the eigenvectors do not need to be normalized (they are already)
-  middle_axis = eigenvectors_.col(1);
-  // Enforce right hand rule
-  major_axis = middle_axis.cross(minor_axis);
+  const Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Scalar, 3, 3>> evd(covariance_matrix);
+  const Eigen::Matrix<Scalar, 3, 3> eigenvectors_ = evd.eigenvectors();
+  const Eigen::Matrix<Scalar, 3, 1> minor_axis = eigenvectors_.col(0);//the eigenvectors do not need to be normalized (they are already)
+  const Eigen::Matrix<Scalar, 3, 1> middle_axis = eigenvectors_.col(1);
+  // Enforce right hand rule:
+  const Eigen::Matrix<Scalar, 3, 1> major_axis = middle_axis.cross(minor_axis);
 
   obb_rotational_matrix <<
     major_axis(0), middle_axis(0), minor_axis(0),
@@ -852,7 +841,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
   if (cloud.is_dense)
   {
-    auto point = cloud[indices[0]];
+    const auto &  point = cloud[indices[0]];
     Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
     Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
 
@@ -862,7 +851,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
     for (size_t i=1; i<indices.size();++i)
     {
-      auto point = cloud[indices[i]];
+      const auto &  point = cloud[indices[i]];
 
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
       Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
@@ -886,7 +875,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
     size_t i = 0;
     for (; i<indices.size();++i)
     {
-      auto point = cloud[indices[i]];
+      const auto &  point = cloud[indices[i]];
       if (!isFinite(point))
         continue;
       Eigen::Matrix<Scalar, 4, 1> P0(static_cast<Scalar>(point.x), static_cast<Scalar>(point.y) , static_cast<Scalar>(point.z), 1.0);
@@ -901,7 +890,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
     for (; i<indices.size();++i)
     {
-      auto point = cloud[indices[i]];
+      const auto &  point = cloud[indices[i]];
       if (!isFinite(point))
         continue;
 
@@ -924,7 +913,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
   }
 
-  Eigen::Matrix<Scalar, 3, 1>  //shift between point cloud centroid and OBB center (position of the OBB center relative to (p.c.centroid, major_axis, middle_axis, minor_axis))
+  const Eigen::Matrix<Scalar, 3, 1>  //shift between point cloud centroid and OBB center (position of the OBB center relative to (p.c.centroid, major_axis, middle_axis, minor_axis))
     shift((obb_max_pointx + obb_min_pointx) / 2.0f,
       (obb_max_pointy + obb_min_pointy) / 2.0f,
       (obb_max_pointz + obb_min_pointz) / 2.0f);
@@ -933,9 +922,9 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   obb_dimensions(1) = obb_max_pointy - obb_min_pointy;
   obb_dimensions(2) = obb_max_pointz - obb_min_pointz;
 
-  obb_center = centroid+ obb_rotational_matrix * shift;//position of the OBB center in the same reference Oxyz of the point cloud
+  obb_center = centroid + obb_rotational_matrix * shift;//position of the OBB center in the same reference Oxyz of the point cloud
 
-  return ( point_count);
+  return (point_count);
 }
 
 

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -661,11 +661,6 @@ computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   return (computeMeanAndCovarianceMatrix (cloud, indices.indices, covariance_matrix, centroid));
 }
 
-
-
-
-
-
 template <typename PointT, typename Scalar> inline unsigned int
 computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   Eigen::Matrix<Scalar, 3, 1> &centroid,
@@ -678,7 +673,9 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   unsigned int point_count= computeMeanAndCovarianceMatrix(cloud, covariance_matrix, centroid4);
   if (!point_count)
     return (0);
-  centroid = centroid4.head<3>();
+  centroid(0) = centroid4(0);
+  centroid(1) = centroid4(1);
+  centroid(2) = centroid4(2);
 
   Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Scalar, 3, 3>> evd(covariance_matrix);
 
@@ -701,7 +698,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   //obb_rotational_matrix.col(2)==minor_axis
 
   //Trasforming the point cloud in the (Centroid, ma-mi-mi_axis) reference
-  //with homogenoeus matrix
+  //with homogeneous matrix
   //[R^t  , -R^t*Centroid ]
   //[0    , 1             ]
   Eigen::Matrix<Scalar, 4, 4> transform = Eigen::Matrix<Scalar, 4, 4>::Identity();
@@ -715,7 +712,6 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
   if (cloud.is_dense)
   {
-
     auto point = cloud.points[0];
     Eigen::Matrix<Scalar, 4, 1> P0((Scalar)(point.x),(Scalar)(point.y) , (Scalar)(point.z), 1.0);
     Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
@@ -784,8 +780,6 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
   }
 
-
-
   Eigen::Matrix<Scalar, 3, 1>  //shift between point cloud centroid and OBB centroid (position of the OBB centroid relative to (p.c.centroid, major_axis, middle_axis, minor_axis))
     shift((obb_max_pointx + obb_min_pointx) / 2.0f,
       (obb_max_pointy + obb_min_pointy) / 2.0f,
@@ -809,7 +803,6 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 }
 
 
-
 template <typename PointT, typename Scalar> inline unsigned int
 computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   const Indices &indices,
@@ -823,7 +816,9 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   unsigned int point_count= computeMeanAndCovarianceMatrix(cloud, indices, covariance_matrix, centroid4);
   if (!point_count)
     return (0);
-  centroid = centroid4.head<3>();
+  centroid(0) = centroid4(0);
+  centroid(1) = centroid4(1);
+  centroid(2) = centroid4(2);
 
   Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Scalar, 3, 3>> evd(covariance_matrix);
 
@@ -846,7 +841,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   //obb_rotational_matrix.col(2)==minor_axis
 
   //Trasforming the point cloud in the (Centroid, ma-mi-mi_axis) reference
-  //with homogenoeus matrix
+  //with homogeneous matrix
   //[R^t  , -R^t*Centroid ]
   //[0    , 1             ]
   Eigen::Matrix<Scalar, 4, 4> transform = Eigen::Matrix<Scalar, 4, 4>::Identity();
@@ -860,7 +855,6 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
   if (cloud.is_dense)
   {
-
     auto point = cloud.points[indices[0]];
     Eigen::Matrix<Scalar, 4, 1> P0((Scalar)(point.x), (Scalar)(point.y), (Scalar)(point.z), 1.0);
     Eigen::Matrix<Scalar, 4, 1> P = transform * P0;
@@ -931,8 +925,6 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
   }
 
-
-
   Eigen::Matrix<Scalar, 3, 1>  //shift between point cloud centroid and OBB centroid (position of the OBB centroid relative to (p.c.centroid, major_axis, middle_axis, minor_axis))
     shift((obb_max_pointx + obb_min_pointx) / 2.0f,
       (obb_max_pointy + obb_min_pointy) / 2.0f,
@@ -954,7 +946,6 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
 
   return ( point_count);
 }
-
 
 
 

--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -43,6 +43,7 @@
 #include <pcl/common/centroid.h>
 #include <pcl/conversions.h>
 #include <pcl/common/point_tests.h> // for pcl::isFinite
+#include <Eigen/Eigenvalues> // for EigenSolver
 
 #include <boost/fusion/algorithm/transformation/filter_if.hpp> // for boost::fusion::filter_if
 #include <boost/fusion/algorithm/iteration/for_each.hpp> // for boost::fusion::for_each
@@ -560,17 +561,17 @@ computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   if (point_count != 0)
   {
     accu /= static_cast<Scalar> (point_count);
-    centroid[0] = accu[6] + K.x(); centroid[1] = accu[7] + K.y(); centroid[2] = accu[8] + K.z();
+    centroid[0] = accu[6] + K.x(); centroid[1] = accu[7] + K.y(); centroid[2] = accu[8] + K.z();//effective mean E[P=(x,y,z)]
     centroid[3] = 1;
-    covariance_matrix.coeffRef (0) = accu [0] - accu [6] * accu [6];
-    covariance_matrix.coeffRef (1) = accu [1] - accu [6] * accu [7];
-    covariance_matrix.coeffRef (2) = accu [2] - accu [6] * accu [8];
-    covariance_matrix.coeffRef (4) = accu [3] - accu [7] * accu [7];
-    covariance_matrix.coeffRef (5) = accu [4] - accu [7] * accu [8];
-    covariance_matrix.coeffRef (8) = accu [5] - accu [8] * accu [8];
-    covariance_matrix.coeffRef (3) = covariance_matrix.coeff (1);
-    covariance_matrix.coeffRef (6) = covariance_matrix.coeff (2);
-    covariance_matrix.coeffRef (7) = covariance_matrix.coeff (5);
+    covariance_matrix.coeffRef (0) = accu [0] - accu [6] * accu [6];//(0,0)xx : E[(x-E[x])^2]=E[x^2]-E[x]^2=E[(x-Kx)^2]-E[x-Kx]^2
+    covariance_matrix.coeffRef (1) = accu [1] - accu [6] * accu [7];//(0,1)xy : E[(x-E[x])(y-E[y])]=E[xy]-E[x]E[y]=E[(x-Kx)(y-Ky)]-E[x-Kx]E[y-Ky]
+    covariance_matrix.coeffRef (2) = accu [2] - accu [6] * accu [8];//(0,2)xz
+    covariance_matrix.coeffRef (4) = accu [3] - accu [7] * accu [7];//(1,1)yy
+    covariance_matrix.coeffRef (5) = accu [4] - accu [7] * accu [8];//(1,2)yz
+    covariance_matrix.coeffRef (8) = accu [5] - accu [8] * accu [8];//(2,2)zz
+    covariance_matrix.coeffRef (3) = covariance_matrix.coeff (1);   //(1,0)yx
+    covariance_matrix.coeffRef (6) = covariance_matrix.coeff (2);   //(2,0)zx
+    covariance_matrix.coeffRef (7) = covariance_matrix.coeff (5);   //(2,1)zy
   }
   return (static_cast<unsigned int> (point_count));
 }
@@ -633,17 +634,17 @@ computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
   if (point_count != 0)
   {
     accu /= static_cast<Scalar> (point_count);
-    centroid[0] = accu[6] + K.x(); centroid[1] = accu[7] + K.y(); centroid[2] = accu[8] + K.z();
+    centroid[0] = accu[6] + K.x(); centroid[1] = accu[7] + K.y(); centroid[2] = accu[8] + K.z();//effective mean E[P=(x,y,z)]
     centroid[3] = 1;
-    covariance_matrix.coeffRef (0) = accu [0] - accu [6] * accu [6];
-    covariance_matrix.coeffRef (1) = accu [1] - accu [6] * accu [7];
-    covariance_matrix.coeffRef (2) = accu [2] - accu [6] * accu [8];
-    covariance_matrix.coeffRef (4) = accu [3] - accu [7] * accu [7];
-    covariance_matrix.coeffRef (5) = accu [4] - accu [7] * accu [8];
-    covariance_matrix.coeffRef (8) = accu [5] - accu [8] * accu [8];
-    covariance_matrix.coeffRef (3) = covariance_matrix.coeff (1);
-    covariance_matrix.coeffRef (6) = covariance_matrix.coeff (2);
-    covariance_matrix.coeffRef (7) = covariance_matrix.coeff (5);
+    covariance_matrix.coeffRef (0) = accu [0] - accu [6] * accu [6];//(0,0)xx : E[(x-E[x])^2]=E[x^2]-E[x]^2=E[(x-Kx)^2]-E[x-Kx]^2
+    covariance_matrix.coeffRef (1) = accu [1] - accu [6] * accu [7];//(0,1)xy : E[(x-E[x])(y-E[y])]=E[xy]-E[x]E[y]=E[(x-Kx)(y-Ky)]-E[x-Kx]E[y-Ky]
+    covariance_matrix.coeffRef (2) = accu [2] - accu [6] * accu [8];//(0,2)xz
+    covariance_matrix.coeffRef (4) = accu [3] - accu [7] * accu [7];//(1,1)yy
+    covariance_matrix.coeffRef (5) = accu [4] - accu [7] * accu [8];//(1,2)yz
+    covariance_matrix.coeffRef (8) = accu [5] - accu [8] * accu [8];//(2,2)zz
+    covariance_matrix.coeffRef (3) = covariance_matrix.coeff (1);   //(1,0)yx
+    covariance_matrix.coeffRef (6) = covariance_matrix.coeff (2);   //(2,0)zx
+    covariance_matrix.coeffRef (7) = covariance_matrix.coeff (5);   //(2,1)zy
   }
   return (static_cast<unsigned int> (point_count));
 }
@@ -657,6 +658,270 @@ computeMeanAndCovarianceMatrix (const pcl::PointCloud<PointT> &cloud,
 {
   return (computeMeanAndCovarianceMatrix (cloud, indices.indices, covariance_matrix, centroid));
 }
+
+
+
+
+
+template <typename PointT, typename Scalar> inline unsigned int
+computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
+                  Eigen::Matrix<Scalar, 3, 1> &centroid,
+                  Eigen::Matrix<Scalar, 3, 1> &obb_center,
+                  Eigen::Matrix<Scalar, 3, 1> &obb_dimensions,
+                  Eigen::Matrix<Scalar, 3, 3> &obb_rotational_matrix)
+{
+    Eigen::Matrix<Scalar, 3, 3> covariance_matrix;
+    Eigen::Matrix<Scalar, 4, 1> centroid4;
+    unsigned int point_count= computeMeanAndCovarianceMatrix(cloud, covariance_matrix, centroid4);
+    if (!point_count)
+      return (0);
+    centroid(0) = centroid4(0);
+    centroid(1) = centroid4(1);
+    centroid(2) = centroid4(2);
+
+    Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Scalar, 3, 3>> evd(covariance_matrix);
+
+    //Eigen::Vector<Scalar, 3> eigenvalues_ = evd.eigenvalues();
+    //major_value =    eigenvalues_(2); //promem order
+    //middle_value =   eigenvalues_(1);
+    //minor_value =    eigenvalues_(0);
+
+    Eigen::Matrix<Scalar, 3, 3> eigenvectors_ = evd.eigenvectors();
+    Eigen::Matrix<Scalar, 3, 1> major_axis;
+    Eigen::Matrix<Scalar, 3, 1> middle_axis;
+    Eigen::Matrix<Scalar, 3, 1> minor_axis;
+
+    minor_axis = eigenvectors_.col(0);//the eigenvectors do not need to be normalized (they are already)
+    middle_axis = eigenvectors_.col(1);
+
+    // cross product of the other two: ux = uy X uz   major = middle X minor
+    major_axis(0) = middle_axis(1) * minor_axis(2) - middle_axis(2) * minor_axis(1);
+    major_axis(1) = middle_axis(2) * minor_axis(0) - middle_axis(0) * minor_axis(2);
+    major_axis(2) = middle_axis(0) * minor_axis(1) - middle_axis(1) * minor_axis(0);
+
+    //when Scalar==double on a Windows 10 machine and MSVS:
+    //if you substitute the following Scalars with floats you get a 20% worse processing time, if with 2 PointT 55% worse
+    Scalar obb_min_pointx, obb_min_pointy, obb_min_pointz;
+    Scalar obb_max_pointx, obb_max_pointy, obb_max_pointz;
+    obb_min_pointx = obb_min_pointy = obb_min_pointz = std::numeric_limits<Scalar>::max();
+    obb_max_pointx = obb_max_pointy = obb_max_pointz = std::numeric_limits<Scalar>::min();
+
+    if (cloud.is_dense)
+    {
+      for (const auto& point : cloud)
+      {
+        Scalar xd = point.x - centroid[0], yd = point.y - centroid[1], zd = point.z - centroid[2];
+
+        Scalar x = xd * major_axis(0) + yd * major_axis(1) + zd * major_axis(2);
+        Scalar y = xd * middle_axis(0) + yd * middle_axis(1) + zd * middle_axis(2);
+        Scalar z = xd * minor_axis(0) + yd * minor_axis(1) + zd * minor_axis(2);
+
+        if (x <= obb_min_pointx)
+          obb_min_pointx = x;
+        if (y <= obb_min_pointy)
+          obb_min_pointy = y;
+        if (z <= obb_min_pointz)
+          obb_min_pointz = z;
+
+        if (x >= obb_max_pointx)
+          obb_max_pointx = x;
+        if (y >= obb_max_pointy)
+          obb_max_pointy = y;
+        if (z >= obb_max_pointz)
+          obb_max_pointz = z;
+      }
+    }
+    else
+    {
+      for (const auto& point: cloud)
+      {
+        if (!isFinite (point))
+          continue;
+
+        Scalar xd = point.x - centroid[0], yd = point.y - centroid[1], zd = point.z - centroid[2];
+
+        Scalar x = xd * major_axis(0) + yd * major_axis(1) + zd * major_axis(2);
+        Scalar y = xd * middle_axis(0) + yd * middle_axis(1) + zd * middle_axis(2);
+        Scalar z = xd * minor_axis(0) + yd * minor_axis(1) + zd * minor_axis(2);
+
+        if (x <= obb_min_pointx)
+          obb_min_pointx = x;
+        if (y <= obb_min_pointy)
+          obb_min_pointy = y;
+        if (z <= obb_min_pointz)
+          obb_min_pointz = z;
+
+        if (x >= obb_max_pointx)
+          obb_max_pointx = x;
+        if (y >= obb_max_pointy)
+          obb_max_pointy = y;
+        if (z >= obb_max_pointz)
+          obb_max_pointz = z;
+      }
+    }
+
+    obb_rotational_matrix <<
+      major_axis(0), middle_axis(0), minor_axis(0),
+      major_axis(1), middle_axis(1), minor_axis(1),
+      major_axis(2), middle_axis(2), minor_axis(2);
+    //obb_rotational_matrix.col(0)==major_axis
+    //obb_rotational_matrix.col(1)==middle_axis
+    //obb_rotational_matrix.col(2)==minor_axis
+
+    Eigen::Matrix<Scalar, 3, 1>  //shift between point cloud centroid and OBB centroid (position of the OBB centroid relative to (p.c.centroid, major_axis, middle_axis, minor_axis))
+      shift((obb_max_pointx + obb_min_pointx) / 2.0f,
+      (obb_max_pointy + obb_min_pointy) / 2.0f,
+      (obb_max_pointz + obb_min_pointz) / 2.0f);
+
+    //obb_min_point.x -= shift(0);//position of the min OBB vertix relative to (OBB centroid, major_axis, middle_axis, minor_axis)
+    //obb_min_point.y -= shift(1);
+    //obb_min_point.z -= shift(2);
+
+    //obb_max_point.x -= shift(0);//position of the max OBB vertix relative to (OBB centroid, major_axis, middle_axis, minor_axis)
+    //obb_max_point.y -= shift(1);
+    //obb_max_point.z -= shift(2);
+
+    obb_dimensions(0) = obb_max_pointx - obb_min_pointx;
+    obb_dimensions(1) = obb_max_pointy - obb_min_pointy;
+    obb_dimensions(2) = obb_max_pointz - obb_min_pointz;
+
+    obb_center = centroid+ obb_rotational_matrix * shift;//position of the OBB centroid in the same reference Oxyz of the point cloud
+
+    return ( point_count);
+}
+
+template <typename PointT, typename Scalar> inline unsigned int
+computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
+                  const Indices &indices,
+                  Eigen::Matrix<Scalar, 3, 1> &centroid,
+                  Eigen::Matrix<Scalar, 3, 1> &obb_center,
+                  Eigen::Matrix<Scalar, 3, 1> &obb_dimensions,
+                  Eigen::Matrix<Scalar, 3, 3> &obb_rotational_matrix)
+{
+
+  Eigen::Matrix<Scalar, 3, 3> covariance_matrix;
+  Eigen::Matrix<Scalar, 4, 1> centroid4;
+  unsigned int point_count= computeMeanAndCovarianceMatrix(cloud, indices, covariance_matrix, centroid4);
+  if (!point_count)
+    return (0);
+  centroid(0) = centroid4(0);
+  centroid(1) = centroid4(1);
+  centroid(2) = centroid4(2);
+
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix<Scalar, 3, 3>> evd(covariance_matrix);
+
+  //Eigen::Vector<Scalar, 3> eigenvalues_ = evd.eigenvalues();
+  //major_value =    eigenvalues_(2); //promem order
+  //middle_value =   eigenvalues_(1);
+  //minor_value =    eigenvalues_(0);
+
+  Eigen::Matrix<Scalar, 3, 3> eigenvectors_ = evd.eigenvectors();
+  Eigen::Matrix<Scalar, 3, 1> major_axis;
+  Eigen::Matrix<Scalar, 3, 1> middle_axis;
+  Eigen::Matrix<Scalar, 3, 1> minor_axis;
+
+  minor_axis = eigenvectors_.col(0);//the eigenvectors do not need to be normalized (they already are)
+  middle_axis = eigenvectors_.col(1);
+
+  // cross product of the other two: ux = uy X uz   major = middle X minor
+  major_axis(0) = middle_axis(1) * minor_axis(2) - middle_axis(2) * minor_axis(1);
+  major_axis(1) = middle_axis(2) * minor_axis(0) - middle_axis(0) * minor_axis(2);
+  major_axis(2) = middle_axis(0) * minor_axis(1) - middle_axis(1) * minor_axis(0);
+
+  //when Scalar==double on a Windows 10 machine and MSVS:
+  //if you substitute the following Scalars with floats you get a 20% worse processing time, if with 2 PointT 55% worse
+  Scalar obb_min_pointx, obb_min_pointy, obb_min_pointz;
+  Scalar obb_max_pointx, obb_max_pointy, obb_max_pointz;
+  obb_min_pointx = obb_min_pointy = obb_min_pointz = std::numeric_limits<Scalar>::max();
+  obb_max_pointx = obb_max_pointy = obb_max_pointz = std::numeric_limits<Scalar>::min();
+
+  if (cloud.is_dense)
+  {
+    for (const auto &index : indices)
+    {
+      auto point = cloud[index];
+      Scalar xd = point.x - centroid[0], yd = point.y - centroid[1], zd = point.z - centroid[2];
+
+      Scalar x = xd * major_axis(0) + yd * major_axis(1) + zd * major_axis(2);
+      Scalar y = xd * middle_axis(0) + yd * middle_axis(1) + zd * middle_axis(2);
+      Scalar z = xd * minor_axis(0) + yd * minor_axis(1) + zd * minor_axis(2);
+
+      if (x <= obb_min_pointx)
+        obb_min_pointx = x;
+      if (y <= obb_min_pointy)
+        obb_min_pointy = y;
+      if (z <= obb_min_pointz)
+        obb_min_pointz = z;
+
+      if (x >= obb_max_pointx)
+        obb_max_pointx = x;
+      if (y >= obb_max_pointy)
+        obb_max_pointy = y;
+      if (z >= obb_max_pointz)
+        obb_max_pointz = z;
+    }
+  }
+  else
+  {
+    for (const auto &index : indices)
+    {
+      auto point = cloud[index];
+      if (!isFinite (point))
+        continue;
+
+      Scalar xd = point.x - centroid[0], yd = point.y - centroid[1], zd = point.z - centroid[2];
+
+      Scalar x = xd * major_axis(0) + yd * major_axis(1) + zd * major_axis(2);
+      Scalar y = xd * middle_axis(0) + yd * middle_axis(1) + zd * middle_axis(2);
+      Scalar z = xd * minor_axis(0) + yd * minor_axis(1) + zd * minor_axis(2);
+
+      if (x <= obb_min_pointx)
+        obb_min_pointx = x;
+      if (y <= obb_min_pointy)
+        obb_min_pointy = y;
+      if (z <= obb_min_pointz)
+        obb_min_pointz = z;
+
+      if (x >= obb_max_pointx)
+        obb_max_pointx = x;
+      if (y >= obb_max_pointy)
+        obb_max_pointy = y;
+      if (z >= obb_max_pointz)
+        obb_max_pointz = z;
+    }
+  }
+
+  obb_rotational_matrix <<
+    major_axis(0), middle_axis(0), minor_axis(0),
+    major_axis(1), middle_axis(1), minor_axis(1),
+    major_axis(2), middle_axis(2), minor_axis(2);
+  //obb_rotational_matrix.col(0)==major_axis
+  //obb_rotational_matrix.col(1)==middle_axis
+  //obb_rotational_matrix.col(2)==minor_axis
+
+  Eigen::Matrix<Scalar, 3, 1>  //shift between point cloud centroid and OBB centroid (position of the OBB centroid relative to (p.c.centroid, major_axis, middle_axis, minor_axis))
+    shift((obb_max_pointx + obb_min_pointx) / 2.0f,
+      (obb_max_pointy + obb_min_pointy) / 2.0f,
+      (obb_max_pointz + obb_min_pointz) / 2.0f);
+
+  //obb_min_point.x -= shift(0);//position of the min OBB vertix relative to (OBB centroid, major_axis, middle_axis, minor_axis)
+  //obb_min_point.y -= shift(1);
+  //obb_min_point.z -= shift(2);
+
+  //obb_max_point.x -= shift(0);//position of the max OBB vertix relative to (OBB centroid, major_axis, middle_axis, minor_axis)
+  //obb_max_point.y -= shift(1);
+  //obb_max_point.z -= shift(2);
+
+  obb_dimensions(0) = obb_max_pointx - obb_min_pointx;
+  obb_dimensions(1) = obb_max_pointy - obb_min_pointy;
+  obb_dimensions(2) = obb_max_pointz - obb_min_pointz;
+
+  obb_center = centroid+ obb_rotational_matrix * shift;//position of the OBB centroid in the same reference Oxyz of the point cloud
+
+  return ( point_count);
+}
+
+
 
 
 template <typename PointT, typename Scalar> void

--- a/doc/tutorials/content/moment_of_inertia.rst
+++ b/doc/tutorials/content/moment_of_inertia.rst
@@ -5,7 +5,8 @@ Moment of inertia and eccentricity based descriptors
 
 In this tutorial we will learn how to use the `pcl::MomentOfInertiaEstimation` class in order to obtain descriptors based on
 eccentricity and moment of inertia. This class also allows to extract axis aligned and oriented bounding boxes of the cloud.
-But keep in mind that extracted OBB is not the minimal possible bounding box.
+But keep in mind that extracted OBB is not the minimal possible bounding box. Users who only need the OBB or AABB, but not the descriptors,
+should use respectively computeCentroidAndOBB or getMinMax3D (faster).
 
 Theoretical Primer
 ------------------


### PR DESCRIPTION

  /** \brief Compute centroid, OBB, PCA axes of a given set of points.
  * OBB is oriented like the three axes (major, middle and minor) with
  * major_axis  = obb_rotational_matrix.col(0)
  * middle_axis = obb_rotational_matrix.col(1)
  * minor_axis  = obb_rotational_matrix.col(2)
  * one way to visualize OBB when Scalar is float:
  * Eigen::Vector3f position(obb_position(0), obb_position(1), obb_position(2));
  * Eigen::Quaternionf quat(obb_rotational_matrix);
  * viewer->addCube(position, quat, obb_dimensions(0), obb_dimensions(1), obb_dimensions(2), .....);
  * \param[in] cloud the input point cloud
  * \param[out] centroid the centroid of the set of points in the cloud
  * \param[out] obb_center position of the centroid of the OBB (Oriented Bounding Box)
  * \param[out] obb_dimensions (width, height and depth) of the OBB (Oriented Bounding Box)
  * \param[out] obb_rotational_matrix rotational matrix of the OBB (Oriented Bounding Box)
  * \return number of valid points used to determine the output.
  * In case of dense point clouds, this is the same as the size of the input cloud.
  * \ingroup common
  */

light connection with issue https://github.com/PointCloudLibrary/pcl/issues/5659 which can be closed after this merge