### PR TITLE
Add sphinx-rtd-theme in doc requirements

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
 sphinx>=3
 sphinxcontrib-doxylink
+sphinx-rtd-theme


### PR DESCRIPTION
Currently, readthedocs is failing with the error:
no theme named 'sphinx_rtd_theme' found (missing theme.conf?)