### PR TITLE
Add missing PCL_EXPORTS

### DIFF
--- a/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
+++ b/gpu/segmentation/include/pcl/gpu/segmentation/impl/gpu_extract_clusters.hpp
@@ -39,12 +39,13 @@
 #pragma once
 #include <pcl/common/copy_point.h>
 #include <pcl/gpu/segmentation/gpu_extract_clusters.h>
+#include <pcl/pcl_exports.h>
 
 namespace pcl {
 namespace detail {
 
 //// Downloads only the neccssary cluster indices from the device to the host.
-void
+PCL_EXPORTS void
 economical_download(const pcl::gpu::NeighborIndices& source_indices,
                     const pcl::Indices& buffer_indices,
                     std::size_t buffer_size,

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cone.h
@@ -41,11 +41,12 @@
 #include <pcl/sample_consensus/sac_model.h>
 #include <pcl/sample_consensus/model_types.h>
 #include <pcl/common/distances.h>
+#include <pcl/pcl_exports.h>
 
 namespace pcl
 {
   namespace internal {
-    int optimizeModelCoefficientsCone (Eigen::VectorXf& coeff, const Eigen::ArrayXf& pts_x, const Eigen::ArrayXf& pts_y, const Eigen::ArrayXf& pts_z);
+    PCL_EXPORTS int optimizeModelCoefficientsCone (Eigen::VectorXf& coeff, const Eigen::ArrayXf& pts_x, const Eigen::ArrayXf& pts_y, const Eigen::ArrayXf& pts_z);
   } // namespace internal
 
   /** \brief @b SampleConsensusModelCone defines a model for 3D cone segmentation.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_cylinder.h
@@ -43,11 +43,12 @@
 #include <pcl/sample_consensus/sac_model.h>
 #include <pcl/sample_consensus/model_types.h>
 #include <pcl/common/distances.h>
+#include <pcl/pcl_exports.h>
 
 namespace pcl
 {
   namespace internal {
-    int optimizeModelCoefficientsCylinder (Eigen::VectorXf& coeff, const Eigen::ArrayXf& pts_x, const Eigen::ArrayXf& pts_y, const Eigen::ArrayXf& pts_z);
+    PCL_EXPORTS int optimizeModelCoefficientsCylinder (Eigen::VectorXf& coeff, const Eigen::ArrayXf& pts_x, const Eigen::ArrayXf& pts_y, const Eigen::ArrayXf& pts_z);
   } // namespace internal
 
   /** \brief @b SampleConsensusModelCylinder defines a model for 3D cylinder segmentation.

--- a/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac_model_sphere.h
@@ -49,11 +49,12 @@
 
 #include <pcl/sample_consensus/sac_model.h>
 #include <pcl/sample_consensus/model_types.h>
+#include <pcl/pcl_exports.h>
 
 namespace pcl
 {
   namespace internal {
-    int optimizeModelCoefficientsSphere (Eigen::VectorXf& coeff, const Eigen::ArrayXf& pts_x, const Eigen::ArrayXf& pts_y, const Eigen::ArrayXf& pts_z);
+    PCL_EXPORTS int optimizeModelCoefficientsSphere (Eigen::VectorXf& coeff, const Eigen::ArrayXf& pts_x, const Eigen::ArrayXf& pts_y, const Eigen::ArrayXf& pts_z);
   } // namespace internal
 
   /** \brief SampleConsensusModelSphere defines a model for 3D sphere segmentation.

--- a/visualization/include/pcl/visualization/vtk/vtkRenderWindowInteractorFix.h
+++ b/visualization/include/pcl/visualization/vtk/vtkRenderWindowInteractorFix.h
@@ -38,5 +38,6 @@
 #pragma once
 
 #include <vtkRenderWindowInteractor.h>
+#include <pcl/pcl_exports.h>
 
-vtkRenderWindowInteractor* vtkRenderWindowInteractorFixNew ();
+PCL_EXPORTS vtkRenderWindowInteractor* vtkRenderWindowInteractorFixNew ();


### PR DESCRIPTION
Fixes https://github.com/PointCloudLibrary/pcl/issues/5923
Fixes https://github.com/PointCloudLibrary/pcl/issues/5925
Adding `PCL_EXPORTS` in `gpu_extract_clusters.hpp` fixes compiler error C2375 (MSVC)  for `economical_download`