### PR TITLE
Modify FlannSearch to return Indices of Point Cloud (issue #5774)

### DIFF
--- a/search/include/pcl/search/flann_search.h
+++ b/search/include/pcl/search/flann_search.h
@@ -363,6 +363,8 @@ namespace pcl
         Indices index_mapping_;
         bool identity_mapping_;
 
+        int total_nr_points_;
+
     };
   }
 }

--- a/search/include/pcl/search/flann_search.h
+++ b/search/include/pcl/search/flann_search.h
@@ -363,7 +363,7 @@ namespace pcl
         Indices index_mapping_;
         bool identity_mapping_;
 
-        int total_nr_points_;
+        std::size_t total_nr_points_;
 
     };
   }

--- a/search/include/pcl/search/impl/flann_search.hpp
+++ b/search/include/pcl/search/impl/flann_search.hpp
@@ -118,7 +118,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::nearestKSearch (const PointT &p
   float* cdata = can_cast ? const_cast<float*> (reinterpret_cast<const float*> (&point)): data;
   const flann::Matrix<float> m (cdata ,1, point_representation_->getNumberOfDimensions ());
 
-  if (k > total_nr_points_)
+  if (static_cast<unsigned int>(k) > total_nr_points_)
     k = total_nr_points_;
 
   flann::SearchParams p;
@@ -183,7 +183,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::nearestKSearch (
     float* cdata = can_cast ? const_cast<float*> (reinterpret_cast<const float*> (&cloud[0])): data;
     const flann::Matrix<float> m (cdata ,cloud.size (), dim_, can_cast ? sizeof (PointT) : dim_ * sizeof (float) );
 
-    if (k > total_nr_points_)
+    if (static_cast<unsigned int>(k) > total_nr_points_)
       k = total_nr_points_;
 
     flann::SearchParams p;

--- a/search/include/pcl/search/impl/flann_search.hpp
+++ b/search/include/pcl/search/impl/flann_search.hpp
@@ -400,7 +400,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::convertInputToFlannMatrix ()
           continue;
         }
 
-        index_mapping_.push_back (static_cast<index_t> (i));  // If the returned index should be for the indices vector
+        index_mapping_.push_back (static_cast<index_t> (i));  
 
         point_representation_->vectorize (point, cloud_ptr);
         cloud_ptr += dim_;
@@ -412,6 +412,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::convertInputToFlannMatrix ()
   {
     input_flann_ = static_cast<MatrixPtr> (new flann::Matrix<float> (new float[original_no_of_points*point_representation_->getNumberOfDimensions ()], original_no_of_points, point_representation_->getNumberOfDimensions ()));
     float* cloud_ptr = input_flann_->ptr();
+    identity_mapping_ = false;
     for (std::size_t indices_index = 0; indices_index < original_no_of_points; ++indices_index)
     {
       index_t cloud_index = (*indices_)[indices_index];
@@ -419,11 +420,10 @@ pcl::search::FlannSearch<PointT, FlannDistance>::convertInputToFlannMatrix ()
       // Check if the point is invalid
       if (!point_representation_->isValid (point))
       {
-        identity_mapping_ = false;
         continue;
       }
 
-      index_mapping_.push_back (static_cast<index_t> (indices_index));  // If the returned index should be for the indices vector
+      index_mapping_.push_back (static_cast<index_t> (cloud_index));  
 
       point_representation_->vectorize (point, cloud_ptr);
       cloud_ptr += dim_;

--- a/search/include/pcl/search/impl/flann_search.hpp
+++ b/search/include/pcl/search/impl/flann_search.hpp
@@ -118,6 +118,9 @@ pcl::search::FlannSearch<PointT, FlannDistance>::nearestKSearch (const PointT &p
   float* cdata = can_cast ? const_cast<float*> (reinterpret_cast<const float*> (&point)): data;
   const flann::Matrix<float> m (cdata ,1, point_representation_->getNumberOfDimensions ());
 
+  if (k > total_nr_points_)
+    k = total_nr_points_;
+
   flann::SearchParams p;
   p.eps = eps_;
   p.sorted = sorted_results_;
@@ -179,6 +182,9 @@ pcl::search::FlannSearch<PointT, FlannDistance>::nearestKSearch (
     // search won't change the matrix
     float* cdata = can_cast ? const_cast<float*> (reinterpret_cast<const float*> (&cloud[0])): data;
     const flann::Matrix<float> m (cdata ,cloud.size (), dim_, can_cast ? sizeof (PointT) : dim_ * sizeof (float) );
+
+    if (k > total_nr_points_)
+      k = total_nr_points_;
 
     flann::SearchParams p;
     p.sorted = sorted_results_;
@@ -385,6 +391,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::convertInputToFlannMatrix ()
       // const cast is evil, but flann won't change the data
       input_flann_ = static_cast<MatrixPtr> (new flann::Matrix<float> (const_cast<float*>(reinterpret_cast<const float*>(&(*input_) [0])), original_no_of_points, point_representation_->getNumberOfDimensions (),sizeof (PointT)));
       input_copied_for_flann_ = false;
+      total_nr_points_ = input_->points.size();
     }
     else
     {
@@ -405,6 +412,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::convertInputToFlannMatrix ()
         point_representation_->vectorize (point, cloud_ptr);
         cloud_ptr += dim_;
       }
+      total_nr_points_ = index_mapping_.size();
     }
 
   }
@@ -428,6 +436,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::convertInputToFlannMatrix ()
       point_representation_->vectorize (point, cloud_ptr);
       cloud_ptr += dim_;
     }
+    total_nr_points_ = index_mapping_.size();
   }
   if (input_copied_for_flann_)
     input_flann_->rows = index_mapping_.size ();

--- a/test/search/test_search.cpp
+++ b/test/search/test_search.cpp
@@ -41,6 +41,7 @@
 
 #include <pcl/search/brute_force.h>
 #include <pcl/search/kdtree.h>
+#include <pcl/search/flann_search.h>
 #include <pcl/search/organized.h>
 #include <pcl/search/octree.h>
 #include <pcl/io/pcd_io.h>
@@ -113,6 +114,9 @@ pcl::search::BruteForce<pcl::PointXYZ> brute_force;
 
 /** \brief instance of KDTree search method to be tested*/
 pcl::search::KdTree<pcl::PointXYZ> KDTree;
+
+/** \brief instance of FlannSearch search method to be tested*/
+pcl::search::FlannSearch<pcl::PointXYZ> FlannSearch;
 
 /** \brief instance of Octree search method to be tested*/
 pcl::search::Octree<pcl::PointXYZ> octree_search (0.1);
@@ -657,10 +661,12 @@ main (int argc, char** argv)
   
   unorganized_search_methods.push_back (&brute_force);
   unorganized_search_methods.push_back (&KDTree);
+  unorganized_search_methods.push_back (&FlannSearch);
   unorganized_search_methods.push_back (&octree_search);
   
   organized_search_methods.push_back (&brute_force);
   organized_search_methods.push_back (&KDTree);
+  organized_search_methods.push_back (&FlannSearch);
   organized_search_methods.push_back (&octree_search);
   organized_search_methods.push_back (&organized);
   


### PR DESCRIPTION
FlannSearch was returning, in the radiusSearch and nearestKSearch, the Indices of the Indices passed, which is inconsistent with the other search classes. This solves issue #5774.


I'm just opening the PR to start the discussion on this change.  I'm still trying to understand and run the tests. As said, though, the change itself is not that complicated, it was two lines of code, unless there is something I am not seeing.
