### PR TITLE
Part A of clang-tidy bugprone-implicit-widening-of-multiplication-result

### DIFF
--- a/2d/include/pcl/2d/impl/edge.hpp
+++ b/2d/include/pcl/2d/impl/edge.hpp
@@ -263,7 +263,8 @@ Edge<PointInT, PointOutT>::suppressNonMaxima(
 
   maxima.height = height;
   maxima.width = width;
-  maxima.resize(static_cast<std::size_t>(height * width));
+  std::size_t resize = static_cast<std::size_t>(height) * width;
+  maxima.resize(resize);
 
   for (auto& point : maxima)
     point.intensity = 0.0f;

--- a/2d/include/pcl/2d/impl/edge.hpp
+++ b/2d/include/pcl/2d/impl/edge.hpp
@@ -41,6 +41,8 @@
 #include <pcl/2d/edge.h>
 #include <pcl/common/angles.h> // for rad2deg
 
+#include <cstddef>
+
 namespace pcl {
 
 template <typename PointInT, typename PointOutT>
@@ -261,7 +263,7 @@ Edge<PointInT, PointOutT>::suppressNonMaxima(
 
   maxima.height = height;
   maxima.width = width;
-  maxima.resize(height * width);
+  maxima.resize(static_cast<std::size_t>(height * width));
 
   for (auto& point : maxima)
     point.intensity = 0.0f;

--- a/common/include/pcl/common/impl/generate.hpp
+++ b/common/include/pcl/common/impl/generate.hpp
@@ -280,7 +280,8 @@ CloudGenerator<pcl::PointXY, GeneratorT>::fill (int width, int height, pcl::Poin
 
   cloud.width = width;
   cloud.height = height;
-  cloud.resize (static_cast<std::size_t>(cloud.width * cloud.height));
+  std::size_t resize = static_cast<std::size_t>(cloud.width) * cloud.height;
+  cloud.resize (resize);
   cloud.is_dense = true;
 
   for (auto &point : cloud)

--- a/common/include/pcl/common/impl/generate.hpp
+++ b/common/include/pcl/common/impl/generate.hpp
@@ -42,6 +42,8 @@
 #include <pcl/common/generate.h>
 #include <pcl/console/print.h>
 
+#include <cstddef>
+
 
 namespace pcl
 {
@@ -278,7 +280,7 @@ CloudGenerator<pcl::PointXY, GeneratorT>::fill (int width, int height, pcl::Poin
 
   cloud.width = width;
   cloud.height = height;
-  cloud.resize (cloud.width * cloud.height);
+  cloud.resize (static_cast<std::size_t>(cloud.width * cloud.height));
   cloud.is_dense = true;
 
   for (auto &point : cloud)

--- a/common/include/pcl/range_image/impl/range_image.hpp
+++ b/common/include/pcl/range_image/impl/range_image.hpp
@@ -196,7 +196,8 @@ RangeImage::createFromPointCloudWithKnownSize (const PointCloudType& point_cloud
 
   using SizeType = decltype(points)::size_type;
   points.clear ();
-  points.resize (static_cast<SizeType>(width*height), unobserved_point);
+  SizeType resize = static_cast<SizeType>(width) * height;
+  points.resize (resize, unobserved_point);
   
   int top=height, right=-1, bottom=-1, left=width;
   doZBuffer (point_cloud, noise_level, min_range, top, right, bottom, left);

--- a/common/include/pcl/range_image/impl/range_image.hpp
+++ b/common/include/pcl/range_image/impl/range_image.hpp
@@ -38,12 +38,13 @@
 
 #pragma once
 
-#include <pcl/range_image/range_image.h>
-
-#include <pcl/pcl_macros.h>
 #include <pcl/common/distances.h>
 #include <pcl/common/point_tests.h> // for pcl::isFinite
 #include <pcl/common/vector_average.h> // for VectorAverage3f
+#include <pcl/range_image/range_image.h>
+#include <pcl/pcl_macros.h>
+
+#include <cstddef>
 #include <vector>
 
 namespace pcl
@@ -193,8 +194,9 @@ RangeImage::createFromPointCloudWithKnownSize (const PointCloudType& point_cloud
   image_offset_x_ = (std::max) (0, center_pixel_x-pixel_radius_x);
   image_offset_y_ = (std::max) (0, center_pixel_y-pixel_radius_y);
 
+  using SizeType = decltype(points)::size_type;
   points.clear ();
-  points.resize (width*height, unobserved_point);
+  points.resize (static_cast<SizeType>(width*height), unobserved_point);
   
   int top=height, right=-1, bottom=-1, left=width;
   doZBuffer (point_cloud, noise_level, min_range, top, right, bottom, left);

--- a/common/src/PCLPointCloud2.cpp
+++ b/common/src/PCLPointCloud2.cpp
@@ -38,12 +38,13 @@
  *
  */
 
-#include <vector>
-
 #include <pcl/common/io.h>
-#include <pcl/pcl_macros.h>
 #include <pcl/exceptions.h>
+#include <pcl/pcl_macros.h>
 #include <pcl/PCLPointCloud2.h>
+
+#include <cstddef>
+#include <vector>
 
 bool
 pcl::PCLPointCloud2::concatenate (pcl::PCLPointCloud2 &cloud1, const pcl::PCLPointCloud2 &cloud2)
@@ -154,9 +155,9 @@ pcl::PCLPointCloud2::concatenate (pcl::PCLPointCloud2 &cloud1, const pcl::PCLPoi
       const auto& size = field_data.size;
       // Leave the data for the skip fields untouched in cloud1
       // Copy only the required data from cloud2 to the correct location for cloud1
-      memcpy (reinterpret_cast<char*> (&cloud1.data[data1_size + cp * cloud1.point_step + cloud1.fields[i].offset]),
+      memcpy (reinterpret_cast<char*> (&cloud1.data[data1_size + static_cast<unsigned long>(cp * cloud1.point_step) + cloud1.fields[i].offset]),
               reinterpret_cast<const char*> (&cloud2.data[cp * cloud2.point_step + cloud2.fields[j].offset]),
-              cloud2.fields[j].count * size);
+              static_cast<size_t>(cloud2.fields[j].count * size));
     }
   }
   return (true);

--- a/common/src/PCLPointCloud2.cpp
+++ b/common/src/PCLPointCloud2.cpp
@@ -155,9 +155,9 @@ pcl::PCLPointCloud2::concatenate (pcl::PCLPointCloud2 &cloud1, const pcl::PCLPoi
       const auto& size = field_data.size;
       // Leave the data for the skip fields untouched in cloud1
       // Copy only the required data from cloud2 to the correct location for cloud1
-      memcpy (reinterpret_cast<char*> (&cloud1.data[data1_size + static_cast<unsigned long>(cp * cloud1.point_step) + cloud1.fields[i].offset]),
+      memcpy (reinterpret_cast<char*> (&cloud1.data[data1_size + (static_cast<size_t>(cp) * cloud1.point_step) + cloud1.fields[i].offset]),
               reinterpret_cast<const char*> (&cloud2.data[cp * cloud2.point_step + cloud2.fields[j].offset]),
-              static_cast<size_t>(cloud2.fields[j].count * size));
+              (static_cast<size_t>(cloud2.fields[j].count) * size));
     }
   }
   return (true);

--- a/common/src/colors.cpp
+++ b/common/src/colors.cpp
@@ -35,14 +35,15 @@
  *
  */
 
-#include <pcl/point_types.h>
 #include <pcl/common/colors.h>
+#include <pcl/point_types.h>
 
-#include <cassert>
 #include <array>
+#include <cassert>
+#include <cstddef>
 
 /// Glasbey lookup table
-static constexpr std::array<unsigned char, 256 * 3> GLASBEY_LUT =
+static constexpr std::array<unsigned char, static_cast<std::size_t>(256 * 3)> GLASBEY_LUT =
 {
   77 , 175, 74 ,
   228, 26 , 28 ,
@@ -303,7 +304,7 @@ static constexpr std::array<unsigned char, 256 * 3> GLASBEY_LUT =
 };
 
 /// Viridis lookup table
-static constexpr std::array<unsigned char, 256 * 3> VIRIDIS_LUT =
+static constexpr std::array<unsigned char, static_cast<std::size_t>(256 * 3)> VIRIDIS_LUT =
 {
   68 , 1  , 84 ,
   68 , 2  , 85 ,
@@ -569,7 +570,7 @@ static constexpr std::size_t GLASBEY_LUT_SIZE = GLASBEY_LUT.size() / 3;
 /// Number of colors in Viridis lookup table
 static constexpr std::size_t VIRIDIS_LUT_SIZE = VIRIDIS_LUT.size() / 3;
 
-static constexpr std::array<const std::array<unsigned char, 256 * 3>*, 2> LUTS = { &GLASBEY_LUT, &VIRIDIS_LUT };
+static constexpr std::array<const std::array<unsigned char, static_cast<std::size_t>(256 * 3)>*, 2> LUTS = { &GLASBEY_LUT, &VIRIDIS_LUT };
 static constexpr std::array<std::size_t, 2> LUT_SIZES = { GLASBEY_LUT_SIZE, VIRIDIS_LUT_SIZE };
 
 template<typename pcl::ColorLUTName T> pcl::RGB

--- a/common/src/fft/kiss_fft.c
+++ b/common/src/fft/kiss_fft.c
@@ -14,6 +14,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 
 #include "pcl/common/fft/_kiss_fft_guts.h"
+#include <stddef.h>
 /* The guts header contains all the multiplication and addition macros that are defined for
  fixed or floating point complex numbers.  It also declares the kf_ internal functions.
  */
@@ -150,9 +151,9 @@ static void kf_bfly5(
 
     Fout0=Fout;
     Fout1=Fout0+m;
-    Fout2=Fout0+2*m;
-    Fout3=Fout0+3*m;
-    Fout4=Fout0+4*m;
+    Fout2=Fout0+(ptrdiff_t)(2*m);
+    Fout3=Fout0+(ptrdiff_t)(3*m);
+    Fout4=Fout0+(ptrdiff_t)(4*m);
 
     tw=st->twiddles;
     for (int u=0; u<m; ++u ) {
@@ -160,9 +161,9 @@ static void kf_bfly5(
         scratch[0] = *Fout0;
 
         C_MUL(scratch[1] ,*Fout1, tw[u*fstride]);
-        C_MUL(scratch[2] ,*Fout2, tw[2*u*fstride]);
-        C_MUL(scratch[3] ,*Fout3, tw[3*u*fstride]);
-        C_MUL(scratch[4] ,*Fout4, tw[4*u*fstride]);
+        C_MUL(scratch[2] ,*Fout2, tw[(unsigned long)(2*u)*fstride]);
+        C_MUL(scratch[3] ,*Fout3, tw[(unsigned long)(3*u)*fstride]);
+        C_MUL(scratch[4] ,*Fout4, tw[(unsigned long)(4*u)*fstride]);
 
         C_ADD( scratch[7],scratch[1],scratch[4]);
         C_SUB( scratch[10],scratch[1],scratch[4]);
@@ -245,7 +246,7 @@ void kf_work(
     kiss_fft_cpx * Fout_beg=Fout;
     const int p=*factors++; /* the radix  */
     const int m=*factors++; /* stage's fft length/p */
-    const kiss_fft_cpx * Fout_end = Fout + p*m;
+    const kiss_fft_cpx * Fout_end = Fout + (ptrdiff_t)(p*m);
 
 #ifdef _OPENMP
     // use openmp extensions at the 

--- a/common/src/fft/kiss_fft.c
+++ b/common/src/fft/kiss_fft.c
@@ -151,9 +151,9 @@ static void kf_bfly5(
 
     Fout0=Fout;
     Fout1=Fout0+m;
-    Fout2=Fout0+(ptrdiff_t)(2*m);
-    Fout3=Fout0+(ptrdiff_t)(3*m);
-    Fout4=Fout0+(ptrdiff_t)(4*m);
+    Fout2=Fout0+2*(ptrdiff_t)(2);
+    Fout3=Fout0+3*(ptrdiff_t)(3);
+    Fout4=Fout0+4*(ptrdiff_t)(4);
 
     tw=st->twiddles;
     for (int u=0; u<m; ++u ) {
@@ -161,9 +161,9 @@ static void kf_bfly5(
         scratch[0] = *Fout0;
 
         C_MUL(scratch[1] ,*Fout1, tw[u*fstride]);
-        C_MUL(scratch[2] ,*Fout2, tw[(unsigned long)(2*u)*fstride]);
-        C_MUL(scratch[3] ,*Fout3, tw[(unsigned long)(3*u)*fstride]);
-        C_MUL(scratch[4] ,*Fout4, tw[(unsigned long)(4*u)*fstride]);
+        C_MUL(scratch[2] ,*Fout2, tw[2*(unsigned long)(u)*fstride]);
+        C_MUL(scratch[3] ,*Fout3, tw[3*(unsigned long)(u)*fstride]);
+        C_MUL(scratch[4] ,*Fout4, tw[4*(unsigned long)(u)*fstride]);
 
         C_ADD( scratch[7],scratch[1],scratch[4]);
         C_SUB( scratch[10],scratch[1],scratch[4]);
@@ -246,7 +246,7 @@ void kf_work(
     kiss_fft_cpx * Fout_beg=Fout;
     const int p=*factors++; /* the radix  */
     const int m=*factors++; /* stage's fft length/p */
-    const kiss_fft_cpx * Fout_end = Fout + (ptrdiff_t)(p*m);
+    const kiss_fft_cpx * Fout_end = Fout + (ptrdiff_t)(p)*m;
 
 #ifdef _OPENMP
     // use openmp extensions at the 

--- a/common/src/gaussian.cpp
+++ b/common/src/gaussian.cpp
@@ -36,7 +36,9 @@
  */
 
 #include <pcl/common/gaussian.h>
+
 #include <cassert>
+#include <cstddef>
 
 void 
 pcl::GaussianKernel::compute (float sigma, 
@@ -147,7 +149,7 @@ pcl::GaussianKernel::convolveRows (const pcl::PointCloud<float>& input,
     {
       output.width = input.width;
       output.height = input.height;
-      output.resize (input.height * input.width);
+      output.resize (static_cast<std::size_t>(input.height * input.width));
     }
     unaliased_input = &input;
   }
@@ -191,7 +193,7 @@ pcl::GaussianKernel::convolveCols (const pcl::PointCloud<float>& input,
     {
       output.width = input.width;
       output.height = input.height;
-      output.resize (input.height * input.width);
+      output.resize (static_cast<std::size_t>(input.height * input.width));
     }
     unaliased_input = &input;
   }

--- a/common/src/gaussian.cpp
+++ b/common/src/gaussian.cpp
@@ -149,7 +149,8 @@ pcl::GaussianKernel::convolveRows (const pcl::PointCloud<float>& input,
     {
       output.width = input.width;
       output.height = input.height;
-      output.resize (static_cast<std::size_t>(input.height * input.width));
+      std::size_t resize = static_cast<std::size_t>(input.height) * input.width;
+      output.resize (resize);
     }
     unaliased_input = &input;
   }
@@ -193,7 +194,8 @@ pcl::GaussianKernel::convolveCols (const pcl::PointCloud<float>& input,
     {
       output.width = input.width;
       output.height = input.height;
-      output.resize (static_cast<std::size_t>(input.height * input.width));
+      std::size_t resize = static_cast<std::size_t>(input.height) * input.width;
+      output.resize (resize);
     }
     unaliased_input = &input;
   }

--- a/common/src/io.cpp
+++ b/common/src/io.cpp
@@ -232,7 +232,7 @@ pcl::getPointCloudAsEigen (const pcl::PCLPointCloud2 &in, Eigen::MatrixXf &out)
     return (false);
   }
 
-  std::size_t npts = static_cast<std::size_t>(in.width * in.height);
+  auto npts = static_cast<std::size_t>(in.width * in.height);
   out = Eigen::MatrixXf::Ones (4, npts);
 
   Eigen::Array4i xyz_offset (in.fields[x_idx].offset, in.fields[y_idx].offset, in.fields[z_idx].offset, 0);

--- a/common/src/io.cpp
+++ b/common/src/io.cpp
@@ -40,6 +40,9 @@
 
 #include <pcl/common/io.h>
 
+#include <cstddef>
+#include <type_traits>
+
 //////////////////////////////////////////////////////////////////////////
 void
 getFieldsSizes (const std::vector<pcl::PCLPointField> &fields,
@@ -178,7 +181,7 @@ pcl::concatenateFields (const pcl::PCLPointCloud2 &cloud1,
   int point_offset = 0;
   for (uindex_t cp = 0; cp < cloud_out.width * cloud_out.height; ++cp)
   {
-    memcpy (&cloud_out.data[point_offset], &cloud2.data[cp * cloud2.point_step], cloud2.point_step);
+    memcpy (&cloud_out.data[point_offset], &cloud2.data[static_cast<uindex_t>(cp * cloud2.point_step)], cloud2.point_step);
     int field_offset = cloud2.point_step;
 
     // Copy each individual point, we have to do this on a per-field basis
@@ -229,7 +232,7 @@ pcl::getPointCloudAsEigen (const pcl::PCLPointCloud2 &in, Eigen::MatrixXf &out)
     return (false);
   }
 
-  std::size_t npts = in.width * in.height;
+  std::size_t npts = static_cast<std::size_t>(in.width * in.height);
   out = Eigen::MatrixXf::Ones (4, npts);
 
   Eigen::Array4i xyz_offset (in.fields[x_idx].offset, in.fields[y_idx].offset, in.fields[z_idx].offset, 0);
@@ -311,11 +314,11 @@ pcl::copyPointCloud (
   cloud_out.row_step     = cloud_in.point_step * static_cast<std::uint32_t> (indices.size ());
   cloud_out.is_dense     = cloud_in.is_dense;
 
-  cloud_out.data.resize (cloud_out.width * cloud_out.height * cloud_out.point_step);
+  cloud_out.data.resize (static_cast<uindex_t>(cloud_out.width * cloud_out.height * cloud_out.point_step));
 
   // Iterate over each point
   for (std::size_t i = 0; i < indices.size (); ++i)
-    memcpy (&cloud_out.data[i * cloud_out.point_step], &cloud_in.data[indices[i] * cloud_in.point_step], cloud_in.point_step);
+    memcpy (&cloud_out.data[i * cloud_out.point_step], &cloud_in.data[static_cast<uindex_t>(indices[i] * cloud_in.point_step)], cloud_in.point_step);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -334,11 +337,11 @@ pcl::copyPointCloud (
   cloud_out.row_step     = cloud_in.point_step * static_cast<std::uint32_t> (indices.size ());
   cloud_out.is_dense     = cloud_in.is_dense;
 
-  cloud_out.data.resize (cloud_out.width * cloud_out.height * cloud_out.point_step);
+  cloud_out.data.resize (static_cast<uindex_t>(cloud_out.width * cloud_out.height * cloud_out.point_step));
 
   // Iterate over each point
   for (std::size_t i = 0; i < indices.size (); ++i)
-    memcpy (&cloud_out.data[i * cloud_out.point_step], &cloud_in.data[indices[i] * cloud_in.point_step], cloud_in.point_step);
+    memcpy (&cloud_out.data[i * cloud_out.point_step], &cloud_in.data[static_cast<uindex_t>(indices[i] * cloud_in.point_step)], cloud_in.point_step);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/common/src/pcl_base.cpp
+++ b/common/src/pcl_base.cpp
@@ -36,11 +36,12 @@
  *
  */
 
-#include <algorithm>
-#include <numeric>
-
-#include <pcl/impl/pcl_base.hpp>
 #include <pcl/common/io.h>  // for getFieldSize
+#include <pcl/impl/pcl_base.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <numeric>
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 pcl::PCLBase<pcl::PCLPointCloud2>::PCLBase ()
@@ -114,12 +115,12 @@ pcl::PCLBase<pcl::PCLPointCloud2>::initCompute ()
   }
 
   // If we have a set of fake indices, but they do not match the number of points in the cloud, update them
-  if (fake_indices_ && indices_->size () != (input_->width * input_->height))
+  if (fake_indices_ && indices_->size () != (static_cast<unsigned long>(input_->width * input_->height)))
   {
     const auto indices_size = indices_->size ();
     try
     {
-      indices_->resize (input_->width * input_->height);
+      indices_->resize (static_cast<uindex_t>(input_->width * input_->height));
     }
     catch (const std::bad_alloc&)
     {
@@ -127,7 +128,9 @@ pcl::PCLBase<pcl::PCLPointCloud2>::initCompute ()
       return (false);
     }
     if (indices_size < indices_->size ())
-      std::iota(indices_->begin () + indices_size, indices_->end (), indices_size);
+    {
+      std::iota(indices_->begin() + indices_size, indices_->end(), indices_size);
+    }
   }
 
   return (true);

--- a/common/src/pcl_base.cpp
+++ b/common/src/pcl_base.cpp
@@ -115,12 +115,14 @@ pcl::PCLBase<pcl::PCLPointCloud2>::initCompute ()
   }
 
   // If we have a set of fake indices, but they do not match the number of points in the cloud, update them
-  if (fake_indices_ && indices_->size () != (static_cast<unsigned long>(input_->width * input_->height)))
+  std::size_t area = std::size_t(input_->width) * input_->height;
+  if (fake_indices_ && indices_->size () != area)
   {
     const auto indices_size = indices_->size ();
     try
     {
-      indices_->resize (static_cast<uindex_t>(input_->width * input_->height));
+      std::size_t resize = static_cast<std::size_t>(input_->width) * input_->height;
+      indices_->resize (resize);
     }
     catch (const std::bad_alloc&)
     {

--- a/common/src/pcl_base.cpp
+++ b/common/src/pcl_base.cpp
@@ -115,7 +115,7 @@ pcl::PCLBase<pcl::PCLPointCloud2>::initCompute ()
   }
 
   // If we have a set of fake indices, but they do not match the number of points in the cloud, update them
-  std::size_t area = std::size_t(input_->width) * input_->height;
+  std::size_t area = static_cast<std::size_t>(input_->width) * input_->height;
   if (fake_indices_ && indices_->size () != area)
   {
     const auto indices_size = indices_->size ();

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -240,7 +240,8 @@ RangeImage::cropImage (int borderSize, int top, int right, int bottom, int left)
   image_offset_x_ = left+oldRangeImage.image_offset_x_;
   image_offset_y_ = top+oldRangeImage.image_offset_y_;
   using SizeType = decltype(points)::size_type;
-  points.resize (static_cast<SizeType>(width*height));
+  SizeType resize = static_cast<SizeType>(width) * height;
+  points.resize (resize);
   
   //std::cout << oldRangeImage.width<<"x"<<oldRangeImage.height<<" -> "<<width<<"x"<<height<<"\n";
   
@@ -291,9 +292,10 @@ RangeImage::getRangesArray () const
 void 
 RangeImage::getIntegralImage (float*& integral_image, int*& valid_points_num_image) const
 {
-  integral_image = new float[static_cast<unsigned long>(width*height)];
+  std::size_t resize = static_cast<std::size_t>(width) * height;
+  integral_image = new float[resize];
   float* integral_image_ptr = integral_image;
-  valid_points_num_image = new int[static_cast<unsigned long>(width*height)];
+  valid_points_num_image = new int[resize];
   int* valid_points_num_image_ptr = valid_points_num_image;
   for (int y = 0; y < static_cast<int> (height); ++y)
   {
@@ -352,7 +354,8 @@ RangeImage::getHalfImage (RangeImage& half_image) const
   half_image.height = height/2;
   half_image.is_dense = is_dense;
   half_image.clear ();
-  half_image.resize (static_cast<std::size_t>(half_image.width*half_image.height));
+  std::size_t resize = static_cast<std::size_t>(half_image.width) * half_image.height;
+  half_image.resize (resize);
   
   int src_start_x = 2*half_image.image_offset_x_ - image_offset_x_,
       src_start_y = 2*half_image.image_offset_y_ - image_offset_y_;
@@ -396,7 +399,8 @@ RangeImage::getSubImage (int sub_image_image_offset_x, int sub_image_image_offse
   sub_image.height = sub_image_height;
   sub_image.is_dense = is_dense;
   sub_image.clear ();
-  sub_image.resize (static_cast<std::size_t>(sub_image.width*sub_image.height));
+  std::size_t resize = static_cast<std::size_t>(sub_image.width) * sub_image.height;
+  sub_image.resize (resize);
   
   int src_start_x = combine_pixels*sub_image.image_offset_x_ - image_offset_x_,
       src_start_y = combine_pixels*sub_image.image_offset_y_ - image_offset_y_;

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -34,12 +34,13 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <cmath>
-#include <pcl/PCLPointCloud2.h> // for PCLPointCloud2
 #include <pcl/common/time.h> // for MEASURE_FUNCTION_TIME
 #include <pcl/range_image/range_image.h>
+#include <pcl/PCLPointCloud2.h> // for PCLPointCloud2
 
 #include <algorithm>
+#include <cmath>
+#include <cstddef>
 
 namespace pcl 
 {
@@ -238,7 +239,8 @@ RangeImage::cropImage (int borderSize, int top, int right, int bottom, int left)
   width = right-left+1; height = bottom-top+1;
   image_offset_x_ = left+oldRangeImage.image_offset_x_;
   image_offset_y_ = top+oldRangeImage.image_offset_y_;
-  points.resize (width*height);
+  using SizeType = decltype(points)::size_type;
+  points.resize (static_cast<SizeType>(width*height));
   
   //std::cout << oldRangeImage.width<<"x"<<oldRangeImage.height<<" -> "<<width<<"x"<<height<<"\n";
   
@@ -289,9 +291,9 @@ RangeImage::getRangesArray () const
 void 
 RangeImage::getIntegralImage (float*& integral_image, int*& valid_points_num_image) const
 {
-  integral_image = new float[width*height];
+  integral_image = new float[static_cast<unsigned long>(width*height)];
   float* integral_image_ptr = integral_image;
-  valid_points_num_image = new int[width*height];
+  valid_points_num_image = new int[static_cast<unsigned long>(width*height)];
   int* valid_points_num_image_ptr = valid_points_num_image;
   for (int y = 0; y < static_cast<int> (height); ++y)
   {
@@ -350,7 +352,7 @@ RangeImage::getHalfImage (RangeImage& half_image) const
   half_image.height = height/2;
   half_image.is_dense = is_dense;
   half_image.clear ();
-  half_image.resize (half_image.width*half_image.height);
+  half_image.resize (static_cast<std::size_t>(half_image.width*half_image.height));
   
   int src_start_x = 2*half_image.image_offset_x_ - image_offset_x_,
       src_start_y = 2*half_image.image_offset_y_ - image_offset_y_;
@@ -394,7 +396,7 @@ RangeImage::getSubImage (int sub_image_image_offset_x, int sub_image_image_offse
   sub_image.height = sub_image_height;
   sub_image.is_dense = is_dense;
   sub_image.clear ();
-  sub_image.resize (sub_image.width*sub_image.height);
+  sub_image.resize (static_cast<std::size_t>(sub_image.width*sub_image.height));
   
   int src_start_x = combine_pixels*sub_image.image_offset_x_ - image_offset_x_,
       src_start_y = combine_pixels*sub_image.image_offset_y_ - image_offset_y_;

--- a/common/src/range_image_planar.cpp
+++ b/common/src/range_image_planar.cpp
@@ -71,7 +71,8 @@ namespace pcl
     center_x_ = static_cast<float> (di_width)  / static_cast<float> (2 * skip);
     center_y_ = static_cast<float> (di_height) / static_cast<float> (2 * skip);
     using SizeType = decltype(points)::size_type;
-    points.resize (static_cast<SizeType>(width*height));
+    SizeType resize = static_cast<SizeType>(width) * height;
+    points.resize (resize);
     
     //std::cout << PVARN (*this);
     
@@ -133,7 +134,8 @@ namespace pcl
     center_x_ = static_cast<float> (di_center_x) / static_cast<float> (skip);
     center_y_ = static_cast<float> (di_center_y) / static_cast<float> (skip);
     using SizeType = decltype(points)::size_type;
-    points.resize (static_cast<SizeType>(width * height));
+    SizeType resize = static_cast<SizeType>(width) * height;
+    points.resize (resize);
     
     for (int y=0; y < static_cast<int> (height); ++y)
     {
@@ -180,7 +182,8 @@ namespace pcl
     center_x_ = static_cast<float> (di_center_x) / static_cast<float> (skip);
     center_y_ = static_cast<float> (di_center_y) / static_cast<float> (skip);
     using SizeType = decltype(points)::size_type;
-    points.resize (static_cast<SizeType>(width * height));
+    SizeType resize = static_cast<SizeType>(width) * height;
+    points.resize (resize);
 
     for (int y = 0; y < static_cast<int> (height); ++y)
     {

--- a/common/src/range_image_planar.cpp
+++ b/common/src/range_image_planar.cpp
@@ -35,6 +35,7 @@
 /** \author Bastian Steder */
 
 #include <cassert>
+#include <cstddef>
 #include <iostream>
 using std::cout;
 using std::cerr;
@@ -69,7 +70,8 @@ namespace pcl
     focal_length_x_reciprocal_ = focal_length_y_reciprocal_ = 1.0f / focal_length_x_;
     center_x_ = static_cast<float> (di_width)  / static_cast<float> (2 * skip);
     center_y_ = static_cast<float> (di_height) / static_cast<float> (2 * skip);
-    points.resize (width*height);
+    using SizeType = decltype(points)::size_type;
+    points.resize (static_cast<SizeType>(width*height));
     
     //std::cout << PVARN (*this);
     
@@ -130,7 +132,8 @@ namespace pcl
     focal_length_y_reciprocal_ = 1.0f / focal_length_y_;
     center_x_ = static_cast<float> (di_center_x) / static_cast<float> (skip);
     center_y_ = static_cast<float> (di_center_y) / static_cast<float> (skip);
-    points.resize (width * height);
+    using SizeType = decltype(points)::size_type;
+    points.resize (static_cast<SizeType>(width * height));
     
     for (int y=0; y < static_cast<int> (height); ++y)
     {
@@ -176,7 +179,8 @@ namespace pcl
     focal_length_y_reciprocal_ = 1.0f / focal_length_y_;
     center_x_ = static_cast<float> (di_center_x) / static_cast<float> (skip);
     center_y_ = static_cast<float> (di_center_y) / static_cast<float> (skip);
-    points.resize (width * height);
+    using SizeType = decltype(points)::size_type;
+    points.resize (static_cast<SizeType>(width * height));
 
     for (int y = 0; y < static_cast<int> (height); ++y)
     {

--- a/examples/common/example_organized_point_cloud.cpp
+++ b/examples/common/example_organized_point_cloud.cpp
@@ -38,6 +38,7 @@
  */
 
 // STL
+#include <cstddef>
 #include <iostream>
 
 // PCL
@@ -56,7 +57,7 @@ main ()
   cloud->height = 10;
   cloud->width = 10;
   cloud->is_dense = true;
-  cloud->resize(cloud->height * cloud->width);
+  cloud->resize(static_cast<std::size_t>(cloud->height * cloud->width));
 
   // Output the (0,0) point
   std::cout << (*cloud)(0,0) << std::endl;

--- a/examples/common/example_organized_point_cloud.cpp
+++ b/examples/common/example_organized_point_cloud.cpp
@@ -57,7 +57,8 @@ main ()
   cloud->height = 10;
   cloud->width = 10;
   cloud->is_dense = true;
-  cloud->resize(static_cast<std::size_t>(cloud->height * cloud->width));
+  std::size_t resize = static_cast<std::size_t>(cloud->height) * cloud->width;
+  cloud->resize(resize);
 
   // Output the (0,0) point
   std::cout << (*cloud)(0,0) << std::endl;

--- a/examples/segmentation/example_supervoxels.cpp
+++ b/examples/segmentation/example_supervoxels.cpp
@@ -196,7 +196,8 @@ main (int argc, char ** argv)
     }
 
     using SizeType = decltype(cloud->points)::size_type;
-    cloud->points.reserve (static_cast<SizeType>(depth_dims[0] * depth_dims[1]));
+    SizeType resize = static_cast<SizeType>(depth_dims[0]) * depth_dims[1];
+    cloud->points.reserve (resize);
     cloud->width = depth_dims[0];
     cloud->height = depth_dims[1];
     cloud->is_dense = false;

--- a/examples/segmentation/example_supervoxels.cpp
+++ b/examples/segmentation/example_supervoxels.cpp
@@ -1,16 +1,17 @@
-#include <thread>
-
 #include <pcl/console/parse.h>
-#include <pcl/io/png_io.h>
 #include <pcl/io/pcd_io.h>
-#include <pcl/visualization/pcl_visualizer.h>
+#include <pcl/io/png_io.h>
 #include <pcl/segmentation/supervoxel_clustering.h>
+#include <pcl/visualization/pcl_visualizer.h>
 
-#include <vtkImageReader2Factory.h>
-#include <vtkImageReader2.h>
 #include <vtkImageData.h>
 #include <vtkImageFlip.h>
+#include <vtkImageReader2.h>
+#include <vtkImageReader2Factory.h>
 #include <vtkPolyLine.h>
+
+#include <cstddef>
+#include <thread>
 
 using namespace std::chrono_literals;
 
@@ -193,8 +194,9 @@ main (int argc, char ** argv)
       std::cout << "Depth Image is of size "<<depth_dims[0] << " by "<<depth_dims[1];
       return (1);
     }
- 
-    cloud->points.reserve (depth_dims[0] * depth_dims[1]);
+
+    using SizeType = decltype(cloud->points)::size_type;
+    cloud->points.reserve (static_cast<SizeType>(depth_dims[0] * depth_dims[1]));
     cloud->width = depth_dims[0];
     cloud->height = depth_dims[1];
     cloud->is_dense = false;

--- a/features/include/pcl/features/impl/brisk_2d.hpp
+++ b/features/include/pcl/features/impl/brisk_2d.hpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+
 /*
  * Software License Agreement (BSD License)
  *
@@ -107,7 +109,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::generateKernel (
     points_ += number;
 
   // set up the patterns
-  pattern_points_ = new BriskPatternPoint[points_*scales_*n_rot_];
+  pattern_points_ = new BriskPatternPoint[static_cast<unsigned long>(points_*scales_*n_rot_)];
   BriskPatternPoint* pattern_iterator = pattern_points_;
 
   // define the scale discretization:
@@ -242,7 +244,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
     const int r_y_1 = (1024 - r_y);
 
     //+const unsigned char* ptr = static_cast<const unsigned char*> (&image[0].r) + x + y * imagecols;
-    const unsigned char* ptr = static_cast<const unsigned char*>(image.data()) + x + y * imagecols;
+    const unsigned char* ptr = static_cast<const unsigned char*>(image.data()) + x + static_cast<ptrdiff_t>(y * imagecols);
 
     // just interpolate:
     ret_val = (r_x_1 * r_y_1 * static_cast<int>(*ptr));
@@ -305,7 +307,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
     // now the calculation:
 
     //+const unsigned char* ptr = static_cast<const unsigned char*> (&image[0].r) + x_left + imagecols * y_top;
-    const unsigned char* ptr = static_cast<const unsigned char*>(image.data()) + x_left + imagecols * y_top;
+    const unsigned char* ptr = static_cast<const unsigned char*>(image.data()) + x_left + static_cast<ptrdiff_t>(imagecols * y_top);
 
     // first the corners:
     ret_val = A * static_cast<int>(*ptr);
@@ -327,7 +329,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
 
     // next the edges:
     //+int* ptr_integral;// = static_cast<int*> (integral.data) + x_left + integralcols * y_top + 1;
-    const int* ptr_integral = static_cast<const int*> (integral_image.data()) + x_left + integralcols * y_top + 1;
+    const int* ptr_integral = static_cast<const int*> (integral_image.data()) + x_left + static_cast<ptrdiff_t>(integralcols * y_top + 1);
 
     // find a simple path through the different surface corners
     const int tmp1 = (*ptr_integral);
@@ -337,7 +339,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
     const int tmp3 = (*ptr_integral);
     ptr_integral++;
     const int tmp4 = (*ptr_integral);
-    ptr_integral += dy * integralcols;
+    ptr_integral += static_cast<ptrdiff_t>(dy * integralcols);
     const int tmp5 = (*ptr_integral);
     ptr_integral--;
     const int tmp6 = (*ptr_integral);
@@ -349,7 +351,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
     const int tmp9 = (*ptr_integral);
     ptr_integral--;
     const int tmp10 = (*ptr_integral);
-    ptr_integral -= dy * integralcols;
+    ptr_integral -= static_cast<ptrdiff_t>(dy * integralcols);
     const int tmp11 = (*ptr_integral);
     ptr_integral++;
     const int tmp12 = (*ptr_integral);
@@ -367,7 +369,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
   // now the calculation:
 
   //const unsigned char* ptr = static_cast<const unsigned char*> (&image[0].r) + x_left + imagecols * y_top;
-  const unsigned char* ptr = static_cast<const unsigned char*>(image.data()) + x_left + imagecols * y_top;
+  const unsigned char* ptr = static_cast<const unsigned char*>(image.data()) + x_left + static_cast<ptrdiff_t>(imagecols * y_top);
 
   // first row:
   ret_val = A * static_cast<int>(*ptr);
@@ -388,7 +390,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
   ptr += imagecols - dx - 1;
 
   //+const unsigned char* end_j = ptr + (dy * imagecols) * sizeof (PointInT);
-  const unsigned char* end_j = ptr + dy * imagecols;
+  const unsigned char* end_j = ptr + static_cast<ptrdiff_t>(dy * imagecols);
 
   //+for (; ptr < end_j; ptr += (imagecols - dx - 1) * sizeof (PointInT))
   for (; ptr < end_j; ptr += imagecols - dx - 1)
@@ -450,7 +452,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
   const auto height = static_cast<index_t>(input_cloud_->height);
 
   // destination for intensity data; will be forwarded to BRISK
-  std::vector<unsigned char> image_data (width*height);
+  std::vector<unsigned char> image_data (static_cast<std::vector<unsigned char>::size_type>(width*height));
 
   for (std::size_t i = 0; i < image_data.size (); ++i)
     image_data[i] = static_cast<unsigned char> (intensity_ ((*input_cloud_)[i]));
@@ -512,7 +514,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
 
   // first, calculate the integral image over the whole image:
   // current integral image
-  std::vector<int> integral ((width+1)*(height+1), 0);    // the integral image
+  std::vector<int> integral (static_cast<std::vector<int>::size_type>((width+1)*(height+1)), 0);    // the integral image
 
   for (index_t row_index = 1; row_index < height; ++row_index)
   {

--- a/features/include/pcl/features/impl/brisk_2d.hpp
+++ b/features/include/pcl/features/impl/brisk_2d.hpp
@@ -109,7 +109,8 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::generateKernel (
     points_ += number;
 
   // set up the patterns
-  pattern_points_ = new BriskPatternPoint[static_cast<unsigned long>(points_*scales_*n_rot_)];
+  std::size_t resize = static_cast<std::size_t>(points_) * static_cast<std::size_t>(scales_) * n_rot_;
+  pattern_points_ = new BriskPatternPoint[resize];
   BriskPatternPoint* pattern_iterator = pattern_points_;
 
   // define the scale discretization:
@@ -244,7 +245,8 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
     const int r_y_1 = (1024 - r_y);
 
     //+const unsigned char* ptr = static_cast<const unsigned char*> (&image[0].r) + x + y * imagecols;
-    const unsigned char* ptr = static_cast<const unsigned char*>(image.data()) + x + static_cast<ptrdiff_t>(y * imagecols);
+    ptrdiff_t addr = static_cast<ptrdiff_t>(y) * imagecols;
+    const unsigned char* ptr = static_cast<const unsigned char*>(image.data()) + x + addr;
 
     // just interpolate:
     ret_val = (r_x_1 * r_y_1 * static_cast<int>(*ptr));
@@ -307,7 +309,8 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
     // now the calculation:
 
     //+const unsigned char* ptr = static_cast<const unsigned char*> (&image[0].r) + x_left + imagecols * y_top;
-    const unsigned char* ptr = static_cast<const unsigned char*>(image.data()) + x_left + static_cast<ptrdiff_t>(imagecols * y_top);
+    ptrdiff_t addr = static_cast<ptrdiff_t>(y_top) * imagecols;
+    const unsigned char* ptr = static_cast<const unsigned char*>(image.data()) + x_left + addr;
 
     // first the corners:
     ret_val = A * static_cast<int>(*ptr);
@@ -329,7 +332,8 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
 
     // next the edges:
     //+int* ptr_integral;// = static_cast<int*> (integral.data) + x_left + integralcols * y_top + 1;
-    const int* ptr_integral = static_cast<const int*> (integral_image.data()) + x_left + static_cast<ptrdiff_t>(integralcols * y_top + 1);
+    ptrdiff_t edgeaddr = static_cast<ptrdiff_t>(y_top + 1) * integralcols;
+    const int* ptr_integral = static_cast<const int*> (integral_image.data()) + x_left + edgeaddr;
 
     // find a simple path through the different surface corners
     const int tmp1 = (*ptr_integral);
@@ -339,7 +343,8 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
     const int tmp3 = (*ptr_integral);
     ptr_integral++;
     const int tmp4 = (*ptr_integral);
-    ptr_integral += static_cast<ptrdiff_t>(dy * integralcols);
+    ptrdiff_t icaddr = static_cast<ptrdiff_t>(dy) * integralcols;
+    ptr_integral += icaddr;
     const int tmp5 = (*ptr_integral);
     ptr_integral--;
     const int tmp6 = (*ptr_integral);
@@ -351,7 +356,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
     const int tmp9 = (*ptr_integral);
     ptr_integral--;
     const int tmp10 = (*ptr_integral);
-    ptr_integral -= static_cast<ptrdiff_t>(dy * integralcols);
+    ptr_integral -= icaddr;
     const int tmp11 = (*ptr_integral);
     ptr_integral++;
     const int tmp12 = (*ptr_integral);
@@ -369,7 +374,8 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
   // now the calculation:
 
   //const unsigned char* ptr = static_cast<const unsigned char*> (&image[0].r) + x_left + imagecols * y_top;
-  const unsigned char* ptr = static_cast<const unsigned char*>(image.data()) + x_left + static_cast<ptrdiff_t>(imagecols * y_top);
+  ptrdiff_t topaddr = static_cast<ptrdiff_t>(imagecols) * y_top;
+  const unsigned char* ptr = static_cast<const unsigned char*>(image.data()) + x_left + topaddr;
 
   // first row:
   ret_val = A * static_cast<int>(*ptr);
@@ -390,7 +396,8 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
   ptr += imagecols - dx - 1;
 
   //+const unsigned char* end_j = ptr + (dy * imagecols) * sizeof (PointInT);
-  const unsigned char* end_j = ptr + static_cast<ptrdiff_t>(dy * imagecols);
+  ptrdiff_t imgaddr = static_cast<ptrdiff_t>(dy) * imagecols;
+  const unsigned char* end_j = ptr + imgaddr;
 
   //+for (; ptr < end_j; ptr += (imagecols - dx - 1) * sizeof (PointInT))
   for (; ptr < end_j; ptr += imagecols - dx - 1)
@@ -452,7 +459,8 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
   const auto height = static_cast<index_t>(input_cloud_->height);
 
   // destination for intensity data; will be forwarded to BRISK
-  std::vector<unsigned char> image_data (static_cast<std::vector<unsigned char>::size_type>(width*height));
+  std::vector<unsigned char>::size_type datasize = static_cast<std::vector<unsigned char>::size_type>(width) * height;
+  std::vector<unsigned char> image_data (datasize);
 
   for (std::size_t i = 0; i < image_data.size (); ++i)
     image_data[i] = static_cast<unsigned char> (intensity_ ((*input_cloud_)[i]));
@@ -514,7 +522,8 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
 
   // first, calculate the integral image over the whole image:
   // current integral image
-  std::vector<int> integral (static_cast<std::vector<int>::size_type>((width+1)*(height+1)), 0);    // the integral image
+  std::vector<int>::size_type isize = static_cast<std::vector<int>::size_type>((width+1)) * (height+1);
+  std::vector<int> integral (isize, 0);    // the integral image
 
   for (index_t row_index = 1; row_index < height; ++row_index)
   {

--- a/features/include/pcl/features/impl/esf.hpp
+++ b/features/include/pcl/features/impl/esf.hpp
@@ -41,11 +41,13 @@
 #ifndef PCL_FEATURES_IMPL_ESF_H_
 #define PCL_FEATURES_IMPL_ESF_H_
 
-#include <pcl/features/esf.h>
 #include <pcl/common/distances.h>
 #include <pcl/common/transforms.h>
-#include <vector>
+#include <pcl/features/esf.h>
+
+#include <cstddef>
 #include <ctime> // for time
+#include <vector>
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointOutT> void
@@ -61,9 +63,9 @@ pcl::ESFEstimation<PointInT, PointOutT>::computeESF (
   std::vector<float> d2v, d1v, d3v, wt_d3;
   std::vector<int> wt_d2;
   d1v.reserve (sample_size);
-  d2v.reserve (sample_size * 3);
+  d2v.reserve (static_cast<std::vector<float>::size_type>(sample_size * 3));
   d3v.reserve (sample_size);
-  wt_d2.reserve (sample_size * 3);
+  wt_d2.reserve (static_cast<std::vector<int>::size_type>(sample_size * 3));
   wt_d3.reserve (sample_size);
 
   float h_in[binsize] = {0.0f};
@@ -223,8 +225,8 @@ pcl::ESFEstimation<PointInT, PointOutT>::computeESF (
       maxd2 = d2v[nn_idx];
     if (d2v[sample_size + nn_idx] > maxd2)
       maxd2 = d2v[sample_size + nn_idx];
-    if (d2v[sample_size*2 +nn_idx] > maxd2)
-      maxd2 = d2v[sample_size*2 +nn_idx];
+    if (d2v[static_cast<unsigned long>(sample_size*2) +nn_idx] > maxd2)
+      maxd2 = d2v[static_cast<unsigned long>(sample_size*2) +nn_idx];
     if (d3v[nn_idx] > maxd3)
       maxd3 = d3v[nn_idx];
   }
@@ -269,7 +271,7 @@ pcl::ESFEstimation<PointInT, PointOutT>::computeESF (
   //float weights[10] = {1,  1,  1,  1,  1,  1,  1,  1 , 1 ,  1};
   float weights[10] = {0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 1.0f,  1.0f, 2.0f, 2.0f, 2.0f};
 
-  hist.reserve (binsize * 10);
+  hist.reserve (static_cast<std::vector<float>::size_type>(binsize * 10));
   for (const float &i : h_a3_in)
     hist.push_back (i * weights[0]);
   for (const float &i : h_a3_out)

--- a/features/include/pcl/features/impl/esf.hpp
+++ b/features/include/pcl/features/impl/esf.hpp
@@ -63,9 +63,11 @@ pcl::ESFEstimation<PointInT, PointOutT>::computeESF (
   std::vector<float> d2v, d1v, d3v, wt_d3;
   std::vector<int> wt_d2;
   d1v.reserve (sample_size);
-  d2v.reserve (static_cast<std::vector<float>::size_type>(sample_size * 3));
+  auto resizef = static_cast<std::vector<float>::size_type>(sample_size * 3);
+  d2v.reserve (resizef);
   d3v.reserve (sample_size);
-  wt_d2.reserve (static_cast<std::vector<int>::size_type>(sample_size * 3));
+  auto resizei = static_cast<std::vector<int>::size_type>(sample_size * 3);
+  wt_d2.reserve (resizei);
   wt_d3.reserve (sample_size);
 
   float h_in[binsize] = {0.0f};
@@ -225,8 +227,9 @@ pcl::ESFEstimation<PointInT, PointOutT>::computeESF (
       maxd2 = d2v[nn_idx];
     if (d2v[sample_size + nn_idx] > maxd2)
       maxd2 = d2v[sample_size + nn_idx];
-    if (d2v[static_cast<unsigned long>(sample_size*2) +nn_idx] > maxd2)
-      maxd2 = d2v[static_cast<unsigned long>(sample_size*2) +nn_idx];
+    std::size_t resize = static_cast<std::size_t>(sample_size*2) + nn_idx;
+    if (d2v[resize] > maxd2)
+      maxd2 = d2v[resize];
     if (d3v[nn_idx] > maxd3)
       maxd3 = d3v[nn_idx];
   }

--- a/features/include/pcl/features/impl/integral_image2D.hpp
+++ b/features/include/pcl/features/impl/integral_image2D.hpp
@@ -63,7 +63,8 @@ IntegralImage2D<DataType, Dimension>::setInput (const DataType * data, unsigned 
     height_ = height;
     first_order_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
     using SizeType = typename decltype(finite_values_integral_image_)::size_type;
-    finite_values_integral_image_.resize ( static_cast<SizeType>((width_ + 1) * (height_ + 1)) );
+    SizeType resize = static_cast<SizeType>((width_ + 1)) * (height_ + 1);
+    finite_values_integral_image_.resize ( resize );
     if (compute_second_order_integral_images_)
       second_order_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
   }
@@ -235,7 +236,8 @@ IntegralImage2D<DataType, 1>::setInput (const DataType * data, unsigned width,un
     height_ = height;
     first_order_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
     using SizeType = typename decltype(finite_values_integral_image_)::size_type;
-    finite_values_integral_image_.resize ( static_cast<SizeType>((width_ + 1) * (height_ + 1)) );
+    SizeType resize = static_cast<SizeType>((width_ + 1)) * (height_ + 1);
+    finite_values_integral_image_.resize ( resize );
     if (compute_second_order_integral_images_)
       second_order_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
   }

--- a/features/include/pcl/features/impl/integral_image2D.hpp
+++ b/features/include/pcl/features/impl/integral_image2D.hpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+
 /*
  * Software License Agreement (BSD License)
  *
@@ -60,7 +62,8 @@ IntegralImage2D<DataType, Dimension>::setInput (const DataType * data, unsigned 
     width_  = width;
     height_ = height;
     first_order_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
-    finite_values_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
+    using SizeType = typename decltype(finite_values_integral_image_)::size_type;
+    finite_values_integral_image_.resize ( static_cast<SizeType>((width_ + 1) * (height_ + 1)) );
     if (compute_second_order_integral_images_)
       second_order_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
   }
@@ -231,7 +234,8 @@ IntegralImage2D<DataType, 1>::setInput (const DataType * data, unsigned width,un
     width_  = width;
     height_ = height;
     first_order_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
-    finite_values_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
+    using SizeType = typename decltype(finite_values_integral_image_)::size_type;
+    finite_values_integral_image_.resize ( static_cast<SizeType>((width_ + 1) * (height_ + 1)) );
     if (compute_second_order_integral_images_)
       second_order_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
   }

--- a/features/include/pcl/features/impl/pfh.hpp
+++ b/features/include/pcl/features/impl/pfh.hpp
@@ -38,10 +38,11 @@
 
 #pragma once
 
+#include <pcl/common/point_tests.h> // for pcl::isFinite
 #include <pcl/features/pfh.h>
 #include <pcl/features/pfh_tools.h> // for computePairFeatures
 
-#include <pcl/common/point_tests.h> // for pcl::isFinite
+#include <cstddef>
 
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -171,7 +172,7 @@ pcl::PFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
   std::queue<std::pair<int, int> > empty;
   std::swap (key_list_, empty);
 
-  pfh_histogram_.setZero (nr_subdiv_ * nr_subdiv_ * nr_subdiv_);
+  pfh_histogram_.setZero (static_cast<Eigen::Index>(nr_subdiv_ * nr_subdiv_ * nr_subdiv_));
 
   // Allocate enough space to hold the results
   // \note This resize is irrelevant for a radiusSearch ().

--- a/features/include/pcl/features/impl/pfh.hpp
+++ b/features/include/pcl/features/impl/pfh.hpp
@@ -172,7 +172,8 @@ pcl::PFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
   std::queue<std::pair<int, int> > empty;
   std::swap (key_list_, empty);
 
-  pfh_histogram_.setZero (static_cast<Eigen::Index>(nr_subdiv_ * nr_subdiv_ * nr_subdiv_));
+  Eigen::Index dim = static_cast<Eigen::Index>(nr_subdiv_) * nr_subdiv_ * nr_subdiv_;
+  pfh_histogram_.setZero (dim);
 
   // Allocate enough space to hold the results
   // \note This resize is irrelevant for a radiusSearch ().

--- a/features/include/pcl/features/impl/pfhrgb.hpp
+++ b/features/include/pcl/features/impl/pfhrgb.hpp
@@ -137,7 +137,8 @@ template <typename PointInT, typename PointNT, typename PointOutT> void
 pcl::PFHRGBEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut &output)
 {
   /// nr_subdiv^3 for RGB and nr_subdiv^3 for the angular features
-  pfhrgb_histogram_.setZero (static_cast<Eigen::Index>(2 * nr_subdiv_ * nr_subdiv_ * nr_subdiv_));
+  Eigen::Index dim = static_cast<Eigen::Index>(2 * nr_subdiv_) * nr_subdiv_ * nr_subdiv_;
+  pfhrgb_histogram_.setZero (dim);
   pfhrgb_tuple_.setZero (7);
 
   // Allocate enough space to hold the results

--- a/features/include/pcl/features/impl/pfhrgb.hpp
+++ b/features/include/pcl/features/impl/pfhrgb.hpp
@@ -42,6 +42,8 @@
 
 #include <pcl/features/pfhrgb.h>
 
+#include <cstddef>
+
 //////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointInT, typename PointNT, typename PointOutT> bool
 pcl::PFHRGBEstimation<PointInT, PointNT, PointOutT>::computeRGBPairFeatures (
@@ -135,7 +137,7 @@ template <typename PointInT, typename PointNT, typename PointOutT> void
 pcl::PFHRGBEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut &output)
 {
   /// nr_subdiv^3 for RGB and nr_subdiv^3 for the angular features
-  pfhrgb_histogram_.setZero (2 * nr_subdiv_ * nr_subdiv_ * nr_subdiv_);
+  pfhrgb_histogram_.setZero (static_cast<Eigen::Index>(2 * nr_subdiv_ * nr_subdiv_ * nr_subdiv_));
   pfhrgb_tuple_.setZero (7);
 
   // Allocate enough space to hold the results

--- a/features/src/narf.cpp
+++ b/features/src/narf.cpp
@@ -38,9 +38,10 @@
 #include <pcl/features/narf.h>
 #include <pcl/features/narf_descriptor.h>
 
-#include <iostream>
-#include <fstream>
 #include <cmath>
+#include <cstddef>
+#include <fstream>
+#include <iostream>
 #include <map> // for std::multimap
 using std::cout;
 using std::cerr;
@@ -109,9 +110,9 @@ Narf::deepCopy (const Narf& other)
   {
     surface_patch_pixel_size_ = other.surface_patch_pixel_size_;
     delete[] surface_patch_;
-    surface_patch_ = new float[surface_patch_pixel_size_*surface_patch_pixel_size_];
+    surface_patch_ = new float[static_cast<unsigned long>(surface_patch_pixel_size_*surface_patch_pixel_size_)];
   }
-  std::copy(other.surface_patch_, other.surface_patch_ + surface_patch_pixel_size_*surface_patch_pixel_size_, surface_patch_);
+  std::copy(other.surface_patch_, other.surface_patch_ + static_cast<ptrdiff_t>(surface_patch_pixel_size_*surface_patch_pixel_size_), surface_patch_);
   surface_patch_world_size_ = other.surface_patch_world_size_;
   surface_patch_rotation_ = other.surface_patch_rotation_;
   
@@ -521,7 +522,7 @@ Narf::saveBinary (std::ostream& file) const
   pcl::saveBinary(transformation_.matrix(), file);
   file.write(reinterpret_cast<const char*>(&surface_patch_pixel_size_), sizeof(surface_patch_pixel_size_));
   file.write(reinterpret_cast<const char*>(surface_patch_),
-             surface_patch_pixel_size_*surface_patch_pixel_size_*sizeof(*surface_patch_));
+             static_cast<unsigned long>(surface_patch_pixel_size_*surface_patch_pixel_size_)*sizeof(*surface_patch_));
   file.write(reinterpret_cast<const char*>(&surface_patch_world_size_), sizeof(surface_patch_world_size_));
   file.write(reinterpret_cast<const char*>(&surface_patch_rotation_), sizeof(surface_patch_rotation_));
   file.write(reinterpret_cast<const char*>(&descriptor_size_), sizeof(descriptor_size_));
@@ -573,9 +574,9 @@ Narf::loadBinary (std::istream& file)
   pcl::loadBinary(position_.matrix(), file);
   pcl::loadBinary(transformation_.matrix(), file);
   file.read(reinterpret_cast<char*>(&surface_patch_pixel_size_), sizeof(surface_patch_pixel_size_));
-  surface_patch_ = new float[surface_patch_pixel_size_*surface_patch_pixel_size_];
+  surface_patch_ = new float[static_cast<unsigned long>(surface_patch_pixel_size_*surface_patch_pixel_size_)];
   file.read(reinterpret_cast<char*>(surface_patch_),
-            surface_patch_pixel_size_*surface_patch_pixel_size_*sizeof(*surface_patch_));
+            static_cast<unsigned long>(surface_patch_pixel_size_*surface_patch_pixel_size_)*sizeof(*surface_patch_));
   file.read(reinterpret_cast<char*>(&surface_patch_world_size_), sizeof(surface_patch_world_size_));
   file.read(reinterpret_cast<char*>(&surface_patch_rotation_), sizeof(surface_patch_rotation_));
   file.read(reinterpret_cast<char*>(&descriptor_size_), sizeof(descriptor_size_));

--- a/features/src/narf.cpp
+++ b/features/src/narf.cpp
@@ -110,9 +110,11 @@ Narf::deepCopy (const Narf& other)
   {
     surface_patch_pixel_size_ = other.surface_patch_pixel_size_;
     delete[] surface_patch_;
-    surface_patch_ = new float[static_cast<unsigned long>(surface_patch_pixel_size_*surface_patch_pixel_size_)];
+    std::size_t size = static_cast<std::size_t>(surface_patch_pixel_size_) * surface_patch_pixel_size_;
+    surface_patch_ = new float[size];
   }
-  std::copy(other.surface_patch_, other.surface_patch_ + static_cast<ptrdiff_t>(surface_patch_pixel_size_*surface_patch_pixel_size_), surface_patch_);
+  ptrdiff_t area = static_cast<ptrdiff_t>(surface_patch_pixel_size_) * surface_patch_pixel_size_;
+  std::copy(other.surface_patch_, other.surface_patch_ + area, surface_patch_);
   surface_patch_world_size_ = other.surface_patch_world_size_;
   surface_patch_rotation_ = other.surface_patch_rotation_;
   
@@ -520,9 +522,10 @@ Narf::saveBinary (std::ostream& file) const
   saveHeader(file);
   pcl::saveBinary(position_.matrix(), file);
   pcl::saveBinary(transformation_.matrix(), file);
+  std::size_t area = static_cast<std::size_t>(surface_patch_pixel_size_) * surface_patch_pixel_size_;
   file.write(reinterpret_cast<const char*>(&surface_patch_pixel_size_), sizeof(surface_patch_pixel_size_));
   file.write(reinterpret_cast<const char*>(surface_patch_),
-             static_cast<unsigned long>(surface_patch_pixel_size_*surface_patch_pixel_size_)*sizeof(*surface_patch_));
+             area*sizeof(*surface_patch_));
   file.write(reinterpret_cast<const char*>(&surface_patch_world_size_), sizeof(surface_patch_world_size_));
   file.write(reinterpret_cast<const char*>(&surface_patch_rotation_), sizeof(surface_patch_rotation_));
   file.write(reinterpret_cast<const char*>(&descriptor_size_), sizeof(descriptor_size_));
@@ -574,9 +577,10 @@ Narf::loadBinary (std::istream& file)
   pcl::loadBinary(position_.matrix(), file);
   pcl::loadBinary(transformation_.matrix(), file);
   file.read(reinterpret_cast<char*>(&surface_patch_pixel_size_), sizeof(surface_patch_pixel_size_));
+  std::size_t area = static_cast<std::size_t>(surface_patch_pixel_size_) * surface_patch_pixel_size_;
   surface_patch_ = new float[static_cast<unsigned long>(surface_patch_pixel_size_*surface_patch_pixel_size_)];
   file.read(reinterpret_cast<char*>(surface_patch_),
-            static_cast<unsigned long>(surface_patch_pixel_size_*surface_patch_pixel_size_)*sizeof(*surface_patch_));
+            area*sizeof(*surface_patch_));
   file.read(reinterpret_cast<char*>(&surface_patch_world_size_), sizeof(surface_patch_world_size_));
   file.read(reinterpret_cast<char*>(&surface_patch_rotation_), sizeof(surface_patch_rotation_));
   file.read(reinterpret_cast<char*>(&descriptor_size_), sizeof(descriptor_size_));

--- a/features/src/range_image_border_extractor.cpp
+++ b/features/src/range_image_border_extractor.cpp
@@ -35,6 +35,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <cstddef>
 #include <iostream>
 using std::cout;
 using std::cerr;
@@ -201,7 +202,7 @@ RangeImageBorderExtractor::extractBorderScoreImages ()
 float*
 RangeImageBorderExtractor::updatedScoresAccordingToNeighborValues (const float* border_scores) const
 {
-  float* new_scores = new float[range_image_->width*range_image_->height];
+  float* new_scores = new float[static_cast<unsigned long>(range_image_->width*range_image_->height)];
   float* new_scores_ptr = new_scores;
   for (int y=0; y < static_cast<int> (range_image_->height); ++y)
     for (int x=0; x < static_cast<int> (range_image_->width); ++x)
@@ -213,7 +214,7 @@ std::vector<float>
 RangeImageBorderExtractor::updatedScoresAccordingToNeighborValues (const std::vector<float>& border_scores) const
 {
   std::vector<float> new_border_scores;
-  new_border_scores.reserve (range_image_->width*range_image_->height);
+  new_border_scores.reserve (static_cast<std::vector<float>::size_type>(range_image_->width*range_image_->height));
   for (int y=0; y < static_cast<int> (range_image_->height); ++y)
     for (int x=0; x < static_cast<int> (range_image_->width); ++x)
       new_border_scores.push_back (updatedScoreAccordingToNeighborValues(x, y, border_scores.data ()));
@@ -250,7 +251,7 @@ RangeImageBorderExtractor::findAndEvaluateShadowBorders ()
 
   int width  = range_image_->width,
       height = range_image_->height;
-  shadow_border_informations_ = new ShadowBorderIndices*[width*height];
+  shadow_border_informations_ = new ShadowBorderIndices*[static_cast<unsigned long>(width*height)];
   for (int y = 0; y < static_cast<int> (height); ++y)
   {
     for (int x = 0; x < static_cast<int> (width); ++x)
@@ -611,8 +612,8 @@ RangeImageBorderExtractor::blurSurfaceChanges ()
 
   const RangeImage& range_image = *range_image_;
 
-  auto* blurred_directions = new Eigen::Vector3f[range_image.width*range_image.height];
-  float* blurred_scores = new float[range_image.width*range_image.height];
+  auto* blurred_directions = new Eigen::Vector3f[static_cast<unsigned long>(range_image.width*range_image.height)];
+  float* blurred_scores = new float[static_cast<unsigned long>(range_image.width*range_image.height)];
   for (int y=0; y<static_cast<int>(range_image.height); ++y)
   {
     for (int x=0; x<static_cast<int>(range_image.width); ++x)

--- a/features/src/range_image_border_extractor.cpp
+++ b/features/src/range_image_border_extractor.cpp
@@ -202,7 +202,8 @@ RangeImageBorderExtractor::extractBorderScoreImages ()
 float*
 RangeImageBorderExtractor::updatedScoresAccordingToNeighborValues (const float* border_scores) const
 {
-  float* new_scores = new float[static_cast<unsigned long>(range_image_->width*range_image_->height)];
+  std::size_t size = static_cast<std::size_t>(range_image_->width) * range_image_->height;
+  float* new_scores = new float[size];
   float* new_scores_ptr = new_scores;
   for (int y=0; y < static_cast<int> (range_image_->height); ++y)
     for (int x=0; x < static_cast<int> (range_image_->width); ++x)
@@ -214,7 +215,8 @@ std::vector<float>
 RangeImageBorderExtractor::updatedScoresAccordingToNeighborValues (const std::vector<float>& border_scores) const
 {
   std::vector<float> new_border_scores;
-  new_border_scores.reserve (static_cast<std::vector<float>::size_type>(range_image_->width*range_image_->height));
+  std::vector<float>::size_type resize = static_cast<std::vector<float>::size_type>(range_image_->width) * range_image_->height;
+  new_border_scores.reserve (resize);
   for (int y=0; y < static_cast<int> (range_image_->height); ++y)
     for (int x=0; x < static_cast<int> (range_image_->width); ++x)
       new_border_scores.push_back (updatedScoreAccordingToNeighborValues(x, y, border_scores.data ()));
@@ -251,7 +253,8 @@ RangeImageBorderExtractor::findAndEvaluateShadowBorders ()
 
   int width  = range_image_->width,
       height = range_image_->height;
-  shadow_border_informations_ = new ShadowBorderIndices*[static_cast<unsigned long>(width*height)];
+  std::size_t size = static_cast<std::size_t>(width) * height;
+  shadow_border_informations_ = new ShadowBorderIndices*[size];
   for (int y = 0; y < static_cast<int> (height); ++y)
   {
     for (int x = 0; x < static_cast<int> (width); ++x)
@@ -611,9 +614,9 @@ RangeImageBorderExtractor::blurSurfaceChanges ()
   int blur_radius = 1;
 
   const RangeImage& range_image = *range_image_;
-
-  auto* blurred_directions = new Eigen::Vector3f[static_cast<unsigned long>(range_image.width*range_image.height)];
-  float* blurred_scores = new float[static_cast<unsigned long>(range_image.width*range_image.height)];
+  std::size_t size = static_cast<std::size_t>(range_image.width) * range_image.height;
+  auto* blurred_directions = new Eigen::Vector3f[size];
+  float* blurred_scores = new float[size];
   for (int y=0; y<static_cast<int>(range_image.height); ++y)
   {
     for (int x=0; x<static_cast<int>(range_image.width); ++x)


### PR DESCRIPTION
Part A of support for the `clang-tidy` check [`bugprone-implicit-widening-of-multiplication-result`](https://clang.llvm.org/extra/clang-tidy/checks/bugprone/implicit-widening-of-multiplication-result.html).

As with PR #5665, this check will be implemented over several PRs to keep them to a reasonable size.