### PR TITLE
ICP: remove possibly inappropriate default setting of rotation convergence threshold when user does not set it.

### DIFF
--- a/registration/include/pcl/registration/impl/icp.hpp
+++ b/registration/include/pcl/registration/impl/icp.hpp
@@ -159,8 +159,6 @@ IterativeClosestPoint<PointSource, PointTarget, Scalar>::computeTransformation(
   convergence_criteria_->setTranslationThreshold(transformation_epsilon_);
   if (transformation_rotation_epsilon_ > 0)
     convergence_criteria_->setRotationThreshold(transformation_rotation_epsilon_);
-  else
-    convergence_criteria_->setRotationThreshold(1.0 - transformation_epsilon_);
 
   // Repeat until convergence
   do {


### PR DESCRIPTION
As per discussion in #5750, it is unclear why this code exists.

If the user does not set a rotation threshold, icp will use 1.0 - translation threshold, which makes no sense as the units are totally different, and the distance unit can be anything, which would change the meaning of the translation threshold.

As for the impact I feel I must be misunderstanding something, as it would seem to be catastrophic:
If e.g. a translation threshold of 0.1 is set, but no rotation threshold, icp will say it converged when the rotation has not changed by more than acos(1 - 0.1) = acos(0.9) ~= 25° if i understand this correctly. This would basically always trigger and prematurely terminate alignment. Maybe this does not usually happen because the translation threshold is not undershot in those cases usually?

Anecdotally, I had an issue where I could not figure out why it would not align better, until I removed my translation threshold, though I cannot say 100% that this was the problem.

Removing this logic will make icp use the convergence criteria's default threshold, which is 0.9999 or some such high value.