### PR TITLE
Add readthedocs config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Ubuntu                   | [![Status][ci-ubuntu-20.04]][ci-latest-build] <br> [!
 Windows                  | [![Status][ci-windows-x86]][ci-latest-build]  <br> [![Status][ci-windows-x64]][ci-latest-build]   |
 macOS                    | [![Status][ci-macos-12]][ci-latest-build]  <br> [![Status][ci-macos-13]][ci-latest-build]   |
 Documentation            | [![Status][ci-docs]][ci-latest-docs] |
+Read the Docs            | [![Documentation Status](https://readthedocs.org/projects/pcl-tutorials/badge/?version=master)](https://pcl.readthedocs.io/projects/tutorials/en/master/?badge=master) |
 
 Community
 ---------

--- a/doc/advanced/.readthedocs.yaml
+++ b/doc/advanced/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: doc/advanced/content/conf.py
+
+formats:
+  - epub
+  - pdf
+
+python:
+  install:
+    - requirements: doc/requirements.txt

--- a/doc/tutorials/.readthedocs.yaml
+++ b/doc/tutorials/.readthedocs.yaml
@@ -1,0 +1,22 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  configuration: doc/tutorials/content/conf.py
+
+formats:
+  - epub
+  - pdf
+
+python:
+  install:
+    - requirements: doc/requirements.txt


### PR DESCRIPTION
Readthedocs now requires special config files: https://blog.readthedocs.com/migrate-configuration-v2/ The builds on rtd have been failing since end of September because we do not have them yet. Also add a rtd batch in our main README so we notice failing builds sooner.