### PR TITLE
Remove default(none) clause in some OpenMP for-loops

### DIFF
--- a/.ci/azure-pipelines/ubuntu-variety.yaml
+++ b/.ci/azure-pipelines/ubuntu-variety.yaml
@@ -32,7 +32,7 @@ jobs:
       POSSIBLE_VTK_VERSION=("9") \
       POSSIBLE_CMAKE_CXX_STANDARD=("14" "17" "20") \
       POSSIBLE_CMAKE_BUILD_TYPE=("None" "Debug" "Release" "RelWithDebInfo" "MinSizeRel") \
-      POSSIBLE_COMPILER_PACKAGE=("g++" "g++-10" "g++-11" "g++-12" "g++-13" "clang" "clang-13" "clang-14" "clang-15" "clang-16" "clang-17") \
+      POSSIBLE_COMPILER_PACKAGE=("g++" "g++-10" "g++-11" "g++-12" "g++-13" "clang libomp-dev" "clang-13 libomp-13-dev" "clang-14 libomp-14-dev" "clang-15 libomp-15-dev" "clang-16 libomp-16-dev" "clang-17 libomp-17-dev") \
       POSSIBLE_CMAKE_C_COMPILER=("gcc" "gcc-10" "gcc-11" "gcc-12" "gcc-13" "clang" "clang-13" "clang-14" "clang-15" "clang-16" "clang-17") \
       POSSIBLE_CMAKE_CXX_COMPILER=("g++" "g++-10" "g++-11" "g++-12" "g++-13" "clang++" "clang++-13" "clang++-14" "clang++-15" "clang++-16" "clang++-17") \
       CHOSEN_COMPILER=$[RANDOM%${#POSSIBLE_COMPILER_PACKAGE[@]}] \

--- a/.dev/docker/env/Dockerfile
+++ b/.dev/docker/env/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update \
       libflann-dev \
       libglew-dev \
       libgtest-dev \
+      libomp-dev \
       libopenni-dev \
       libopenni2-dev \
       libpcap-dev \

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_crh.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_crh.hpp
@@ -297,7 +297,6 @@ pcl::rec_3d_framework::GlobalNNCRHRecognizer<Distance, PointInT, FeatureT>::reco
 
       // clang-format off
 #pragma omp parallel for \
-  default(none) \
   shared(VOXEL_SIZE_ICP_, cloud_voxelized_icp) \
   num_threads(omp_get_num_procs())
       // clang-format on

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_cvfh.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/global_nn_recognizer_cvfh.hpp
@@ -456,7 +456,6 @@ pcl::rec_3d_framework::GlobalNNCVFHRecognizer<Distance, PointInT, FeatureT>::rec
 
       // clang-format off
 #pragma omp parallel for \
-  default(none) \
   shared(cloud_voxelized_icp, VOXEL_SIZE_ICP_) \
   num_threads(omp_get_num_procs())
       // clang-format on

--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pipeline/impl/local_recognizer.hpp
@@ -371,7 +371,6 @@ pcl::rec_3d_framework::LocalRecognitionPipeline<Distance, PointInT, FeatureT>::
 
     // clang-format off
 #pragma omp parallel for \
-  default(none) \
   shared(cloud_voxelized_icp) \
   schedule(dynamic,1) \
   num_threads(omp_get_num_procs())

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -865,7 +865,6 @@ RangeImage::getOverlap (const RangeImage& other_range_image, const Eigen::Affine
   float max_distance_squared = max_distance*max_distance;
   
 #pragma omp parallel for \
-  default(none) \
   shared(max_distance_squared, other_range_image, pixel_step, relative_transformation, search_radius) \
   schedule(dynamic, 1) \
   reduction(+ : valid_points_counter) \

--- a/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
+++ b/keypoints/include/pcl/keypoints/impl/harris_3d.hpp
@@ -506,7 +506,6 @@ pcl::HarrisKeypoint3D<PointInT, PointOutT, NormalT>::refineCorners (PointCloudOu
   Eigen::Vector3f NNTp;
   constexpr unsigned max_iterations = 10;
 #pragma omp parallel for \
-  default(none) \
   shared(corners) \
   firstprivate(nnT, NNT, NNTp) \
   num_threads(threads_)

--- a/keypoints/src/narf_keypoint.cpp
+++ b/keypoints/src/narf_keypoint.cpp
@@ -478,7 +478,6 @@ NarfKeypoint::calculateSparseInterestImage ()
   
   //double interest_value_calculation_start_time = getTime ();
 #pragma omp parallel for \
-  default(none) \
   shared(array_size, border_descriptions, increased_radius_squared, radius_reciprocal, radius_overhead_squared, range_image, search_radius, \
          surface_change_directions, surface_change_scores) \
   num_threads(parameters_.max_no_of_threads) \

--- a/tools/fast_bilateral_filter.cpp
+++ b/tools/fast_bilateral_filter.cpp
@@ -114,7 +114,6 @@ int
 batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir, float sigma_s, float sigma_r)
 {
 #pragma omp parallel for \
-  default(none) \
   shared(output_dir, pcd_files, sigma_r, sigma_s)
   // Disable lint since this 'for' is part of the pragma
   // NOLINTNEXTLINE(modernize-loop-convert)

--- a/tools/normal_estimation.cpp
+++ b/tools/normal_estimation.cpp
@@ -133,7 +133,6 @@ int
 batchProcess (const std::vector<std::string> &pcd_files, std::string &output_dir, int k, double radius)
 {
 #pragma omp parallel for \
-  default(none) \
   shared(k, output_dir, pcd_files, radius)
   // Disable lint since this 'for' is part of the pragma
   // NOLINTNEXTLINE(modernize-loop-convert)


### PR DESCRIPTION
clang 17 complains that in these loops, some variables do not have an explicitly defined data sharing attribute, e.g. `Eigen::Dynamic` (which is a `const int`).
Explicitly defining it as shared would be weird since the use of `Eigen::Dynamic` is not obvious in those loops, and would also likely lead to problems with other compilers because const variables are implicitly shared (at least in OpenMP versions < 4.0), and defining them explicitly as shared leads to compiler errors (see also http://jakascorner.com/blog/2016/07/omp-default-none-and-const.html).
Removing default(none) solves the problem. Generally, the use of default(none) is recommended while writing the code because it forces the programmer to think about whether each variable should be shared or private, but since the code is already finished, removing default(none) should have no downsides.

Also: install libomp-dev to make OpenMP available for Clang on CI