### PR TITLE
Part G of transition to support modernize-use-default-member-init

### DIFF
--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -46,7 +46,7 @@ namespace pcl {
 template <typename PointSource, typename PointTarget, typename Scalar>
 NormalDistributionsTransform<PointSource, PointTarget, Scalar>::
     NormalDistributionsTransform()
-: target_cells_(), trans_likelihood_()
+: target_cells_()
 {
   reg_name_ = "NormalDistributionsTransform";
 

--- a/segmentation/include/pcl/segmentation/approximate_progressive_morphological_filter.h
+++ b/segmentation/include/pcl/segmentation/approximate_progressive_morphological_filter.h
@@ -144,28 +144,28 @@ namespace pcl
     protected:
 
       /** \brief Maximum window size to be used in filtering ground returns. */
-      int max_window_size_;
+      int max_window_size_{33};
 
       /** \brief Slope value to be used in computing the height threshold. */
-      float slope_;
+      float slope_{0.7f};
 
       /** \brief Maximum height above the parameterized ground surface to be considered a ground return. */
-      float max_distance_;
+      float max_distance_{10.0f};
 
       /** \brief Initial height above the parameterized ground surface to be considered a ground return. */
-      float initial_distance_;
+      float initial_distance_{0.15f};
 
       /** \brief Cell size. */
-      float cell_size_;
+      float cell_size_{1.0f};
 
       /** \brief Base to be used in computing progressive window sizes. */
-      float base_;
+      float base_{2.0f};
 
       /** \brief Exponentially grow window sizes? */
-      bool exponential_;
+      bool exponential_{true};
 
       /** \brief Number of threads to be used. */
-      unsigned int threads_;      
+      unsigned int threads_{0};      
   };
 }
 

--- a/segmentation/include/pcl/segmentation/conditional_euclidean_clustering.h
+++ b/segmentation/include/pcl/segmentation/conditional_euclidean_clustering.h
@@ -99,8 +99,7 @@ namespace pcl
       ConditionalEuclideanClustering (bool extract_removed_clusters = false) :
           searcher_ (),
           condition_function_ (),
-          cluster_tolerance_ (0.0f),
-          min_cluster_size_ (1),
+          
           max_cluster_size_ (std::numeric_limits<int>::max ()),
           extract_removed_clusters_ (extract_removed_clusters),
           small_clusters_ (new pcl::IndicesClusters),
@@ -243,10 +242,10 @@ namespace pcl
       std::function<bool (const PointT&, const PointT&, float)> condition_function_;
 
       /** \brief The distance to scan for cluster candidates (default = 0.0) */
-      float cluster_tolerance_;
+      float cluster_tolerance_{0.0f};
 
       /** \brief The minimum cluster size (default = 1) */
-      int min_cluster_size_;
+      int min_cluster_size_{1};
 
       /** \brief The maximum cluster size (default = unlimited) */
       int max_cluster_size_;

--- a/segmentation/include/pcl/segmentation/cpc_segmentation.h
+++ b/segmentation/include/pcl/segmentation/cpc_segmentation.h
@@ -138,25 +138,25 @@ namespace pcl
       ///  *** Parameters *** ///
 
       /** \brief Maximum number of cuts */
-      std::uint32_t max_cuts_;
+      std::uint32_t max_cuts_{20};
 
       /** \brief Minimum segment size for cutting */
-      std::uint32_t min_segment_size_for_cutting_;
+      std::uint32_t min_segment_size_for_cutting_{400};
 
       /** \brief Cut_score threshold */
-      float min_cut_score_;
+      float min_cut_score_{0.16};
 
       /** \brief Use local constrains for cutting */
-      bool use_local_constrains_;
+      bool use_local_constrains_{true};
 
       /** \brief Use directed weights for the cutting */
-      bool use_directed_weights_;
+      bool use_directed_weights_{true};
 
       /** \brief Use clean cutting */
       bool use_clean_cutting_;
 
       /** \brief Iterations for RANSAC */
-      std::uint32_t ransac_itrs_;
+      std::uint32_t ransac_itrs_{10000};
 
 
 /******************************************* Directional weighted RANSAC declarations ******************************************************************/

--- a/segmentation/include/pcl/segmentation/extract_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_clusters.h
@@ -338,8 +338,7 @@ namespace pcl
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
       /** \brief Empty constructor. */
       EuclideanClusterExtraction () : tree_ (), 
-                                      cluster_tolerance_ (0),
-                                      min_pts_per_cluster_ (1), 
+                                       
                                       max_pts_per_cluster_ (std::numeric_limits<pcl::uindex_t>::max ())
       {};
 
@@ -426,10 +425,10 @@ namespace pcl
       KdTreePtr tree_;
 
       /** \brief The spatial cluster tolerance as a measure in the L2 Euclidean space. */
-      double cluster_tolerance_;
+      double cluster_tolerance_{0};
 
       /** \brief The minimum number of points that a cluster needs to contain in order to be considered valid (default = 1). */
-      pcl::uindex_t min_pts_per_cluster_;
+      pcl::uindex_t min_pts_per_cluster_{1};
 
       /** \brief The maximum number of points that a cluster needs to contain in order to be considered valid (default = MAXINT). */
       pcl::uindex_t max_pts_per_cluster_;

--- a/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
@@ -117,9 +117,8 @@ public:
   /** \brief Empty constructor. */
   LabeledEuclideanClusterExtraction()
   : tree_()
-  , cluster_tolerance_(0)
-  , min_pts_per_cluster_(1)
-  , max_pts_per_cluster_(std::numeric_limits<int>::max())
+  , 
+   max_pts_per_cluster_(std::numeric_limits<int>::max())
   , max_label_(std::numeric_limits<int>::max()){};
 
   /** \brief Provide a pointer to the search object.
@@ -225,11 +224,11 @@ protected:
   KdTreePtr tree_;
 
   /** \brief The spatial cluster tolerance as a measure in the L2 Euclidean space. */
-  double cluster_tolerance_;
+  double cluster_tolerance_{0};
 
   /** \brief The minimum number of points that a cluster needs to contain in order to be
    * considered valid (default = 1). */
-  int min_pts_per_cluster_;
+  int min_pts_per_cluster_{1};
 
   /** \brief The maximum number of points that a cluster needs to contain in order to be
    * considered valid (default = MAXINT). */

--- a/segmentation/include/pcl/segmentation/extract_polygonal_prism_data.h
+++ b/segmentation/include/pcl/segmentation/extract_polygonal_prism_data.h
@@ -115,10 +115,8 @@ namespace pcl
       using PointIndicesConstPtr = PointIndices::ConstPtr;
 
       /** \brief Empty constructor. */
-      ExtractPolygonalPrismData () : planar_hull_ (), min_pts_hull_ (3), 
-                                     height_limit_min_ (0),
-                                     height_limit_max_(std::numeric_limits<float>::max()),
-                                     vpx_ (0), vpy_ (0), vpz_ (0)
+      ExtractPolygonalPrismData () : planar_hull_ (), 
+                                     height_limit_max_(std::numeric_limits<float>::max()) 
       {};
 
       /** \brief Provide a pointer to the input planar hull dataset.
@@ -190,12 +188,12 @@ namespace pcl
       PointCloudConstPtr planar_hull_;
 
       /** \brief The minimum number of points needed on the convex hull. */
-      int min_pts_hull_;
+      int min_pts_hull_{3};
 
       /** \brief The minimum allowed height (distance to the model) a point
         * will be considered from. 
         */
-      double height_limit_min_;
+      double height_limit_min_{0};
 
       /** \brief The maximum allowed height (distance to the model) a point
         * will be considered from. 
@@ -203,7 +201,7 @@ namespace pcl
       double height_limit_max_;
 
       /** \brief Values describing the data acquisition viewpoint. Default: 0,0,0. */
-      float vpx_, vpy_, vpz_;
+      float vpx_{0}, vpy_{0}, vpz_{0};
 
       /** \brief Class getName method. */
       virtual std::string 

--- a/segmentation/include/pcl/segmentation/grabcut_segmentation.h
+++ b/segmentation/include/pcl/segmentation/grabcut_segmentation.h
@@ -157,7 +157,7 @@ namespace pcl
           /// nodes and their outgoing internal edges
           std::vector<capacitated_edge> nodes_;
           /// current flow value (includes constant)
-          double flow_value_;
+          double flow_value_{0.0};
           /// identifies which side of the cut a node falls
           std::vector<unsigned char> cut_;
 
@@ -259,8 +259,8 @@ namespace pcl
         GaussianFitter (float epsilon = 0.0001)
           : sum_ (Eigen::Vector3f::Zero ())
           , accumulator_ (Eigen::Matrix3f::Zero ())
-          , count_ (0)
-          , epsilon_ (epsilon)
+          , 
+           epsilon_ (epsilon)
         { }
 
         /// Add a color sample
@@ -285,7 +285,7 @@ namespace pcl
         /// matrix of products (i.e. r*r, r*g, r*b), some values are duplicated.
         Eigen::Matrix3f accumulator_;
         /// count of color samples added to the gaussian
-        std::uint32_t count_;
+        std::uint32_t count_{0};
         /// small value to add to covariance matrix diagonal to avoid singular values
         float epsilon_;
         PCL_MAKE_ALIGNED_OPERATOR_NEW
@@ -329,12 +329,8 @@ namespace pcl
       using PCLBase<PointT>::fake_indices_;
 
       /// Constructor
-      GrabCut (std::uint32_t K = 5, float lambda = 50.f)
-        : K_ (K)
-        , lambda_ (lambda)
-        , nb_neighbours_ (9)
-        , initialized_ (false)
-      {}
+      GrabCut(std::uint32_t K = 5, float lambda = 50.f) : K_(K), lambda_(lambda) {}
+
       /// Destructor
       ~GrabCut () override = default;
       // /// Set input cloud
@@ -399,9 +395,9 @@ namespace pcl
       // Storage for N-link weights, each pixel stores links to nb_neighbours
       struct NLinks
       {
-        NLinks () : nb_links (0), indices (0), dists (0), weights (0) {}
+        NLinks () :  indices (0), dists (0), weights (0) {}
 
-        int nb_links;
+        int nb_links{0};
         Indices indices;
         std::vector<float> dists;
         std::vector<float> weights;
@@ -460,9 +456,9 @@ namespace pcl
       /// Pointer to the spatial search object.
       KdTreePtr tree_;
       /// Number of neighbours
-      int nb_neighbours_;
+      int nb_neighbours_{9};
       /// is segmentation initialized
-      bool initialized_;
+      bool initialized_{false};
       /// Precomputed N-link weights
       std::vector<NLinks> n_links_;
       /// Converted input

--- a/segmentation/include/pcl/segmentation/impl/approximate_progressive_morphological_filter.hpp
+++ b/segmentation/include/pcl/segmentation/impl/approximate_progressive_morphological_filter.hpp
@@ -49,17 +49,7 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
-pcl::ApproximateProgressiveMorphologicalFilter<PointT>::ApproximateProgressiveMorphologicalFilter () :
-  max_window_size_ (33),
-  slope_ (0.7f),
-  max_distance_ (10.0f),
-  initial_distance_ (0.15f),
-  cell_size_ (1.0f),
-  base_ (2.0f),
-  exponential_ (true),
-  threads_ (0)
-{
-}
+pcl::ApproximateProgressiveMorphologicalFilter<PointT>::ApproximateProgressiveMorphologicalFilter () = default;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT>

--- a/segmentation/include/pcl/segmentation/impl/cpc_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/cpc_segmentation.hpp
@@ -42,15 +42,7 @@
 #include <pcl/segmentation/cpc_segmentation.h>
 
 template <typename PointT>
-pcl::CPCSegmentation<PointT>::CPCSegmentation () :
-    max_cuts_ (20),
-    min_segment_size_for_cutting_ (400),
-    min_cut_score_ (0.16),
-    use_local_constrains_ (true),
-    use_directed_weights_ (true),
-    ransac_itrs_ (10000)
-{
-}
+pcl::CPCSegmentation<PointT>::CPCSegmentation () = default;
 
 template <typename PointT>
 pcl::CPCSegmentation<PointT>::~CPCSegmentation () = default;

--- a/segmentation/include/pcl/segmentation/impl/lccp_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/lccp_segmentation.hpp
@@ -51,19 +51,7 @@
 
 
 template <typename PointT>
-pcl::LCCPSegmentation<PointT>::LCCPSegmentation () :
-  concavity_tolerance_threshold_ (10),
-  grouping_data_valid_ (false),
-  supervoxels_set_ (false),
-  use_smoothness_check_ (false),
-  smoothness_threshold_ (0.1),
-  use_sanity_check_ (false),  
-  seed_resolution_ (0),
-  voxel_resolution_ (0),
-  k_factor_ (0),
-  min_segment_size_ (0)
-{
-}
+pcl::LCCPSegmentation<PointT>::LCCPSegmentation () = default;
 
 template <typename PointT>
 pcl::LCCPSegmentation<PointT>::~LCCPSegmentation () = default;

--- a/segmentation/include/pcl/segmentation/impl/min_cut_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/min_cut_segmentation.hpp
@@ -48,23 +48,15 @@
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
 pcl::MinCutSegmentation<PointT>::MinCutSegmentation () :
-  inverse_sigma_ (16.0),
-  binary_potentials_are_valid_ (false),
-  epsilon_ (0.0001),
-  radius_ (16.0),
-  unary_potentials_are_valid_ (false),
-  source_weight_ (0.8),
+  
   search_ (),
-  number_of_neighbours_ (14),
-  graph_is_valid_ (false),
+  
   foreground_points_ (0),
   background_points_ (0),
   clusters_ (0),
   vertices_ (0),
-  edge_marker_ (0),
-  source_ (),/////////////////////////////////
-  sink_ (),///////////////////////////////////
-  max_flow_ (0.0)
+  edge_marker_ (0)
+  ///////////////////////////////////
 {
 }
 

--- a/segmentation/include/pcl/segmentation/impl/progressive_morphological_filter.hpp
+++ b/segmentation/include/pcl/segmentation/impl/progressive_morphological_filter.hpp
@@ -48,16 +48,7 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
-pcl::ProgressiveMorphologicalFilter<PointT>::ProgressiveMorphologicalFilter () :
-  max_window_size_ (33),
-  slope_ (0.7f),
-  max_distance_ (10.0f),
-  initial_distance_ (0.15f),
-  cell_size_ (1.0f),
-  base_ (2.0f),
-  exponential_ (true)
-{
-}
+pcl::ProgressiveMorphologicalFilter<PointT>::ProgressiveMorphologicalFilter () = default;
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT>

--- a/segmentation/include/pcl/segmentation/impl/region_growing.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing.hpp
@@ -54,26 +54,16 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename NormalT>
-pcl::RegionGrowing<PointT, NormalT>::RegionGrowing () :
-  min_pts_per_cluster_ (1),
-  max_pts_per_cluster_ (std::numeric_limits<pcl::uindex_t>::max ()),
-  smooth_mode_flag_ (true),
-  curvature_flag_ (true),
-  residual_flag_ (false),
-  theta_threshold_ (30.0f / 180.0f * static_cast<float> (M_PI)),
-  residual_threshold_ (0.05f),
-  curvature_threshold_ (0.05f),
-  neighbour_number_ (30),
-  search_ (),
-  normals_ (),
-  point_neighbours_ (0),
-  point_labels_ (0),
-  normal_flag_ (true),
-  num_pts_in_segment_ (0),
-  clusters_ (0),
-  number_of_segments_ (0)
-{
-}
+pcl::RegionGrowing<PointT, NormalT>::RegionGrowing()
+: max_pts_per_cluster_(std::numeric_limits<pcl::uindex_t>::max())
+, theta_threshold_(30.0f / 180.0f * static_cast<float>(M_PI))
+, search_()
+, normals_()
+, point_neighbours_(0)
+, point_labels_(0)
+, num_pts_in_segment_(0)
+, clusters_(0)
+{}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename NormalT>

--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -50,10 +50,7 @@
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, typename NormalT>
 pcl::RegionGrowingRGB<PointT, NormalT>::RegionGrowingRGB () :
-  color_p2p_threshold_ (1225.0f),
-  color_r2r_threshold_ (10.0f),
-  distance_threshold_ (0.05f),
-  region_neighbour_number_ (100),
+  
   point_distances_ (0),
   segment_neighbours_ (0),
   segment_distances_ (0),

--- a/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
+++ b/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
@@ -45,17 +45,14 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
-pcl::SupervoxelClustering<PointT>::SupervoxelClustering (float voxel_resolution, float seed_resolution) :
-  resolution_ (voxel_resolution),
-  seed_resolution_ (seed_resolution),
-  adjacency_octree_ (),
-  voxel_centroid_cloud_ (),
-  color_importance_ (0.1f),
-  spatial_importance_ (0.4f),
-  normal_importance_ (1.0f),
-  use_default_transform_behaviour_ (true)
+pcl::SupervoxelClustering<PointT>::SupervoxelClustering(float voxel_resolution,
+                                                        float seed_resolution)
+: resolution_(voxel_resolution)
+, seed_resolution_(seed_resolution)
+, adjacency_octree_()
+, voxel_centroid_cloud_()
 {
-  adjacency_octree_.reset (new OctreeAdjacencyT (resolution_));
+  adjacency_octree_.reset(new OctreeAdjacencyT(resolution_));
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
+++ b/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
@@ -52,14 +52,9 @@
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT>
-pcl::UnaryClassifier<PointT>::UnaryClassifier () :
-  input_cloud_ (new pcl::PointCloud<PointT>),
-  label_field_ (false),
-  normal_radius_search_ (0.01f),
-  fpfh_radius_search_ (0.05f),
-  feature_threshold_ (5.0)
-{
-}
+pcl::UnaryClassifier<PointT>::UnaryClassifier()
+: input_cloud_(new pcl::PointCloud<PointT>)
+{}
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT>

--- a/segmentation/include/pcl/segmentation/lccp_segmentation.h
+++ b/segmentation/include/pcl/segmentation/lccp_segmentation.h
@@ -60,21 +60,18 @@ namespace pcl
     struct EdgeProperties
     {
       /** \brief Describes the difference of normals of the two supervoxels being connected*/
-      float normal_difference;
+      float normal_difference{0.0f};
 
       /** \brief Describes if a connection is convex or concave*/
-      bool is_convex;
+      bool is_convex{false};
 
       /** \brief Describes if a connection is valid for the segment growing. Usually convex connections are and concave connection are not. Due to k-concavity a convex connection can be invalidated*/
-      bool is_valid;
+      bool is_valid{false};
 
       /** \brief Additional member used for the CPC algorithm. If edge has already induced a cut, it should be ignored for further cutting.*/
-      bool used_for_cutting;
+      bool used_for_cutting{false};
 
-      EdgeProperties () :
-      normal_difference (0), is_convex (false), is_valid (false), used_for_cutting (false)
-      {
-      }
+      EdgeProperties () = default;
     };
 
     public:
@@ -297,34 +294,34 @@ namespace pcl
       ///  *** Parameters *** ///
 
       /** \brief Normal Threshold in degrees [0,180] used for merging */
-      float concavity_tolerance_threshold_;
+      float concavity_tolerance_threshold_{10};
 
       /** \brief Marks if valid grouping data (\ref sv_adjacency_list_, \ref sv_label_to_seg_label_map_, \ref processed_) is available */
-      bool grouping_data_valid_;
+      bool grouping_data_valid_{false};
 
       /** \brief Marks if supervoxels have been set by calling \ref setInputSupervoxels */
-      bool supervoxels_set_;
+      bool supervoxels_set_{false};
 
       /** \brief Determines if the smoothness check is used during segmentation*/
-      bool use_smoothness_check_;
+      bool use_smoothness_check_{false};
 
       /** \brief Two supervoxels are unsmooth if their plane-to-plane distance DIST >  (expected_distance + smoothness_threshold_*voxel_resolution_). For parallel supervoxels, the expected_distance is zero. */
-      float smoothness_threshold_;
+      float smoothness_threshold_{0.1};
 
       /** \brief Determines if we use the sanity check which tries to find and invalidate singular connected patches*/
-      bool use_sanity_check_;
+      bool use_sanity_check_{false};
 
       /** \brief Seed resolution of the supervoxels (used only for smoothness check) */
-      float seed_resolution_;
+      float seed_resolution_{0};
 
       /** \brief Voxel resolution used to build the supervoxels (used only for smoothness check)*/
-      float voxel_resolution_;
+      float voxel_resolution_{0};
 
       /** \brief Factor used for k-convexity */
-      std::uint32_t k_factor_;
+      std::uint32_t k_factor_{0};
 
       /** \brief Minimum segment size */
-      std::uint32_t min_segment_size_;
+      std::uint32_t min_segment_size_{0};
 
       /** \brief Stores which supervoxel labels were already visited during recursive grouping.
        *  \note processed_[sv_Label] = false (default)/true (already processed) */

--- a/segmentation/include/pcl/segmentation/min_cut_segmentation.h
+++ b/segmentation/include/pcl/segmentation/min_cut_segmentation.h
@@ -261,31 +261,31 @@ namespace pcl
     protected:
 
       /** \brief Stores the sigma coefficient. It is used for finding smooth costs. More information can be found in the article. */
-      double inverse_sigma_;
+      double inverse_sigma_{16.0};
 
       /** \brief Signalizes if the binary potentials are valid. */
-      bool binary_potentials_are_valid_;
+      bool binary_potentials_are_valid_{false};
 
       /** \brief Used for comparison of the floating point numbers. */
-      double epsilon_;
+      double epsilon_{0.0001};
 
       /** \brief Stores the distance to the background. */
-      double radius_;
+      double radius_{16.0};
 
       /** \brief Signalizes if the unary potentials are valid. */
-      bool unary_potentials_are_valid_;
+      bool unary_potentials_are_valid_{false};
 
       /** \brief Stores the weight for every edge that comes from source point. */
-      double source_weight_;
+      double source_weight_{0.8};
 
       /** \brief Stores the search method that will be used for finding K nearest neighbors. Neighbours are used for building the graph. */
       KdTreePtr search_;
 
       /** \brief Stores the number of neighbors to find. */
-      unsigned int number_of_neighbours_;
+      unsigned int number_of_neighbours_{14};
 
       /** \brief Signalizes if the graph is valid. */
-      bool graph_is_valid_;
+      bool graph_is_valid_{false};
 
       /** \brief Stores the points that are known to be in the foreground. */
       std::vector<PointT, Eigen::aligned_allocator<PointT> > foreground_points_;
@@ -312,13 +312,13 @@ namespace pcl
       std::vector< std::set<int> > edge_marker_;
 
       /** \brief Stores the vertex that serves as source. */
-      VertexDescriptor source_;
+      VertexDescriptor source_{};
 
       /** \brief Stores the vertex that serves as sink. */
-      VertexDescriptor sink_;
+      VertexDescriptor sink_{};
 
       /** \brief Stores the maximum flow value that was calculated during the segmentation. */
-      double max_flow_;
+      double max_flow_{0.0};
 
     public:
       PCL_MAKE_ALIGNED_OPERATOR_NEW

--- a/segmentation/include/pcl/segmentation/organized_multi_plane_segmentation.h
+++ b/segmentation/include/pcl/segmentation/organized_multi_plane_segmentation.h
@@ -91,11 +91,9 @@ namespace pcl
       /** \brief Constructor for OrganizedMultiPlaneSegmentation. */
       OrganizedMultiPlaneSegmentation () :
         normals_ (), 
-        min_inliers_ (1000), 
+         
         angular_threshold_ (pcl::deg2rad (3.0)), 
-        distance_threshold_ (0.02),
-        maximum_curvature_ (0.001),
-        project_points_ (false), 
+         
         compare_ (new PlaneComparator ()), refinement_compare_ (new PlaneRefinementComparator ())
       {
       }
@@ -282,19 +280,19 @@ namespace pcl
       PointCloudNConstPtr normals_;
 
       /** \brief The minimum number of inliers required for each plane. */
-      unsigned min_inliers_;
+      unsigned min_inliers_{1000};
 
       /** \brief The tolerance in radians for difference in normal direction between neighboring points, to be considered part of the same plane. */
       double angular_threshold_;
 
       /** \brief The tolerance in meters for difference in perpendicular distance (d component of plane equation) to the plane between neighboring points, to be considered part of the same plane. */
-      double distance_threshold_;
+      double distance_threshold_{0.02};
 
       /** \brief The tolerance for maximum curvature after fitting a plane.  Used to remove smooth, but non-planar regions. */
-      double maximum_curvature_;
+      double maximum_curvature_{0.001};
 
       /** \brief Whether or not points should be projected to the plane, or left in the original 3D space. */
-      bool project_points_;
+      bool project_points_{false};
 
       /** \brief A comparator for comparing neighboring pixels' plane equations. */
       PlaneComparatorPtr compare_;

--- a/segmentation/include/pcl/segmentation/progressive_morphological_filter.h
+++ b/segmentation/include/pcl/segmentation/progressive_morphological_filter.h
@@ -137,25 +137,25 @@ namespace pcl
     protected:
 
       /** \brief Maximum window size to be used in filtering ground returns. */
-      int max_window_size_;
+      int max_window_size_{33};
 
       /** \brief Slope value to be used in computing the height threshold. */
-      float slope_;
+      float slope_{0.7f};
 
       /** \brief Maximum height above the parameterized ground surface to be considered a ground return. */
-      float max_distance_;
+      float max_distance_{10.0f};
 
       /** \brief Initial height above the parameterized ground surface to be considered a ground return. */
-      float initial_distance_;
+      float initial_distance_{0.15f};
 
       /** \brief Cell size. */
-      float cell_size_;
+      float cell_size_{1.0f};
 
       /** \brief Base to be used in computing progressive window sizes. */
-      float base_;
+      float base_{2.0f};
 
       /** \brief Exponentially grow window sizes? */
-      bool exponential_;
+      bool exponential_{true};
   };
 }
 

--- a/segmentation/include/pcl/segmentation/region_growing.h
+++ b/segmentation/include/pcl/segmentation/region_growing.h
@@ -279,31 +279,31 @@ namespace pcl
     protected:
 
       /** \brief Stores the minimum number of points that a cluster needs to contain in order to be considered valid. */
-      pcl::uindex_t min_pts_per_cluster_;
+      pcl::uindex_t min_pts_per_cluster_{1};
 
       /** \brief Stores the maximum number of points that a cluster needs to contain in order to be considered valid. */
       pcl::uindex_t max_pts_per_cluster_;
 
       /** \brief Flag that signalizes if the smoothness constraint will be used. */
-      bool smooth_mode_flag_;
+      bool smooth_mode_flag_{true};
 
       /** \brief If set to true then curvature test will be done during segmentation. */
-      bool curvature_flag_;
+      bool curvature_flag_{true};
 
       /** \brief If set to true then residual test will be done during segmentation. */
-      bool residual_flag_;
+      bool residual_flag_{false};
 
       /** \brief Threshold used for testing the smoothness between points. */
       float theta_threshold_;
 
       /** \brief Threshold used in residual test. */
-      float residual_threshold_;
+      float residual_threshold_{0.05f};
 
       /** \brief Threshold used in curvature test. */
-      float curvature_threshold_;
+      float curvature_threshold_{0.05f};
 
       /** \brief Number of neighbours to find. */
-      unsigned int neighbour_number_;
+      unsigned int neighbour_number_{30};
 
       /** \brief Search method that will be used for KNN. */
       KdTreePtr search_;
@@ -320,7 +320,7 @@ namespace pcl
       /** \brief If set to true then normal/smoothness test will be done during segmentation.
         * It is always set to true for the usual region growing algorithm. It is used for turning on/off the test
         * for smoothness in the child class RegionGrowingRGB.*/
-      bool normal_flag_;
+      bool normal_flag_{true};
 
       /** \brief Tells how much points each segment contains. Used for reserving memory. */
       std::vector<pcl::uindex_t> num_pts_in_segment_;
@@ -329,7 +329,7 @@ namespace pcl
       std::vector <pcl::PointIndices> clusters_;
 
       /** \brief Stores the number of segments. */
-      int number_of_segments_;
+      int number_of_segments_{0};
 
     public:
       PCL_MAKE_ALIGNED_OPERATOR_NEW

--- a/segmentation/include/pcl/segmentation/region_growing_rgb.h
+++ b/segmentation/include/pcl/segmentation/region_growing_rgb.h
@@ -252,16 +252,16 @@ namespace pcl
     protected:
 
       /** \brief Thershold used in color test for points. */
-      float color_p2p_threshold_;
+      float color_p2p_threshold_{1225.0f};
 
       /** \brief Thershold used in color test for regions. */
-      float color_r2r_threshold_;
+      float color_r2r_threshold_{10.0f};
 
       /** \brief Threshold that tells which points we need to assume neighbouring. */
-      float distance_threshold_;
+      float distance_threshold_{0.05f};
 
       /** \brief Number of neighbouring segments to find. */
-      unsigned int region_neighbour_number_;
+      unsigned int region_neighbour_number_{100};
 
       /** \brief Stores distances for the point neighbours from point_neighbours_ */
       std::vector< std::vector<float> > point_distances_;

--- a/segmentation/include/pcl/segmentation/sac_segmentation.h
+++ b/segmentation/include/pcl/segmentation/sac_segmentation.h
@@ -84,20 +84,15 @@ namespace pcl
       SACSegmentation (bool random = false) 
         : model_ ()
         , sac_ ()
-        , model_type_ (-1)
-        , method_type_ (0)
-        , threshold_ (0)
-        , optimize_coefficients_ (true)
-        , radius_min_ (-std::numeric_limits<double>::max ())
+        , 
+         radius_min_ (-std::numeric_limits<double>::max ())
         , radius_max_ (std::numeric_limits<double>::max ())
-        , samples_radius_ (0.0)
-        , samples_radius_search_ ()
-        , eps_angle_ (0.0)
-        , axis_ (Eigen::Vector3f::Zero ())
-        , max_iterations_ (50)
-        , threads_ (-1)
-        , probability_ (0.99)
-        , random_ (random)
+        , 
+         samples_radius_search_ ()
+        , 
+         axis_ (Eigen::Vector3f::Zero ())
+        , 
+         random_ (random)
       {
       }
 
@@ -270,40 +265,40 @@ namespace pcl
       SampleConsensusPtr sac_;
 
       /** \brief The type of model to use (user given parameter). */
-      int model_type_;
+      int model_type_{-1};
 
       /** \brief The type of sample consensus method to use (user given parameter). */
-      int method_type_;
+      int method_type_{0};
 
       /** \brief Distance to the model threshold (user given parameter). */
-      double threshold_;
+      double threshold_{0};
 
       /** \brief Set to true if a coefficient refinement is required. */
-      bool optimize_coefficients_;
+      bool optimize_coefficients_{true};
 
       /** \brief The minimum and maximum radius limits for the model. Applicable to all models that estimate a radius. */
       double radius_min_, radius_max_;
 
       /** \brief The maximum distance of subsequent samples from the first (radius search) */
-      double samples_radius_;
+      double samples_radius_{0.0};
 
       /** \brief The search object for picking subsequent samples using radius search */
       SearchPtr samples_radius_search_;
 
       /** \brief The maximum allowed difference between the model normal and the given axis. */
-      double eps_angle_;
+      double eps_angle_{0.0};
 
       /** \brief The axis along which we need to search for a model perpendicular to. */
       Eigen::Vector3f axis_;
 
       /** \brief Maximum number of iterations before giving up (user given parameter). */
-      int max_iterations_;
+      int max_iterations_{50};
 
       /** \brief The number of threads the scheduler should use, or a negative number if no parallelization is wanted. */
-      int threads_;
+      int threads_{-1};
 
       /** \brief Desired probability of choosing at least one sample free from outliers (user given parameter). */
-      double probability_;
+      double probability_{0.99};
 
       /** \brief Set to true if we need a random seed. */
       bool random_;
@@ -350,10 +345,7 @@ namespace pcl
       SACSegmentationFromNormals (bool random = false) 
         : SACSegmentation<PointT> (random)
         , normals_ ()
-        , distance_weight_ (0.1)
-        , distance_from_origin_ (0)
-        , min_angle_ (0.0)
-        , max_angle_ (M_PI_2)
+         
       {};
 
       /** \brief Provide a pointer to the input dataset that contains the point normals of 
@@ -415,14 +407,14 @@ namespace pcl
       /** \brief The relative weight (between 0 and 1) to give to the angular
         * distance (0 to pi/2) between point normals and the plane normal. 
         */
-      double distance_weight_;
+      double distance_weight_{0.1};
 
       /** \brief The distance from the template plane to the origin. */
-      double distance_from_origin_;
+      double distance_from_origin_{0};
 
       /** \brief The minimum and maximum allowed opening angle of valid cone model. */
-      double min_angle_;
-      double max_angle_;
+      double min_angle_{0.0};
+      double max_angle_{M_PI_2};
 
       /** \brief Initialize the Sample Consensus model and set its parameters.
         * \param[in] model_type the type of SAC model that is to be used

--- a/segmentation/include/pcl/segmentation/seeded_hue_segmentation.h
+++ b/segmentation/include/pcl/segmentation/seeded_hue_segmentation.h
@@ -107,7 +107,7 @@ namespace pcl
 
       //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
       /** \brief Empty constructor. */
-      SeededHueSegmentation () : cluster_tolerance_ (0), delta_hue_ (0.0)
+      SeededHueSegmentation ()  
       {};
 
       /** \brief Provide a pointer to the search object.
@@ -158,10 +158,10 @@ namespace pcl
       KdTreePtr tree_;
 
       /** \brief The spatial cluster tolerance as a measure in the L2 Euclidean space. */
-      double cluster_tolerance_;
+      double cluster_tolerance_{0};
 
       /** \brief The allowed difference on the hue*/
-      float delta_hue_;
+      float delta_hue_{0.0};
 
       /** \brief Class getName method. */
       virtual std::string getClassName () const { return ("seededHueSegmentation"); }

--- a/segmentation/include/pcl/segmentation/segment_differences.h
+++ b/segmentation/include/pcl/segmentation/segment_differences.h
@@ -86,7 +86,7 @@ namespace pcl
 
       /** \brief Empty constructor. */
       SegmentDifferences () : 
-        tree_ (), target_ (), distance_threshold_ (0)
+        tree_ (), target_ () 
       {};
 
       /** \brief Provide a pointer to the target dataset against which we
@@ -147,7 +147,7 @@ namespace pcl
       /** \brief The distance tolerance (squared) as a measure in the L2
         * Euclidean space between corresponding points. 
         */
-      double distance_threshold_;
+      double distance_threshold_{0};
 
       /** \brief Class getName method. */
       virtual std::string 

--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -139,9 +139,7 @@ namespace pcl
             xyz_ (0.0f, 0.0f, 0.0f),
             rgb_ (0.0f, 0.0f, 0.0f),
             normal_ (0.0f, 0.0f, 0.0f, 0.0f),
-            curvature_ (0.0f),
-            distance_(0),
-            idx_(0),
+            
             owner_ (nullptr)
             {}
 
@@ -160,9 +158,9 @@ namespace pcl
           Eigen::Vector3f xyz_;
           Eigen::Vector3f rgb_;
           Eigen::Vector4f normal_;
-          float curvature_;
-          float distance_;
-          int idx_;
+          float curvature_{0.0f};
+          float distance_{0};
+          int idx_{0};
           SupervoxelHelper* owner_;
 
         public:
@@ -373,11 +371,11 @@ namespace pcl
       typename NormalCloudT::ConstPtr input_normals_;
 
       /** \brief Importance of color in clustering */
-      float color_importance_;
+      float color_importance_{0.1f};
       /** \brief Importance of distance from seed center in clustering */
-      float spatial_importance_;
+      float spatial_importance_{0.4f};
       /** \brief Importance of similarity in normals for clustering */
-      float normal_importance_;
+      float normal_importance_{1.0f};
 
       /** \brief Whether or not to use the transform compressing depth in Z
        *  This is only checked if it has been manually set by the user.
@@ -385,7 +383,7 @@ namespace pcl
        */
       bool use_single_camera_transform_;
       /** \brief Whether to use default transform behavior or not */
-      bool use_default_transform_behaviour_;
+      bool use_default_transform_behaviour_{true};
 
       /** \brief Internal storage class for supervoxels
        * \note Stores pointers to leaves of clustering internal octree,

--- a/segmentation/include/pcl/segmentation/unary_classifier.h
+++ b/segmentation/include/pcl/segmentation/unary_classifier.h
@@ -147,13 +147,13 @@ namespace pcl
       /** \brief Contains the input cloud */
       typename pcl::PointCloud<PointT>::Ptr input_cloud_;
       
-      bool label_field_;
+      bool label_field_{false};
       
       unsigned int cluster_size_;
 
-      float normal_radius_search_;
-      float fpfh_radius_search_;
-      float feature_threshold_;
+      float normal_radius_search_{0.01f};
+      float fpfh_radius_search_{0.05f};
+      float feature_threshold_{5.0};
       
       
       std::vector<pcl::PointCloud<pcl::FPFHSignature33>::Ptr> trained_features_;

--- a/segmentation/src/grabcut_segmentation.cpp
+++ b/segmentation/src/grabcut_segmentation.cpp
@@ -47,7 +47,6 @@
 const int pcl::segmentation::grabcut::BoykovKolmogorov::TERMINAL = -1;
 
 pcl::segmentation::grabcut::BoykovKolmogorov::BoykovKolmogorov (std::size_t max_nodes)
-  : flow_value_(0.0)
 {
   if (max_nodes > 0)
   {

--- a/stereo/include/pcl/stereo/digital_elevation_map.h
+++ b/stereo/include/pcl/stereo/digital_elevation_map.h
@@ -129,11 +129,11 @@ public:
 
 protected:
   /** \brief Column resolution of the DEM. */
-  std::size_t resolution_column_;
+  std::size_t resolution_column_{64};
   /** \brief disparity resolution of the DEM. */
-  std::size_t resolution_disparity_;
+  std::size_t resolution_disparity_{32};
   /** \brief Minimum amount of points in a DEM's cell. */
-  std::size_t min_points_in_cell_;
+  std::size_t min_points_in_cell_{1};
 };
 
 } // namespace pcl

--- a/stereo/include/pcl/stereo/disparity_map_converter.h
+++ b/stereo/include/pcl/stereo/disparity_map_converter.h
@@ -228,28 +228,28 @@ protected:
   translateCoordinates(std::size_t row, std::size_t column, float disparity) const;
 
   /** \brief X-coordinate of the image center. */
-  float center_x_;
+  float center_x_{0.0f};
   /** \brief Y-coordinate of the image center. */
-  float center_y_;
+  float center_y_{0.0f};
   /** \brief Focal length. */
-  float focal_length_;
+  float focal_length_{0.0f};
   /** \brief Baseline. */
-  float baseline_;
+  float baseline_{0.0f};
 
   /** \brief Is color image is set. */
-  bool is_color_;
+  bool is_color_{false};
   /** \brief Color image of the scene. */
   pcl::PointCloud<pcl::RGB>::ConstPtr image_;
 
   /** \brief Vector for the disparity map. */
   std::vector<float> disparity_map_;
   /** \brief X-size of the disparity map. */
-  std::size_t disparity_map_width_;
+  std::size_t disparity_map_width_{640};
   /** \brief Y-size of the disparity map. */
-  std::size_t disparity_map_height_;
+  std::size_t disparity_map_height_{480};
 
   /** \brief Thresholds of the disparity. */
-  float disparity_threshold_min_;
+  float disparity_threshold_min_{0.0f};
   float disparity_threshold_max_;
 };
 

--- a/stereo/include/pcl/stereo/impl/disparity_map_converter.hpp
+++ b/stereo/include/pcl/stereo/impl/disparity_map_converter.hpp
@@ -47,15 +47,8 @@
 
 template <typename PointT>
 pcl::DisparityMapConverter<PointT>::DisparityMapConverter()
-: center_x_(0.0f)
-, center_y_(0.0f)
-, focal_length_(0.0f)
-, baseline_(0.0f)
-, is_color_(false)
-, disparity_map_width_(640)
-, disparity_map_height_(480)
-, disparity_threshold_min_(0.0f)
-, disparity_threshold_max_(std::numeric_limits<float>::max())
+: 
+ disparity_threshold_max_(std::numeric_limits<float>::max())
 {}
 
 template <typename PointT>

--- a/stereo/src/digital_elevation_map.cpp
+++ b/stereo/src/digital_elevation_map.cpp
@@ -38,9 +38,7 @@
 #include <pcl/console/print.h>
 #include <pcl/stereo/digital_elevation_map.h>
 
-pcl::DigitalElevationMapBuilder::DigitalElevationMapBuilder()
-: resolution_column_(64), resolution_disparity_(32), min_points_in_cell_(1)
-{}
+pcl::DigitalElevationMapBuilder::DigitalElevationMapBuilder() = default;
 
 pcl::DigitalElevationMapBuilder::~DigitalElevationMapBuilder() = default;
 

--- a/tools/obj_rec_ransac_accepted_hypotheses.cpp
+++ b/tools/obj_rec_ransac_accepted_hypotheses.cpp
@@ -85,9 +85,8 @@ class CallbackParameters
       viz_ (viz),
       points_ (points),
       normals_ (normals),
-      num_hypotheses_to_show_ (num_hypotheses_to_show),
-      show_models_ (true)
-    { }
+      num_hypotheses_to_show_ (num_hypotheses_to_show)
+    {}
 
     ObjRecRANSAC& objrec_;
     PCLVisualizer& viz_;
@@ -95,7 +94,7 @@ class CallbackParameters
     PointCloud<Normal>& normals_;
     int num_hypotheses_to_show_;
     std::list<vtkActor*> actors_, model_actors_;
-    bool show_models_;
+    bool show_models_{true};
 };
 
 //===============================================================================================================================

--- a/tools/octree_viewer.cpp
+++ b/tools/octree_viewer.cpp
@@ -62,12 +62,7 @@ public:
     cloud (new pcl::PointCloud<pcl::PointXYZ>()),
     displayCloud (new pcl::PointCloud<pcl::PointXYZ>()),
     cloudVoxel (new pcl::PointCloud<pcl::PointXYZ>()),
-    octree (resolution),
-    wireframe (true),
-    show_cubes_ (true),
-    show_centroids_ (false),
-    show_original_points_ (false),
-    point_size_ (1.0)
+    octree (resolution)
   {
 
     //try to load the cloud
@@ -126,9 +121,9 @@ private:
   //level
   int displayedDepth;
   //bool to decide what should be display
-  bool wireframe;
-  bool show_cubes_, show_centroids_, show_original_points_;
-  float point_size_;
+  bool wireframe{true};
+  bool show_cubes_{true}, show_centroids_{false}, show_original_points_{false};
+  float point_size_{1.0};
   //========================================================
 
   /* \brief Callback to interact with the keyboard

--- a/tools/openni_image.cpp
+++ b/tools/openni_image.cpp
@@ -549,7 +549,6 @@ class Viewer
     ///////////////////////////////////////////////////////////////////////////////////////
     Viewer (Buffer &buf)
       : buf_ (buf)
-      , image_cld_init_ (false), depth_image_cld_init_ (false)
     {
       image_viewer_.reset (new visualization::ImageViewer ("PCL/OpenNI RGB image viewer"));
       depth_image_viewer_.reset (new visualization::ImageViewer ("PCL/OpenNI depth image viewer"));
@@ -620,7 +619,7 @@ class Viewer
     Buffer &buf_;
     visualization::ImageViewer::Ptr image_viewer_;
     visualization::ImageViewer::Ptr depth_image_viewer_;
-    bool image_cld_init_, depth_image_cld_init_;
+    bool image_cld_init_{false}, depth_image_cld_init_{false};
 };
 
 void

--- a/tools/openni_viewer.cpp
+++ b/tools/openni_viewer.cpp
@@ -109,12 +109,10 @@ class OpenNIViewer
     using Cloud = pcl::PointCloud<PointType>;
     using CloudConstPtr = typename Cloud::ConstPtr;
 
-    OpenNIViewer (pcl::Grabber& grabber)
-      : cloud_viewer_ (new pcl::visualization::PCLVisualizer ("PCL OpenNI cloud"))
-      , grabber_ (grabber)
-      , rgb_data_ (nullptr), rgb_data_size_ (0)
-    {
-    }
+    OpenNIViewer(pcl::Grabber& grabber)
+    : cloud_viewer_(new pcl::visualization::PCLVisualizer("PCL OpenNI cloud"))
+    , grabber_(grabber)
+    {}
 
     void
     cloud_callback (const CloudConstPtr& cloud)
@@ -263,8 +261,8 @@ class OpenNIViewer
     
     CloudConstPtr cloud_;
     openni_wrapper::Image::Ptr image_;
-    unsigned char* rgb_data_;
-    unsigned rgb_data_size_;
+    unsigned char* rgb_data_{nullptr};
+    unsigned rgb_data_size_{0};
 };
 
 // Create the PCLVisualizer object

--- a/tools/ply2obj.cpp
+++ b/tools/ply2obj.cpp
@@ -122,18 +122,14 @@ class ply_to_obj_converter
     void
     face_end ();
 
-    flags_type flags_;
-    std::ostream* ostream_;
-    double vertex_x_, vertex_y_, vertex_z_;
-    std::size_t face_vertex_indices_element_index_, face_vertex_indices_first_element_, face_vertex_indices_previous_element_;
+    flags_type flags_{0};
+    std::ostream* ostream_{};
+    double vertex_x_{0}, vertex_y_{0}, vertex_z_{0};
+    std::size_t face_vertex_indices_element_index_{0}, face_vertex_indices_first_element_{0}, face_vertex_indices_previous_element_{0};
 };
 
 ply_to_obj_converter::ply_to_obj_converter (flags_type flags)
-  : flags_ (flags), ostream_ (), 
-  vertex_x_ (0), vertex_y_ (0), vertex_z_ (0),
-  face_vertex_indices_element_index_ (), 
-  face_vertex_indices_first_element_ (),
-  face_vertex_indices_previous_element_ ()
+  : flags_ (flags)
 {
 }
 

--- a/tools/ply2ply.cpp
+++ b/tools/ply2ply.cpp
@@ -65,10 +65,8 @@ class ply_to_ply_converter
       binary_big_endian_format,
       binary_little_endian_format
     };
-  
-    ply_to_ply_converter(format_type format) : 
-      format_(format), input_format_(), output_format_(), 
-      bol_ (), ostream_ () {}
+
+    ply_to_ply_converter(format_type format) : format_(format) {}
 
     bool 
     convert (const std::string &filename, std::istream& istream, std::ostream& ostream);
@@ -128,9 +126,9 @@ class ply_to_ply_converter
     end_header_callback();
 
     format_type format_;
-    pcl::io::ply::format_type input_format_, output_format_;
-    bool bol_;
-    std::ostream* ostream_;
+    pcl::io::ply::format_type input_format_{}, output_format_{};
+    bool bol_{};
+    std::ostream* ostream_{};
 };
 
 void

--- a/tools/ply2raw.cpp
+++ b/tools/ply2raw.cpp
@@ -61,14 +61,9 @@
 class ply_to_raw_converter
 {
   public:
-    ply_to_raw_converter () : 
-      ostream_ (), vertex_x_ (0), vertex_y_ (0), vertex_z_ (0), 
-      face_vertex_indices_element_index_ (),
-      face_vertex_indices_first_element_ (), 
-      face_vertex_indices_previous_element_ ()
-    {}
+  ply_to_raw_converter() {}
 
-    ply_to_raw_converter (const ply_to_raw_converter &f) :
+  ply_to_raw_converter (const ply_to_raw_converter &f) :
       ostream_ (), vertex_x_ (0), vertex_y_ (0), vertex_z_ (0), 
       face_vertex_indices_element_index_ (),
       face_vertex_indices_first_element_ (), 
@@ -144,10 +139,10 @@ class ply_to_raw_converter
     void
     face_end ();
 
-    std::ostream* ostream_;
-    pcl::io::ply::float32 vertex_x_, vertex_y_, vertex_z_;
-    pcl::io::ply::int32 face_vertex_indices_element_index_, face_vertex_indices_first_element_, face_vertex_indices_previous_element_;
-    std::vector<std::tuple<pcl::io::ply::float32, pcl::io::ply::float32, pcl::io::ply::float32> > vertices_;
+    std::ostream* ostream_{};
+    pcl::io::ply::float32 vertex_x_{0}, vertex_y_{0}, vertex_z_{0};
+    pcl::io::ply::int32 face_vertex_indices_element_index_{0}, face_vertex_indices_first_element_{0}, face_vertex_indices_previous_element_{0};
+    std::vector<std::tuple<pcl::io::ply::float32, pcl::io::ply::float32, pcl::io::ply::float32> > vertices_{};
 };
 
 void


### PR DESCRIPTION
Part G of the transition to add these checks to `clang-tidy`:

- [modernize-use-default-member-init](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-default-member-init.html)

- [modernize-use-bool-literals](https://clang.llvm.org/extra/clang-tidy/checks/modernize/use-bool-literals.html)