### PR TITLE
[surface] Fix memory leak bug of poisson reconstruction

### DIFF
--- a/surface/include/pcl/surface/3rdparty/poisson4/bspline_data.hpp
+++ b/surface/include/pcl/surface/3rdparty/poisson4/bspline_data.hpp
@@ -291,7 +291,11 @@ namespace pcl
     {
       if (flags & VV_DOT_FLAG) {
         delete[] vvDotTable ; vvDotTable = NULL;
+      }
+      if (flags & DV_DOT_FLAG) {
         delete[] dvDotTable ; dvDotTable = NULL;
+      }
+      if (flags & DD_DOT_FLAG) {
         delete[] ddDotTable ; ddDotTable = NULL;
       }
     }


### PR DESCRIPTION
Fix memory leak when call pcl::Poisson::performReconstruction by release dot table memory according to input flags in BSplineData::clearDotTables.