### PR TITLE
Add instantiations for ICP and TransformationEstimationSVD

### DIFF
--- a/apps/3d_rec_framework/CMakeLists.txt
+++ b/apps/3d_rec_framework/CMakeLists.txt
@@ -90,7 +90,7 @@ PCL_ADD_INCLUDES("${SUBSUBSYS_NAME}" "${SUBSYS_NAME}/${SUBSUBSYS_NAME}/pipeline/
 
 set(LIB_NAME "pcl_${SUBSUBSYS_NAME}")
 PCL_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSUBSYS_NAME} SOURCES ${srcs} ${impl_incs_pipeline} ${incs_utils} ${incs_fw} ${incs_fw_global} ${incs_fw_local} ${incc_tools_framework} ${incs_pipelines} ${incs_pc_source})
-target_link_libraries("${LIB_NAME}" pcl_apps pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_surface pcl_features pcl_sample_consensus pcl_search)
+target_link_libraries("${LIB_NAME}" pcl_apps pcl_common pcl_io pcl_filters pcl_visualization pcl_segmentation pcl_surface pcl_features pcl_sample_consensus pcl_search pcl_registration)
 
 if(WITH_OPENNI)
   target_link_libraries("${LIB_NAME}" ${OPENNI_LIBRARIES})

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -92,7 +92,7 @@ if(VTK_FOUND)
       src/manual_registration/pcl_viewer_dialog.ui
       BUNDLE)
 
-    target_link_libraries(pcl_manual_registration pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface ${QTX}::Widgets)
+    target_link_libraries(pcl_manual_registration pcl_common pcl_io pcl_visualization pcl_segmentation pcl_features pcl_surface pcl_registration ${QTX}::Widgets)
 
     PCL_ADD_EXECUTABLE(pcl_pcd_video_player
       COMPONENT

--- a/registration/include/pcl/registration/icp.h
+++ b/registration/include/pcl/registration/icp.h
@@ -47,7 +47,8 @@
 #include <pcl/registration/transformation_estimation_point_to_plane_lls.h>
 #include <pcl/registration/transformation_estimation_svd.h>
 #include <pcl/registration/transformation_estimation_symmetric_point_to_plane_lls.h>
-#include <pcl/memory.h> // for dynamic_pointer_cast, pcl::make_shared, shared_ptr
+#include <pcl/memory.h>     // for dynamic_pointer_cast, pcl::make_shared, shared_ptr
+#include <pcl/pcl_config.h> // for PCL_NO_PRECOMPILE
 
 namespace pcl {
 /** \brief @b IterativeClosestPoint provides a base implementation of the Iterative
@@ -447,3 +448,9 @@ protected:
 } // namespace pcl
 
 #include <pcl/registration/impl/icp.hpp>
+
+#if !defined(PCL_NO_PRECOMPILE) && !defined(PCL_REGISTRATION_ICP_CPP_)
+extern template class pcl::IterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>;
+extern template class pcl::IterativeClosestPoint<pcl::PointXYZI, pcl::PointXYZI>;
+extern template class pcl::IterativeClosestPoint<pcl::PointXYZRGB, pcl::PointXYZRGB>;
+#endif // PCL_NO_PRECOMPILE

--- a/registration/include/pcl/registration/transformation_estimation_svd.h
+++ b/registration/include/pcl/registration/transformation_estimation_svd.h
@@ -42,6 +42,7 @@
 
 #include <pcl/registration/transformation_estimation.h>
 #include <pcl/cloud_iterator.h>
+#include <pcl/pcl_config.h> // for PCL_NO_PRECOMPILE
 
 namespace pcl {
 namespace registration {
@@ -154,3 +155,13 @@ protected:
 } // namespace pcl
 
 #include <pcl/registration/impl/transformation_estimation_svd.hpp>
+
+#if !defined(PCL_NO_PRECOMPILE) &&                                                     \
+    !defined(PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_SVD_CPP_)
+extern template class pcl::registration::TransformationEstimationSVD<pcl::PointXYZ,
+                                                                     pcl::PointXYZ>;
+extern template class pcl::registration::TransformationEstimationSVD<pcl::PointXYZI,
+                                                                     pcl::PointXYZI>;
+extern template class pcl::registration::TransformationEstimationSVD<pcl::PointXYZRGB,
+                                                                     pcl::PointXYZRGB>;
+#endif // PCL_NO_PRECOMPILE

--- a/registration/src/icp.cpp
+++ b/registration/src/icp.cpp
@@ -37,4 +37,15 @@
  *
  */
 
+#define PCL_REGISTRATION_ICP_CPP_
 #include <pcl/registration/icp.h>
+#include <pcl/pcl_config.h> // for PCL_NO_PRECOMPILE
+
+#ifndef PCL_NO_PRECOMPILE
+#include <pcl/pcl_exports.h> // for PCL_EXPORTS
+#include <pcl/point_types.h>
+template class PCL_EXPORTS pcl::IterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ>;
+template class PCL_EXPORTS pcl::IterativeClosestPoint<pcl::PointXYZI, pcl::PointXYZI>;
+template class PCL_EXPORTS
+    pcl::IterativeClosestPoint<pcl::PointXYZRGB, pcl::PointXYZRGB>;
+#endif // PCL_NO_PRECOMPILE

--- a/registration/src/transformation_estimation_svd.cpp
+++ b/registration/src/transformation_estimation_svd.cpp
@@ -36,4 +36,17 @@
  *
  */
 
+#define PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_SVD_CPP_
 #include <pcl/registration/transformation_estimation_svd.h>
+#include <pcl/pcl_config.h> // for PCL_NO_PRECOMPILE
+
+#ifndef PCL_NO_PRECOMPILE
+#include <pcl/pcl_exports.h> // for PCL_EXPORTS
+#include <pcl/point_types.h>
+template class PCL_EXPORTS
+    pcl::registration::TransformationEstimationSVD<pcl::PointXYZ, pcl::PointXYZ>;
+template class PCL_EXPORTS
+    pcl::registration::TransformationEstimationSVD<pcl::PointXYZI, pcl::PointXYZI>;
+template class PCL_EXPORTS
+    pcl::registration::TransformationEstimationSVD<pcl::PointXYZRGB, pcl::PointXYZRGB>;
+#endif // PCL_NO_PRECOMPILE


### PR DESCRIPTION
Add explicit instantiations in the .cpp files, for very commonly used point types (while building pcl_registration).
When using ICP or TransformationEstimationSVD in other files, the `extern template class ...` statements in the .h files tell the compiler to not instantiate the templates, and to use the previous instantiations instead (from pcl_registration).
This decreases the compilation time for user code, and also for e.g. pcl tools and pcl apps (the pcl_icp tool for example compiles in 10s now vs 13s before).
The compilation time of PCL as a whole decreases slightly (1.5 percent less in one configuration with clang).
Supersedes and closes https://github.com/PointCloudLibrary/pcl/pull/5683
@themightyoarfish FYI. Feel free to test this.
So far, PCL offers explicit template instantiations for other classes in a different way: by hiding the complete template definition (which is in the .hpp files) when a user includes a .h file. Since the complete definition is not available, the compiler uses the existing instantiation from the PCL library (from the .cpp file).
This approach would not work for ICP and TransformationEstimationSVD because they both have three template parameters, and we would have to instantiate all possible parameter combinations in the .cpp file if we wanted to hide the template definition from the user. Otherwise we would risk that a user gets link errors when they use a template parameter combination not covered in the .cpp file.
By using the approach with `extern template class ...` in the .h files, the compiler still has the full template definition available (from the .hpp files, so it can instantiate it for any template parameter combination), but is told _not_ to instantiate it for the three combinations that PCL offers already.