### PR TITLE
CI: update MacOS from 11 to 12

### DIFF
--- a/.ci/azure-pipelines/azure-pipelines.yaml
+++ b/.ci/azure-pipelines/azure-pipelines.yaml
@@ -73,9 +73,9 @@ stages:
           vmImage: '$(VMIMAGE)'
         strategy:
           matrix:
-            Big Sur 11:
-              VMIMAGE: 'macOS-11'
-              OSX_VERSION: '11'
+            Monterey 12:
+              VMIMAGE: 'macOS-12'
+              OSX_VERSION: '12'
             Ventura 13:
               VMIMAGE: 'macOS-13'
               OSX_VERSION: '13'

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Continuous integration
 [ci-ubuntu-23.04]: https://dev.azure.com/PointCloudLibrary/pcl/_apis/build/status/9?branchName=master&stageName=Build%20GCC&jobName=Ubuntu&configuration=Ubuntu%2023.04%20GCC&label=Ubuntu%2023.04%20GCC
 [ci-windows-x86]: https://dev.azure.com/PointCloudLibrary/pcl/_apis/build/status/9?branchName=master&stageName=Build%20MSVC&jobName=Windows%20Build&configuration=Windows%20Build%20x86&label=Windows%20VS2019%20x86
 [ci-windows-x64]: https://dev.azure.com/PointCloudLibrary/pcl/_apis/build/status/9?branchName=master&stageName=Build%20MSVC&jobName=Windows%20Build&configuration=Windows%20Build%20x64&label=Windows%20VS2019%20x64
-[ci-macos-11]: https://dev.azure.com/PointCloudLibrary/pcl/_apis/build/status/9?branchName=master&stageName=Build%20Clang&jobName=macOS&configuration=macOS%20Big%20Sur%2011&label=macOS%20Big%20Sur%2011
+[ci-macos-12]: https://dev.azure.com/PointCloudLibrary/pcl/_apis/build/status/9?branchName=master&stageName=Build%20Clang&jobName=macOS&configuration=macOS%20Monterey%2012&label=macOS%20Monterey%2012
 [ci-macos-13]: https://dev.azure.com/PointCloudLibrary/pcl/_apis/build/status/9?branchName=master&stageName=Build%20Clang&jobName=macOS&configuration=macOS%20Ventura%2013&label=macOS%20Ventura%2013
 [ci-docs]: https://dev.azure.com/PointCloudLibrary/pcl/_apis/build/status/Documentation?branchName=master
 [ci-latest-docs]: https://dev.azure.com/PointCloudLibrary/pcl/_build/latest?definitionId=14&branchName=master
@@ -35,7 +35,7 @@ Build Platform           | Status
 ------------------------ | ------------------------------------------------------------------------------------------------- |
 Ubuntu                   | [![Status][ci-ubuntu-20.04]][ci-latest-build] <br> [![Status][ci-ubuntu-22.04]][ci-latest-build] <br> [![Status][ci-ubuntu-23.04]][ci-latest-build] |
 Windows                  | [![Status][ci-windows-x86]][ci-latest-build]  <br> [![Status][ci-windows-x64]][ci-latest-build]   |
-macOS                    | [![Status][ci-macos-11]][ci-latest-build]  <br> [![Status][ci-macos-13]][ci-latest-build]   |
+macOS                    | [![Status][ci-macos-12]][ci-latest-build]  <br> [![Status][ci-macos-13]][ci-latest-build]   |
 Documentation            | [![Status][ci-docs]][ci-latest-docs] |
 
 Community


### PR DESCRIPTION
MacOS 11 is not supported any more, and one of the homebrew packages fails.