### PR TITLE
Fix Bug in NormalSpaceSampling::findBin()

### DIFF
--- a/filters/include/pcl/filters/impl/normal_space.hpp
+++ b/filters/include/pcl/filters/impl/normal_space.hpp
@@ -82,9 +82,9 @@ pcl::NormalSpaceSampling<PointT, NormalT>::findBin (const float *normal)
 {
   // in the case where normal[0] == 1.0f, ix will be binsx_, which is out of range.
   // thus, use std::min to avoid this situation.
-  const auto ix = std::min (binsx_ - 1, static_cast<unsigned> (std::floor (0.5f * (binsx_) * (normal[0] + 1.f))));
-  const auto iy = std::min (binsy_ - 1, static_cast<unsigned> (std::floor (0.5f * (binsy_) * (normal[1] + 1.f))));
-  const auto iz = std::min (binsz_ - 1, static_cast<unsigned> (std::floor (0.5f * (binsz_) * (normal[2] + 1.f))));
+  const auto ix = std::min (binsx_ - 1, static_cast<unsigned> (std::max (0.0f, std::floor (0.5f * (binsx_) * (normal[0] + 1.f)))));
+  const auto iy = std::min (binsy_ - 1, static_cast<unsigned> (std::max (0.0f, std::floor (0.5f * (binsy_) * (normal[1] + 1.f)))));
+  const auto iz = std::min (binsz_ - 1, static_cast<unsigned> (std::max (0.0f, std::floor (0.5f * (binsz_) * (normal[2] + 1.f)))));
   return ix * (binsy_*binsz_) + iy * binsz_ + iz;
 }
 

--- a/filters/include/pcl/filters/impl/normal_space.hpp
+++ b/filters/include/pcl/filters/impl/normal_space.hpp
@@ -80,9 +80,11 @@ pcl::NormalSpaceSampling<PointT, NormalT>::isEntireBinSampled (boost::dynamic_bi
 template<typename PointT, typename NormalT> unsigned int 
 pcl::NormalSpaceSampling<PointT, NormalT>::findBin (const float *normal)
 {
-  const auto ix = static_cast<unsigned> (std::round (0.5f * (binsx_ - 1.f) * (normal[0] + 1.f)));
-  const auto iy = static_cast<unsigned> (std::round (0.5f * (binsy_ - 1.f) * (normal[1] + 1.f)));
-  const auto iz = static_cast<unsigned> (std::round (0.5f * (binsz_ - 1.f) * (normal[2] + 1.f)));
+  // in the case where normal[0] == 1.0f, ix will be binsx_, which is out of range.
+  // thus, use std::min to avoid this situation.
+  const auto ix = std::min (binsx_ - 1, static_cast<unsigned> (std::floor (0.5f * (binsx_) * (normal[0] + 1.f))));
+  const auto iy = std::min (binsy_ - 1, static_cast<unsigned> (std::floor (0.5f * (binsy_) * (normal[1] + 1.f))));
+  const auto iz = std::min (binsz_ - 1, static_cast<unsigned> (std::floor (0.5f * (binsz_) * (normal[2] + 1.f))));
   return ix * (binsy_*binsz_) + iy * binsz_ + iz;
 }
 


### PR DESCRIPTION
This is a bugfix for the discussion in [this](https://github.com/PointCloudLibrary/pcl/pull/3862#issuecomment-1895114109), following the suggestion from @mvieth .

Sorry for not being able to format the code. I've tried to format _`normal_space.hpp`_ using this command `clang-format-14 --style=file -i filters/include/pcl/filters/impl/normal_space.hpp`. However, the entire file has been formatted. This is my first time submitting code to PCL, is my formatting operation incorrect? 