### PR TITLE
Deprecate SampleConsensusModelStick

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_stick.h
@@ -56,11 +56,16 @@ namespace pcl
     *   - \b line_direction.z : the Z coordinate of a line's direction
     *   - \b line_width       : the width of the line
     *
+    * \warning This model is considered deprecated. The coefficients are used inconsistently in the methods, and the last coefficient (line width) is unused. We recommend to use the line or cylinder model instead.
     * \author Radu B. Rusu
     * \ingroup sample_consensus
     */
   template <typename PointT>
+#ifdef SAC_MODEL_STICK_DONT_WARN_DEPRECATED
   class SampleConsensusModelStick : public SampleConsensusModel<PointT>
+#else
+  class PCL_DEPRECATED(1, 17, "Use line or cylinder model instead") SampleConsensusModelStick : public SampleConsensusModel<PointT>
+#endif
   {
     public:
       using SampleConsensusModel<PointT>::model_name_;

--- a/sample_consensus/src/sac_model_stick.cpp
+++ b/sample_consensus/src/sac_model_stick.cpp
@@ -37,6 +37,7 @@
  */
 
 #include <pcl/pcl_config.h>
+#define SAC_MODEL_STICK_DONT_WARN_DEPRECATED
 #include <pcl/sample_consensus/impl/sac_model_stick.hpp>
 
 #ifndef PCL_NO_PRECOMPILE

--- a/segmentation/include/pcl/segmentation/impl/sac_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/sac_segmentation.hpp
@@ -68,7 +68,9 @@
 #include <pcl/sample_consensus/sac_model_plane.h>
 #include <pcl/sample_consensus/sac_model_sphere.h>
 #include <pcl/sample_consensus/sac_model_normal_sphere.h>
+#define SAC_MODEL_STICK_DONT_WARN_DEPRECATED
 #include <pcl/sample_consensus/sac_model_stick.h>
+#undef SAC_MODEL_STICK_DONT_WARN_DEPRECATED
 #include <pcl/sample_consensus/sac_model_ellipse3d.h>
 
 #include <pcl/memory.h>  // for static_pointer_cast
@@ -155,6 +157,7 @@ pcl::SACSegmentation<PointT>::initSACModel (const int model_type)
     }
     case SACMODEL_STICK:
     {
+      PCL_WARN ("[pcl::%s::initSACModel] SACMODEL_STICK is deprecated: Use SACMODEL_LINE instead (It will be removed in PCL 1.17)\n", getClassName ().c_str ());
       PCL_DEBUG ("[pcl::%s::initSACModel] Using a model of type: SACMODEL_STICK\n", getClassName ().c_str ());
       model_.reset (new SampleConsensusModelStick<PointT> (input_, *indices_));
       double min_radius, max_radius;


### PR DESCRIPTION
Fixes https://github.com/PointCloudLibrary/pcl/issues/2452
The extra logic with `SAC_MODEL_STICK_DONT_WARN_DEPRECATED` is necessary so we can still build and use the model within PCL without getting deprecation warnings.