### PR TITLE
Add new googletest path

### DIFF
--- a/cmake/Modules/FindGTestSource.cmake
+++ b/cmake/Modules/FindGTestSource.cmake
@@ -24,6 +24,7 @@ find_path(GTEST_SRC_DIR src/gtest-all.cc
     HINTS "${GTEST_ROOT}" "$ENV{GTEST_ROOT}"
     PATHS "$ENV{PROGRAMFILES}/gtest" "$ENV{PROGRAMW6432}/gtest"
     PATHS "$ENV{PROGRAMFILES}/gtest-1.7.0" "$ENV{PROGRAMW6432}/gtest-1.7.0"
+    PATH /usr/src/googletest
     PATH /usr/src/googletest/googletest
     PATH /usr/src/gtest
     PATH_SUFFIXES gtest src/gtest googletest/googletest)


### PR DESCRIPTION
Fixed at least for [ArchLinux](https://archlinux.org/packages/extra/x86_64/gtest/files/).