### PR TITLE
Fix behaviour of BoxClipper3D

### DIFF
--- a/filters/include/pcl/filters/box_clipper3D.h
+++ b/filters/include/pcl/filters/box_clipper3D.h
@@ -46,7 +46,8 @@ namespace pcl
   /**
     * \author Suat Gedikli <gedikli@willowgarage.com>
     * \brief Implementation of a box clipper in 3D. Actually it allows affine transformations, thus any parallelepiped in general pose.
-    *        The affine transformation is used to transform the point before clipping it using the unit cube centered at origin and with an extend of -1 to +1 in each dimension
+    *        The affine transformation is used to transform the point before clipping it using a cube centered at origin and with an extend of -1 to +1 in each dimension
+    * \sa CropBox
     * \ingroup filters
     */
   template<typename PointT>
@@ -61,7 +62,7 @@ namespace pcl
       /**
         * \author Suat Gedikli <gedikli@willowgarage.com>
         * \brief Constructor taking an affine transformation matrix, which allows also shearing of the clipping area
-        * \param[in] transformation the 3x3 affine transformation matrix that is used to describe the unit cube
+        * \param[in] transformation the 3 dimensional affine transformation that is used to describe the cube ([-1; +1] in each dimension). The transformation is applied to the point(s)!
         */
       BoxClipper3D (const Eigen::Affine3f& transformation);
 
@@ -75,7 +76,7 @@ namespace pcl
 
       /**
         * \brief Set the affine transformation
-        * \param[in] transformation
+        * \param[in] transformation applied to the point(s)
         */
       void setTransformation (const Eigen::Affine3f& transformation);
 
@@ -115,7 +116,7 @@ namespace pcl
       void transformPoint (const PointT& pointIn, PointT& pointOut) const;
     private:
       /**
-        * \brief the affine transformation that is applied before clipping is done on the unit cube.
+        * \brief the affine transformation that is applied before clipping is done on the [-1; +1] cube.
         */
       Eigen::Affine3f transformation_;
 

--- a/filters/include/pcl/filters/impl/box_clipper3D.hpp
+++ b/filters/include/pcl/filters/impl/box_clipper3D.hpp
@@ -41,7 +41,6 @@ template<typename PointT>
 pcl::BoxClipper3D<PointT>::BoxClipper3D (const Eigen::Affine3f& transformation)
 : transformation_ (transformation)
 {
-  //inverse_transformation_ = transformation_.inverse ();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -61,15 +60,13 @@ template<typename PointT> void
 pcl::BoxClipper3D<PointT>::setTransformation (const Eigen::Affine3f& transformation)
 {
   transformation_ = transformation;
-  //inverse_transformation_ = transformation_.inverse ();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template<typename PointT> void
 pcl::BoxClipper3D<PointT>::setTransformation (const Eigen::Vector3f& rodrigues, const Eigen::Vector3f& translation, const Eigen::Vector3f& box_size)
 {
-  transformation_ = Eigen::Translation3f (translation) * Eigen::AngleAxisf(rodrigues.norm (), rodrigues.normalized ()) * Eigen::Scaling (box_size);
-  //inverse_transformation_ = transformation_.inverse ();
+  transformation_ = (Eigen::Translation3f (translation) * Eigen::AngleAxisf(rodrigues.norm (), rodrigues.normalized ()) * Eigen::Scaling (0.5f * box_size)).inverse ();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The constructor (as well as the setTransformation function) that takes a rotation, translation, and scaling as input, says in the documentation that theses transformations are applied to the box. But actually they are applied to the points. This commit changes the behaviour of the code to match the documentation. I considered changing the documentation to match the behaviour of the code, but
- in my opinion it is useful to have a constructor/function to describe the box (rotation, box center, box dimensions)
- the current code (which applies first scaling, then rotation, then translation to the points) is not very useful or intuitive. Imagine for example a box, one side twice as long as the others, and rotated by 45 degrees around some axis. Then it is impossible to find a scaling transformation and rotation to transform all points inside the box to the interval [-1; +1]³, considering the scaling is applied first and in each axis separately. It would always result in a parallelepiped.
- if one specifically wants to rotate/translate/whatever the points, it is easy to do so by using the constructor/function that takes an Affine3f and construct for example `Eigen::Affine3f transform = Eigen::Translation3f(...) * Eigen::AngleAxisf(..., Eigen::Vector3f(...).normalized());`

This also fixes incorrect references to a unit cube, which is a cube with edge length 1, or sometimes specifically a cube in the interval [0; 1]. However, BoxClipper3D uses a cube in the interval [-1; +1] (edge length 2).

Fixes https://github.com/PointCloudLibrary/pcl/issues/3914