### PR TITLE
Let setInputCloud of search methods indicate success or failure

### DIFF
--- a/filters/include/pcl/filters/impl/local_maximum.hpp
+++ b/filters/include/pcl/filters/impl/local_maximum.hpp
@@ -97,7 +97,13 @@ pcl::LocalMaximum<PointT>::applyFilterIndices (Indices &indices)
     else
       searcher_.reset (new pcl::search::KdTree<PointT> (false));
   }
-  searcher_->setInputCloud (cloud_projected);
+  if (!searcher_->setInputCloud (cloud_projected))
+  {
+    PCL_ERROR ("[pcl::%s::applyFilter] Error when initializing search method!\n", getClassName ().c_str ());
+    indices.clear ();
+    removed_indices_->clear ();
+    return;
+  }
 
   // The arrays to be used
   indices.resize (indices_->size ());

--- a/filters/include/pcl/filters/impl/radius_outlier_removal.hpp
+++ b/filters/include/pcl/filters/impl/radius_outlier_removal.hpp
@@ -64,7 +64,13 @@ pcl::RadiusOutlierRemoval<PointT>::applyFilterIndices (Indices &indices)
     else
       searcher_.reset (new pcl::search::KdTree<PointT> (false));
   }
-  searcher_->setInputCloud (input_);
+  if (!searcher_->setInputCloud (input_))
+  {
+    PCL_ERROR ("[pcl::%s::applyFilter] Error when initializing search method!\n", getClassName ().c_str ());
+    indices.clear ();
+    removed_indices_->clear ();
+    return;
+  }
 
   // The arrays to be used
   Indices nn_indices (indices_->size ());

--- a/filters/include/pcl/filters/impl/statistical_outlier_removal.hpp
+++ b/filters/include/pcl/filters/impl/statistical_outlier_removal.hpp
@@ -56,7 +56,13 @@ pcl::StatisticalOutlierRemoval<PointT>::applyFilterIndices (Indices &indices)
     else
       searcher_.reset (new pcl::search::KdTree<PointT> (false));
   }
-  searcher_->setInputCloud (input_);
+  if (!searcher_->setInputCloud (input_))
+  {
+    PCL_ERROR ("[pcl::%s::applyFilter] Error when initializing search method!\n", getClassName ().c_str ());
+    indices.clear ();
+    removed_indices_->clear ();
+    return;
+  }
 
   // The arrays to be used
   const int searcher_k = mean_k_ + 1;  // Find one more, since results include the query point.

--- a/filters/include/pcl/filters/local_maximum.h
+++ b/filters/include/pcl/filters/local_maximum.h
@@ -84,6 +84,12 @@ namespace pcl
       inline float
       getRadius () const { return (radius_); }
 
+      /** \brief Provide a pointer to the search object.
+        * Calling this is optional. If not called, the search method will be chosen automatically.
+        * \param[in] searcher a pointer to the spatial search object.
+        */
+      inline void
+      setSearchMethod (const SearcherPtr &searcher) { searcher_ = searcher; }
     protected:
       using PCLBase<PointT>::input_;
       using PCLBase<PointT>::indices_;

--- a/filters/include/pcl/filters/radius_outlier_removal.h
+++ b/filters/include/pcl/filters/radius_outlier_removal.h
@@ -136,6 +136,12 @@ namespace pcl
         return (min_pts_radius_);
       }
 
+      /** \brief Provide a pointer to the search object.
+        * Calling this is optional. If not called, the search method will be chosen automatically.
+        * \param[in] searcher a pointer to the spatial search object.
+        */
+      inline void
+      setSearchMethod (const SearcherPtr &searcher) { searcher_ = searcher; }
     protected:
       using PCLBase<PointT>::input_;
       using PCLBase<PointT>::indices_;

--- a/filters/include/pcl/filters/statistical_outlier_removal.h
+++ b/filters/include/pcl/filters/statistical_outlier_removal.h
@@ -140,6 +140,12 @@ namespace pcl
         return (std_mul_);
       }
 
+      /** \brief Provide a pointer to the search object.
+        * Calling this is optional. If not called, the search method will be chosen automatically.
+        * \param[in] searcher a pointer to the spatial search object.
+        */
+      inline void
+      setSearchMethod (const SearcherPtr &searcher) { searcher_ = searcher; }
     protected:
       using PCLBase<PointT>::input_;
       using PCLBase<PointT>::indices_;

--- a/search/include/pcl/search/flann_search.h
+++ b/search/include/pcl/search/flann_search.h
@@ -254,7 +254,7 @@ namespace pcl
           * \param[in] cloud the const boost shared pointer to a PointCloud message
           * \param[in] indices the point indices subset that is to be used from \a cloud
           */
-        void
+        bool
         setInputCloud (const PointCloudConstPtr& cloud, const IndicesConstPtr& indices = IndicesConstPtr ()) override;
 
         using Search<PointT>::nearestKSearch;

--- a/search/include/pcl/search/impl/flann_search.hpp
+++ b/search/include/pcl/search/impl/flann_search.hpp
@@ -91,7 +91,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::~FlannSearch()
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, typename FlannDistance> void
+template <typename PointT, typename FlannDistance> bool
 pcl::search::FlannSearch<PointT, FlannDistance>::setInputCloud (const PointCloudConstPtr& cloud, const IndicesConstPtr& indices)
 {
   input_ = cloud;
@@ -99,6 +99,7 @@ pcl::search::FlannSearch<PointT, FlannDistance>::setInputCloud (const PointCloud
   convertInputToFlannMatrix ();
   index_ = creator_->createIndex (input_flann_);
   index_->buildIndex ();
+  return true;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/search/include/pcl/search/impl/kdtree.hpp
+++ b/search/include/pcl/search/impl/kdtree.hpp
@@ -72,7 +72,7 @@ pcl::search::KdTree<PointT,Tree>::setEpsilon (float eps)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT, class Tree> void
+template <typename PointT, class Tree> bool
 pcl::search::KdTree<PointT,Tree>::setInputCloud (
     const PointCloudConstPtr& cloud, 
     const IndicesConstPtr& indices)
@@ -80,6 +80,7 @@ pcl::search::KdTree<PointT,Tree>::setInputCloud (
   tree_->setInputCloud (cloud, indices);
   input_ = cloud;
   indices_ = indices;
+  return true;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/search/include/pcl/search/impl/organized.hpp
+++ b/search/include/pcl/search/impl/organized.hpp
@@ -329,7 +329,7 @@ pcl::search::OrganizedNeighbor<PointT>::computeCameraMatrix (Eigen::Matrix3f& ca
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
-template<typename PointT> void
+template<typename PointT> bool
 pcl::search::OrganizedNeighbor<PointT>::estimateProjectionMatrix ()
 {
   // internally we calculate with double but store the result into float matrices.
@@ -337,7 +337,7 @@ pcl::search::OrganizedNeighbor<PointT>::estimateProjectionMatrix ()
   if (input_->height == 1 || input_->width == 1)
   {
     PCL_ERROR ("[pcl::%s::estimateProjectionMatrix] Input dataset is not organized!\n", this->getName ().c_str ());
-    return;
+    return false;
   }
   
   const unsigned ySkip = (std::max) (input_->height >> pyramid_level_, static_cast<unsigned>(1));
@@ -363,7 +363,7 @@ pcl::search::OrganizedNeighbor<PointT>::estimateProjectionMatrix ()
   if (std::abs (residual_sqr) > eps_ * static_cast<float>(indices.size ()))
   {
     PCL_ERROR ("[pcl::%s::estimateProjectionMatrix] Input dataset is not from a projective device!\nResidual (MSE) %g, using %d valid points\n", this->getName ().c_str (), residual_sqr / double (indices.size()), indices.size ());
-    return;
+    return false;
   }
 
   // get left 3x3 sub matrix, which contains K * R, with K = camera matrix = [[fx s cx] [0 fy cy] [0 0 1]]
@@ -383,8 +383,10 @@ pcl::search::OrganizedNeighbor<PointT>::estimateProjectionMatrix ()
     if (!projectPoint(test_point, q) || std::abs(q.x-test_index%input_->width)>1 || std::abs(q.y-test_index/input_->width)>1) {
       PCL_WARN ("[pcl::%s::estimateProjectionMatrix] Input dataset does not seem to be from a projective device! (point %zu (%g,%g,%g) projected to pixel coordinates (%g,%g), but actual pixel coordinates are (%zu,%zu))\n",
                 this->getName ().c_str (), test_index, test_point.x, test_point.y, test_point.z, q.x, q.y, static_cast<std::size_t>(test_index%input_->width), static_cast<std::size_t>(test_index/input_->width));
+      return false;
     }
   }
+  return true;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/search/include/pcl/search/impl/search.hpp
+++ b/search/include/pcl/search/impl/search.hpp
@@ -71,12 +71,13 @@ pcl::search::Search<PointT>::getSortedResults ()
 }
  
 ///////////////////////////////////////////////////////////////////////////////////////////
-template <typename PointT> void
+template <typename PointT> bool
 pcl::search::Search<PointT>::setInputCloud (
     const PointCloudConstPtr& cloud, const IndicesConstPtr &indices)
 {
   input_ = cloud;
   indices_ = indices;
+  return true;
 }
 
 

--- a/search/include/pcl/search/kdtree.h
+++ b/search/include/pcl/search/kdtree.h
@@ -128,7 +128,7 @@ namespace pcl
           * \param[in] cloud the const boost shared pointer to a PointCloud message
           * \param[in] indices the point indices subset that is to be used from \a cloud 
           */
-        void
+        bool
         setInputCloud (const PointCloudConstPtr& cloud, 
                        const IndicesConstPtr& indices = IndicesConstPtr ()) override;
 

--- a/search/include/pcl/search/octree.h
+++ b/search/include/pcl/search/octree.h
@@ -114,7 +114,7 @@ namespace pcl
           * \param[in] cloud the const boost shared pointer to a PointCloud message
           * \param[in] indices the point indices subset that is to be used from \a cloud 
           */
-        inline void
+        inline bool
         setInputCloud (const PointCloudConstPtr &cloud, const IndicesConstPtr& indices) override
         {
           tree_->deleteTree ();
@@ -122,6 +122,7 @@ namespace pcl
           tree_->addPointsFromInputCloud ();
           input_ = cloud;
           indices_ = indices;
+          return true;
         }
 
         /** \brief Search for the k-nearest neighbors for the given query point.

--- a/search/include/pcl/search/organized.h
+++ b/search/include/pcl/search/organized.h
@@ -125,7 +125,7 @@ namespace pcl
           * \param[in] cloud the const boost shared pointer to a PointCloud message
           * \param[in] indices the const boost shared pointer to PointIndices
           */
-        void
+        bool
         setInputCloud (const PointCloudConstPtr& cloud, const IndicesConstPtr &indices = IndicesConstPtr ()) override
         {
           input_ = cloud;
@@ -143,7 +143,7 @@ namespace pcl
           else
             mask_.assign (input_->size (), 1);
 
-          estimateProjectionMatrix ();
+          return estimateProjectionMatrix () && isValid ();
         }
 
         /** \brief Search for all neighbors of query point that are within a given radius.
@@ -164,7 +164,7 @@ namespace pcl
                       unsigned int max_nn = 0) const override;
 
         /** \brief estimated the projection matrix from the input cloud. */
-        void 
+        bool
         estimateProjectionMatrix ();
 
          /** \brief Search for the k-nearest neighbors for a given query point.

--- a/search/include/pcl/search/search.h
+++ b/search/include/pcl/search/search.h
@@ -113,8 +113,9 @@ namespace pcl
         /** \brief Pass the input dataset that the search will be performed on.
           * \param[in] cloud a const pointer to the PointCloud data
           * \param[in] indices the point indices subset that is to be used from the cloud
+          * \return True if successful, false if an error occurred, for example because the point cloud is unsuited for the search method.
           */
-        virtual void
+        virtual bool
         setInputCloud (const PointCloudConstPtr& cloud, 
                        const IndicesConstPtr &indices = IndicesConstPtr ());
 


### PR DESCRIPTION
Instead of returning nothing, return true on success and false on failure. This is especially useful for organized neighbor to indicate whether the input cloud is suitable, but might also come in handy for other methods in the future. In filters, use the returned value to abort in case of failure. Fixes https://github.com/PointCloudLibrary/pcl/issues/5819