### PR TITLE
[surface] Speed up nurbs surface fitting

### DIFF
--- a/surface/src/on_nurbs/nurbs_solve_eigen.cpp
+++ b/surface/src/on_nurbs/nurbs_solve_eigen.cpp
@@ -136,7 +136,7 @@ NurbsSolve::solve ()
 {
   //  m_xeig = m_Keig.colPivHouseholderQr().solve(m_feig);
   //  Eigen::MatrixXd x = A.householderQr().solve(b);
-  m_xeig = m_Keig.jacobiSvd (Eigen::ComputeThinU | Eigen::ComputeThinV).solve (m_feig);
+  m_xeig = m_Keig.completeOrthogonalDecomposition().solve (m_feig);
 
   return true;
 }


### PR DESCRIPTION
Use Eigen function completeOrthogonalDecomposition instead of jacobiSvd to solve linear least squares systems to speed up nurbs surface fitting, see https://eigen.tuxfamily.org/dox/group__LeastSquares.html for details.

By the way, it may fix segmemt fault on some machines caused by jacobiSvd call.