### PR TITLE
Allow hidden visibility default on gcc/clang

### DIFF
--- a/cmake/pcl_options.cmake
+++ b/cmake/pcl_options.cmake
@@ -124,7 +124,7 @@ option(PCL_DISABLE_GPU_TESTS "Disable running GPU tests. If disabled, tests will
 option(PCL_DISABLE_VISUALIZATION_TESTS "Disable running visualizations tests. If disabled, tests will still be built." OFF)
 
 # This leads to smaller libraries, possibly faster code, and fixes some bugs. See https://gcc.gnu.org/wiki/Visibility
-option(PCL_SYMBOL_VISIBILITY_HIDDEN "Hide all binary symbols by default, export only those explicitly marked (gcc and clang only). Experimental!" ON)
+option(PCL_SYMBOL_VISIBILITY_HIDDEN "Hide all binary symbols by default, export only those explicitly marked (gcc and clang only). Experimental!" OFF)
 mark_as_advanced(PCL_SYMBOL_VISIBILITY_HIDDEN)
 if(PCL_SYMBOL_VISIBILITY_HIDDEN)
   set(CMAKE_CXX_VISIBILITY_PRESET hidden)

--- a/cmake/pcl_options.cmake
+++ b/cmake/pcl_options.cmake
@@ -122,3 +122,11 @@ option(PCL_DISABLE_GPU_TESTS "Disable running GPU tests. If disabled, tests will
 # Set whether visualizations tests should be run
 # (Used to prevent visualizations tests from executing in CI where visualization is unavailable)
 option(PCL_DISABLE_VISUALIZATION_TESTS "Disable running visualizations tests. If disabled, tests will still be built." OFF)
+
+# This leads to smaller libraries, possibly faster code, and fixes some bugs. See https://gcc.gnu.org/wiki/Visibility
+option(PCL_SYMBOL_VISIBILITY_HIDDEN "Hide all binary symbols by default, export only those explicitly marked (gcc and clang only). Experimental!" ON)
+mark_as_advanced(PCL_SYMBOL_VISIBILITY_HIDDEN)
+if(PCL_SYMBOL_VISIBILITY_HIDDEN)
+  set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+  set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
+endif()

--- a/common/include/pcl/exceptions.h
+++ b/common/include/pcl/exceptions.h
@@ -40,6 +40,7 @@
 #include <stdexcept>
 #include <sstream>
 #include <boost/current_function.hpp>
+#include <pcl/pcl_exports.h> // for PCL_EXPORTS
 
 /** PCL_THROW_EXCEPTION a helper macro to be used for throwing exceptions.
   * This is an example on how to use:
@@ -62,7 +63,7 @@ namespace pcl
     * \brief A base class for all pcl exceptions which inherits from std::runtime_error
     * \author Eitan Marder-Eppstein, Suat Gedikli, Nizar Sallem
     */
-  class PCLException : public std::runtime_error
+  class PCL_EXPORTS PCLException : public std::runtime_error
   {
     public:
 
@@ -134,7 +135,7 @@ namespace pcl
   /** \class InvalidConversionException
     * \brief An exception that is thrown when a PCLPointCloud2 message cannot be converted into a PCL type
     */
-  class InvalidConversionException : public PCLException
+  class PCL_EXPORTS InvalidConversionException : public PCLException
   {
     public:
 
@@ -148,7 +149,7 @@ namespace pcl
   /** \class IsNotDenseException
     * \brief An exception that is thrown when a PointCloud is not dense but is attempted to be used as dense
     */
-  class IsNotDenseException : public PCLException
+  class PCL_EXPORTS IsNotDenseException : public PCLException
   {
     public:
 
@@ -163,7 +164,7 @@ namespace pcl
     * \brief An exception that is thrown when a sample consensus model doesn't
     * have the correct number of samples defined in model_types.h
     */
-  class InvalidSACModelTypeException : public PCLException
+  class PCL_EXPORTS InvalidSACModelTypeException : public PCLException
   {
     public:
 
@@ -177,7 +178,7 @@ namespace pcl
   /** \class IOException
     * \brief An exception that is thrown during an IO error (typical read/write errors)
     */
-  class IOException : public PCLException
+  class PCL_EXPORTS IOException : public PCLException
   {
     public:
 
@@ -192,7 +193,7 @@ namespace pcl
     * \brief An exception thrown when init can not be performed should be used in all the
     * PCLBase class inheritants.
     */
-  class InitFailedException : public PCLException
+  class PCL_EXPORTS InitFailedException : public PCLException
   {
     public:
       InitFailedException (const std::string& error_description = "",
@@ -206,7 +207,7 @@ namespace pcl
     * \brief An exception that is thrown when an organized point cloud is needed
     * but not provided.
     */
-  class UnorganizedPointCloudException : public PCLException
+  class PCL_EXPORTS UnorganizedPointCloudException : public PCLException
   {
     public:
     
@@ -220,7 +221,7 @@ namespace pcl
   /** \class KernelWidthTooSmallException
     * \brief An exception that is thrown when the kernel size is too small
     */
-  class KernelWidthTooSmallException : public PCLException
+  class PCL_EXPORTS KernelWidthTooSmallException : public PCLException
   {
     public:
     
@@ -231,7 +232,7 @@ namespace pcl
       : pcl::PCLException (error_description, file_name, function_name, line_number) { }
   } ;
 
-  class UnhandledPointTypeException : public PCLException
+  class PCL_EXPORTS UnhandledPointTypeException : public PCLException
   {
     public:
     UnhandledPointTypeException (const std::string& error_description,
@@ -241,7 +242,7 @@ namespace pcl
       : pcl::PCLException (error_description, file_name, function_name, line_number) { }
   };
 
-  class ComputeFailedException : public PCLException
+  class PCL_EXPORTS ComputeFailedException : public PCLException
   {
     public:
     ComputeFailedException (const std::string& error_description,
@@ -254,7 +255,7 @@ namespace pcl
   /** \class BadArgumentException
     * \brief An exception that is thrown when the arguments number or type is wrong/unhandled.
     */
-  class BadArgumentException : public PCLException
+  class PCL_EXPORTS BadArgumentException : public PCLException
   {
     public:
     BadArgumentException (const std::string& error_description,

--- a/common/include/pcl/pcl_exports.h
+++ b/common/include/pcl/pcl_exports.h
@@ -34,6 +34,8 @@
 
 #pragma once
 
+#include <pcl/pcl_config.h> // for PCL_SYMBOL_VISIBILITY_HIDDEN
+
 // This header is created to include to NVCC compiled sources.
 // Header 'pcl_macros' is not suitable since it includes <Eigen/Core>,
 // which can't be eaten by nvcc (it's too weak)
@@ -45,5 +47,9 @@
         #define PCL_EXPORTS
     #endif
 #else
-    #define PCL_EXPORTS
+    #ifdef PCL_SYMBOL_VISIBILITY_HIDDEN
+        #define PCL_EXPORTS __attribute__ ((visibility ("default")))
+    #else
+        #define PCL_EXPORTS
+    #endif
 #endif

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -323,7 +323,11 @@ pcl_round (float number)
         #define PCL_EXPORTS
     #endif
 #else
-    #define PCL_EXPORTS
+    #ifdef PCL_SYMBOL_VISIBILITY_HIDDEN
+        #define PCL_EXPORTS __attribute__ ((visibility ("default")))
+    #else
+        #define PCL_EXPORTS
+    #endif
 #endif
 
 #if defined WIN32 || defined _WIN32

--- a/common/include/pcl/range_image/range_image.h
+++ b/common/include/pcl/range_image/range_image.h
@@ -51,11 +51,7 @@ namespace pcl
     * \author Bastian Steder
     * \ingroup range_image
     */
-#if defined _WIN32 || defined WINCE || defined __MINGW32__
   class RangeImage : public pcl::PointCloud<PointWithRange>
-#else
-  class PCL_EXPORTS RangeImage : public pcl::PointCloud<PointWithRange>
-#endif
   {
     public:
       // =====TYPEDEFS=====
@@ -75,7 +71,7 @@ namespace pcl
       /** Constructor */
       PCL_EXPORTS RangeImage ();
       /** Destructor */
-      PCL_EXPORTS virtual ~RangeImage () = default;
+      PCL_EXPORTS virtual ~RangeImage ();
 
       // =====STATIC VARIABLES=====
       /** The maximum number of openmp threads that can be used in this class */

--- a/common/include/pcl/range_image/range_image.h
+++ b/common/include/pcl/range_image/range_image.h
@@ -51,7 +51,11 @@ namespace pcl
     * \author Bastian Steder
     * \ingroup range_image
     */
+#if defined _WIN32 || defined WINCE || defined __MINGW32__
   class RangeImage : public pcl::PointCloud<PointWithRange>
+#else
+  class PCL_EXPORTS RangeImage : public pcl::PointCloud<PointWithRange>
+#endif
   {
     public:
       // =====TYPEDEFS=====

--- a/common/include/pcl/range_image/range_image.h
+++ b/common/include/pcl/range_image/range_image.h
@@ -782,10 +782,10 @@ namespace pcl
 
 
       // =====STATIC PROTECTED=====
-      static const int lookup_table_size;
-      static std::vector<float> asin_lookup_table;
-      static std::vector<float> atan_lookup_table;
-      static std::vector<float> cos_lookup_table;
+      PCL_EXPORTS static const int lookup_table_size;
+      PCL_EXPORTS static std::vector<float> asin_lookup_table;
+      PCL_EXPORTS static std::vector<float> atan_lookup_table;
+      PCL_EXPORTS static std::vector<float> cos_lookup_table;
       /** Create lookup tables for trigonometric functions */
       static void
       createLookupTables ();

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -113,6 +113,8 @@ RangeImage::RangeImage () :
   unobserved_point.range = -std::numeric_limits<float>::infinity ();
 }
 
+RangeImage::~RangeImage () = default;
+
 /////////////////////////////////////////////////////////////////////////
 void
 RangeImage::reset ()

--- a/filters/src/convolution.cpp
+++ b/filters/src/convolution.cpp
@@ -189,17 +189,5 @@ Convolution<pcl::RGB, pcl::RGB>::convolveOneColDense(int i, int j)
   result.b = static_cast<std::uint8_t>(b);
   return (result);
 }
-
-#ifndef PCL_NO_PRECOMPILE
-#include <pcl/impl/instantiate.hpp>
-#include <pcl/point_types.h>
-
-PCL_INSTANTIATE_PRODUCT(
-    Convolution, ((pcl::RGB))((pcl::RGB)))
-
-PCL_INSTANTIATE_PRODUCT(
-    Convolution, ((pcl::PointXYZRGB))((pcl::PointXYZRGB)))
-#endif // PCL_NO_PRECOMPILE
-
 } // namespace filters
 } // namespace pcl

--- a/gpu/containers/src/initialization.cpp
+++ b/gpu/containers/src/initialization.cpp
@@ -42,7 +42,9 @@
 #include <array> // replace c-style array with std::array
 #include <cstdio>
 
+#if !defined(HAVE_CUDA)
 #define HAVE_CUDA
+#endif
 //#include <pcl_config.h>
 
 #if !defined(HAVE_CUDA)

--- a/pcl_config.h.in
+++ b/pcl_config.h.in
@@ -3,11 +3,12 @@
 // Ensure the compiler is meeting the minimum C++ standard
 // MSVC is not checked via __cplusplus due to
 // https://developercommunity.visualstudio.com/content/problem/120156/-cplusplus-macro-still-defined-as-pre-c11-value.html
-#if (!defined(_MSC_VER) && __cplusplus < 201402L) || (defined(_MSC_VER) && _MSC_VER < 1900)
+#if defined(__cplusplus) && ((!defined(_MSC_VER) && __cplusplus < 201402L) || (defined(_MSC_VER) && _MSC_VER < 1900))
   #error PCL requires C++14 or above
 #endif
 
 #define BUILD_@CMAKE_BUILD_TYPE@
+#cmakedefine PCL_SYMBOL_VISIBILITY_HIDDEN
 /* PCL version information */
 #define PCL_MAJOR_VERSION ${PCL_VERSION_MAJOR}
 #define PCL_MINOR_VERSION ${PCL_VERSION_MINOR}

--- a/registration/include/pcl/registration/transformation_estimation_svd.h
+++ b/registration/include/pcl/registration/transformation_estimation_svd.h
@@ -55,7 +55,7 @@ namespace registration {
  * \ingroup registration
  */
 template <typename PointSource, typename PointTarget, typename Scalar = float>
-class PCL_EXPORTS TransformationEstimationSVD
+class TransformationEstimationSVD
 : public TransformationEstimation<PointSource, PointTarget, Scalar> {
 public:
   using Ptr = shared_ptr<TransformationEstimationSVD<PointSource, PointTarget, Scalar>>;

--- a/segmentation/include/pcl/segmentation/impl/crf_normal_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/crf_normal_segmentation.hpp
@@ -71,6 +71,6 @@ pcl::CrfNormalSegmentation<PointT>::segmentPoints ()
 {
 }
 
-#define PCL_INSTANTIATE_CrfNormalSegmentation(T) template class pcl::CrfNormalSegmentation<T>;
+#define PCL_INSTANTIATE_CrfNormalSegmentation(T) template class PCL_EXPORTS pcl::CrfNormalSegmentation<T>;
 
 #endif    // PCL_CRF_NORMAL_SEGMENTATION_HPP_

--- a/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
+++ b/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
@@ -686,57 +686,11 @@ pcl::SupervoxelClustering<PointT>::getMaxLabel () const
   return max_label;
 }
 
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 namespace pcl
 { 
-  namespace octree
-  {
-    //Explicit overloads for RGB types
-    template<>
-    void
-    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGB,pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData>::addPoint (const pcl::PointXYZRGB &new_point);
-    
-    template<>
-    void
-    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGBA,pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData>::addPoint (const pcl::PointXYZRGBA &new_point);
-    
-    //Explicit overloads for RGB types
-    template<> void
-    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGB,pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData>::computeData ();
-    
-    template<> void
-    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGBA,pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData>::computeData ();
-    
-    //Explicit overloads for XYZ types
-    template<>
-    void
-    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZ,pcl::SupervoxelClustering<pcl::PointXYZ>::VoxelData>::addPoint (const pcl::PointXYZ &new_point);
-    
-    template<> void
-    pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZ,pcl::SupervoxelClustering<pcl::PointXYZ>::VoxelData>::computeData ();
-  }
-}
-
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace pcl
-{
-  
-  template<> void
-  pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData::getPoint (pcl::PointXYZRGB &point_arg) const;
-  
-  template<> void
-  pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData::getPoint (pcl::PointXYZRGBA &point_arg ) const;
-  
-  template<typename PointT> void
-  pcl::SupervoxelClustering<PointT>::VoxelData::getPoint (PointT &point_arg ) const
-  {
-    //XYZ is required or this doesn't make much sense...
-    point_arg.x = xyz_[0];
-    point_arg.y = xyz_[1];
-    point_arg.z = xyz_[2];
-  }
-  
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
   template <typename PointT> void
   pcl::SupervoxelClustering<PointT>::VoxelData::getNormal (Normal &normal_arg) const

--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -143,11 +143,33 @@ namespace pcl
             owner_ (nullptr)
             {}
 
+#ifdef DOXYGEN_ONLY
           /** \brief Gets the data of in the form of a point
            *  \param[out] point_arg Will contain the point value of the voxeldata
            */
           void
           getPoint (PointT &point_arg) const;
+#else
+          template<typename PointT2 = PointT, traits::HasColor<PointT2> = true> void
+          getPoint (PointT &point_arg) const
+          {
+            point_arg.rgba = static_cast<std::uint32_t>(rgb_[0]) << 16 |
+            static_cast<std::uint32_t>(rgb_[1]) << 8 |
+            static_cast<std::uint32_t>(rgb_[2]);
+            point_arg.x = xyz_[0];
+            point_arg.y = xyz_[1];
+            point_arg.z = xyz_[2];
+          }
+
+          template<typename PointT2 = PointT, traits::HasNoColor<PointT2> = true> void
+          getPoint (PointT &point_arg ) const
+          {
+            //XYZ is required or this doesn't make much sense...
+            point_arg.x = xyz_[0];
+            point_arg.y = xyz_[1];
+            point_arg.z = xyz_[2];
+          }
+#endif
 
           /** \brief Gets the data of in the form of a normal
            *  \param[out] normal_arg Will contain the normal value of the voxeldata

--- a/segmentation/src/supervoxel_clustering.cpp
+++ b/segmentation/src/supervoxel_clustering.cpp
@@ -49,6 +49,10 @@
 #include <pcl/segmentation/impl/supervoxel_clustering.hpp>
 #include <pcl/octree/impl/octree_pointcloud_adjacency.hpp>
 
+template class PCL_EXPORTS pcl::SupervoxelClustering<pcl::PointXYZ>;
+template class PCL_EXPORTS pcl::SupervoxelClustering<pcl::PointXYZRGB>;
+template class PCL_EXPORTS pcl::SupervoxelClustering<pcl::PointXYZRGBA>;
+
 namespace pcl
 { 
   namespace octree
@@ -135,31 +139,6 @@ namespace pcl
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-namespace pcl
-{
-  template<> void
-  pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData::getPoint (pcl::PointXYZRGB &point_arg) const
-  {
-    point_arg.rgba = static_cast<std::uint32_t>(rgb_[0]) << 16 | 
-    static_cast<std::uint32_t>(rgb_[1]) << 8 | 
-    static_cast<std::uint32_t>(rgb_[2]);  
-    point_arg.x = xyz_[0];
-    point_arg.y = xyz_[1];
-    point_arg.z = xyz_[2];
-  }
-  
-  template<> void
-  pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData::getPoint (pcl::PointXYZRGBA &point_arg ) const
-  {
-    point_arg.rgba = static_cast<std::uint32_t>(rgb_[0]) << 16 | 
-    static_cast<std::uint32_t>(rgb_[1]) << 8 | 
-    static_cast<std::uint32_t>(rgb_[2]);  
-    point_arg.x = xyz_[0];
-    point_arg.y = xyz_[1];
-    point_arg.z = xyz_[2];
-  }
-}
-
 using VoxelDataT = pcl::SupervoxelClustering<pcl::PointXYZ>::VoxelData;
 using VoxelDataRGBT = pcl::SupervoxelClustering<pcl::PointXYZRGB>::VoxelData;
 using VoxelDataRGBAT = pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData;
@@ -167,10 +146,6 @@ using VoxelDataRGBAT = pcl::SupervoxelClustering<pcl::PointXYZRGBA>::VoxelData;
 using AdjacencyContainerT = pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZ, VoxelDataT>;
 using AdjacencyContainerRGBT = pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGB, VoxelDataRGBT>;
 using AdjacencyContainerRGBAT = pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGBA, VoxelDataRGBAT>;
-
-template class pcl::SupervoxelClustering<pcl::PointXYZ>;
-template class pcl::SupervoxelClustering<pcl::PointXYZRGB>;
-template class pcl::SupervoxelClustering<pcl::PointXYZRGBA>;
 
 template class pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZ, VoxelDataT>;
 template class pcl::octree::OctreePointCloudAdjacencyContainer<pcl::PointXYZRGB, VoxelDataRGBT>;


### PR DESCRIPTION
Can be enabled/disabled with the CMake option `PCL_SYMBOL_VISIBILITY_HIDDEN`. The main benefits are reduced library size and reduced risk of certain bugs. Some sources also claim that it can increase execution speed under certain conditions, but so far I did not test whether this is the case for PCL. This feature is still somewhat experimental (although I did a lot of testing), so for anyone reading this who got a linker error when this is enabled: please open an issue, it may be that `PCL_EXPORTS` is missing somewhere. I think for now, it is better to leave this disabled by default, and only encourage users who are fine with experimental features to enable it. In the future, we might then enable it for everyone.

Suggested read: https://gcc.gnu.org/wiki/Visibility

# Range image
A commenter suggested a different solution, now only the four static members need to be marked with `PCL_EXPORTS`.
~~For gcc, I could only get it to work with the whole `RangeImage`  class marked as `PCL_EXPORTS` (i.e. `__attribute__ ((visibility ("default")))`), otherwise I get the linking error `undefined reference to vtable RangeImage`.
For MSVC on the other hand, marking the whole class as `PCL_EXPORTS` (i.e. `__declspec(dllexport)`) seems to be problematic because when including range_image.h in another PCL module, `RangeImage` is also marked as `dllexport` so the compiler seems to expect a definition of the static members (lookup tables) in that module as well.~~ In the future, it might be a good idea to move away from the static class member lookup tables, and perhaps use static local variables instead like in `RGB2sRGB_LUT`).

# Supervoxel clustering
Moved the specializations of `getPoint` to supervoxel_clustering.h, using `traits::HasColor`. This was necessary to resolve some interdependencies between `SupervoxelClustering`, `OctreePointCloudAdjacencyContainer`, and `OctreePointCloudAdjacency`

# Further changes
- removed `PCL_EXPORTS` on `TransformationEstimationSVD` again. I added it in a previous PR but noticed now that it was not necessary and caused warnings on MSVC.
- since I added `PCL_EXPORTS` to the static members in `RangeImage`, these change might fix also https://github.com/PointCloudLibrary/pcl/issues/807 , but I did not test that
- in convolution.cpp, the explicit instantiation with `RGB`  and `PointXYZRGB` is not necessary and even creates a warning that the visibility attributes change with this redefinition. The class is tested in https://github.com/PointCloudLibrary/pcl/blob/master/test/filters/test_convolution.cpp with both types
- in pcl_config.h.in, we now first check whether `__cplusplus` is defined (i.e. whether the program is a C++ program) before doing C++ version checks, because this file is now included in some C source code file via pcl_exports.h

# Library size
| in kilobytes   |MinSizeRel, hidden symbols   |MinSizeRel, hidden symbols off   |Release, hidden symbols   |Release, hidden symbols off   |
|---|---:|---:|---:|---:|
|common |726   |839   |825   | 879  |
|features   |43023   |49729   |51947   |57824   |
|filters   |8708   |10326   |10013   | 11194  |
|io_ply   |324   |412   | 401  | 467  |
|io   |2454   |3272   |2985   | 3587  |
|kdtree   |1199   |1565   |1453   | 1754  |
|keypoints   |1674   |2032   | 2040  |2337   |
|ml   |125   |146   |188   |196   |
|octree   |2593   |2818   | 3252  |3371   |
|outofcore   |81   |85   |97   | 101  |
|people   |22   |22   | 29  | 29  |
|recognition   |5455   |6821   |6642   | 7592  |
|registration   |2108   | 2793  |2428   |2829   |
|sample_consensus   |13392   |14776   | 16101  | 17036  |
|search   |2059   |2501   | 2463  | 2850  |
|segmentation   |12893   |16671   |15067   | 18132  |
|stereo   |241   |258   |302   | 306  |
|surface   |6304   |7174   | 8178  |  8747 |
|tracking   |3903   |4578   |4814   | 5378  |
|visualization   |1294   |1648   |1601   | 1865  |

Built with GCC 13.2. All CMake options except `CMAKE_BUILD_TYPE` and `PCL_SYMBOL_VISIBILITY_HIDDEN` are the default ones