### PR TITLE
MSAC and RMSAC: fix check array distances empty

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/impl/msac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/msac.hpp
@@ -90,8 +90,12 @@ pcl::MEstimatorSampleConsensus<PointT>::computeModel (int debug_verbosity_level)
     // Iterate through the 3d points and calculate the distances from them to the model
     sac_model_->getDistancesToModel (model_coefficients, distances);
     
-    if (distances.empty () && k > 1.0)
+    if (distances.empty ())
+    {
+      // skip invalid model suppress infinite loops 
+      ++ skipped_count;
       continue;
+    }
 
     for (const double &distance : distances)
       d_cur_penalty += (std::min) (distance, threshold_);

--- a/sample_consensus/include/pcl/sample_consensus/impl/rmsac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/rmsac.hpp
@@ -108,7 +108,7 @@ pcl::RandomizedMEstimatorSampleConsensus<PointT>::computeModel (int debug_verbos
     // Iterate through the 3d points and calculate the distances from them to the model
     sac_model_->getDistancesToModel (model_coefficients, distances);
 
-    if (distances.empty)
+    if (distances.empty ())
     {
       ++ skipped_count;
       continue;

--- a/sample_consensus/include/pcl/sample_consensus/impl/rmsac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/rmsac.hpp
@@ -108,8 +108,11 @@ pcl::RandomizedMEstimatorSampleConsensus<PointT>::computeModel (int debug_verbos
     // Iterate through the 3d points and calculate the distances from them to the model
     sac_model_->getDistancesToModel (model_coefficients, distances);
 
-    if (distances.empty () && k > 1.0)
+    if (distances.empty)
+    {
+      ++ skipped_count;
       continue;
+    }
 
     for (const double &distance : distances)
       d_cur_penalty += std::min (distance, threshold_);


### PR DESCRIPTION
see #5847 

This already been fixed for mlesac at a0d6b04a44240986f991faadc30b72de6e1e46f9