### PR TITLE
Make io more locale invariant

### DIFF
--- a/io/include/pcl/io/file_io.h
+++ b/io/include/pcl/io/file_io.h
@@ -342,6 +342,7 @@ namespace pcl
     }
     else {
       is.str(st);
+      is.clear(); // clear error state flags
       if (!(is >> value))
         value = static_cast<Type>(atof(st.c_str()));
     }
@@ -364,6 +365,7 @@ namespace pcl
     std::int8_t value;
     int val;
     is.str(st);
+    is.clear(); // clear error state flags
     // is >> val;  -- unfortunately this fails on older GCC versions and CLANG on MacOS
     if (!(is >> val)) {
       val = static_cast<int>(atof(st.c_str()));
@@ -388,6 +390,7 @@ namespace pcl
     std::uint8_t value;
     int val;
     is.str(st);
+    is.clear(); // clear error state flags
     // is >> val;  -- unfortunately this fails on older GCC versions and CLANG on
     // MacOS
     if (!(is >> val)) {

--- a/io/src/ply_io.cpp
+++ b/io/src/ply_io.cpp
@@ -787,6 +787,7 @@ pcl::PLYWriter::generateHeader (const pcl::PCLPointCloud2 &cloud,
                                 int valid_points)
 {
   std::ostringstream oss;
+  oss.imbue (std::locale::classic ()); // mostly to make sure that no thousands separator is printed
   // Begin header
   oss << "ply";
   if (!binary)

--- a/test/io/test_ply_io.cpp
+++ b/test/io/test_ply_io.cpp
@@ -105,6 +105,7 @@ TEST (PCL, PLYReaderWriter)
     EXPECT_FLOAT_EQ (cloud[counter].z, cloud2[counter].z);     // test for fromPCLPointCloud2 ()
     EXPECT_FLOAT_EQ (cloud[counter].intensity, cloud2[counter].intensity);  // test for fromPCLPointCloud2 ()
   }
+  remove ("test_pcl_io.ply");
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -567,6 +568,7 @@ TEST_F (PLYTest, Float64Cloud)
 
   // create file
   std::ofstream fs;
+  fs.imbue (std::locale::classic ()); // make sure that floats are printed with decimal point
   fs.open (mesh_file_ply_.c_str ());
   fs << "ply\n"
         "format ascii 1.0\n"


### PR DESCRIPTION
- Expand test: write with English locale, then read with German locale (previously the test only wrote with German, read with English)
- In `copyStringValue` used by PCD reader: clear error flags after replacing content of istringstream, otherwise the `!(is >> value)` test always fails and `atof` is used (which uses the global locale)
- Minor additional improvements

Fixes https://github.com/PointCloudLibrary/pcl/issues/5694