### PR TITLE
fix: remove unnecessary indices erase in extract_clusters

### DIFF
--- a/segmentation/include/pcl/segmentation/extract_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_clusters.h
@@ -179,9 +179,8 @@ namespace pcl
         for (std::size_t j = 0; j < seed_queue.size (); ++j)
           r.indices[j] = seed_queue[j];
 
-        // These two lines should not be needed: (can anyone confirm?) -FF
+        // After clustering, indices are out of order, so sort them
         std::sort (r.indices.begin (), r.indices.end ());
-        r.indices.erase (std::unique (r.indices.begin (), r.indices.end ()), r.indices.end ());
 
         r.header = cloud.header;
         clusters.push_back (r);   // We could avoid a copy by working directly in the vector
@@ -299,9 +298,8 @@ namespace pcl
         for (std::size_t j = 0; j < seed_queue.size (); ++j)
           r.indices[j] = seed_queue[j];
 
-        // These two lines should not be needed: (can anyone confirm?) -FF
+        // After clustering, indices are out of order, so sort them
         std::sort (r.indices.begin (), r.indices.end ());
-        r.indices.erase (std::unique (r.indices.begin (), r.indices.end ()), r.indices.end ());
 
         r.header = cloud.header;
         clusters.push_back (r);

--- a/segmentation/include/pcl/segmentation/impl/extract_clusters.hpp
+++ b/segmentation/include/pcl/segmentation/impl/extract_clusters.hpp
@@ -106,9 +106,8 @@ pcl::extractEuclideanClusters (const PointCloud<PointT> &cloud,
       for (std::size_t j = 0; j < seed_queue.size (); ++j)
         r.indices[j] = seed_queue[j];
 
-      // These two lines should not be needed: (can anyone confirm?) -FF
+      // After clustering, indices are out of order, so sort them
       std::sort (r.indices.begin (), r.indices.end ());
-      r.indices.erase (std::unique (r.indices.begin (), r.indices.end ()), r.indices.end ());
 
       r.header = cloud.header;
       clusters.push_back (r);   // We could avoid a copy by working directly in the vector
@@ -203,10 +202,8 @@ pcl::extractEuclideanClusters (const PointCloud<PointT> &cloud,
         // This is the only place where indices come into play
         r.indices[j] = seed_queue[j];
 
-      // These two lines should not be needed: (can anyone confirm?) -FF
-      //r.indices.assign(seed_queue.begin(), seed_queue.end());
+      // After clustering, indices are out of order, so sort them
       std::sort (r.indices.begin (), r.indices.end ());
-      r.indices.erase (std::unique (r.indices.begin (), r.indices.end ()), r.indices.end ());
 
       r.header = cloud.header;
       clusters.push_back (r);   // We could avoid a copy by working directly in the vector

--- a/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
+++ b/segmentation/include/pcl/segmentation/impl/extract_labeled_clusters.hpp
@@ -129,9 +129,8 @@ pcl::extractLabeledEuclideanClusters(
       r.indices.resize(seed_queue.size());
       for (std::size_t j = 0; j < seed_queue.size(); ++j)
         r.indices[j] = seed_queue[j];
-
+      // After clustering, indices are out of order, so sort them
       std::sort(r.indices.begin(), r.indices.end());
-      r.indices.erase(std::unique(r.indices.begin(), r.indices.end()), r.indices.end());
 
       r.header = cloud.header;
       labeled_clusters[cloud[i].label].push_back(


### PR DESCRIPTION
fix https://github.com/PointCloudLibrary/pcl/issues/5786

Remove unnecessary indices erase in extract_clusters, by the way I'm still not sure if sorting is necessary for the following reasons

**We need to keep the interface behavior uniform**

The best example is `conditional_euclidean_clustering.h` does not sort cluster indices. In fact, I only found `seeded_hue_segmentation.hpp`, `extract_labeled_clusters.hpp` and `extract_clusters.hpp` are sorted. 

I know that rashly modifying the api may cause compatibility issues, but should we consider the unity of the interface so that all segment algorithms are sorted or not
