### PR TITLE
Rename variables with reserved names

### DIFF
--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -691,8 +691,8 @@ namespace pcl
     inline constexpr PointXYZLAB() : PointXYZLAB{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f} {}
 
     inline constexpr PointXYZLAB (float _x, float _y, float _z,
-                        float _L, float _a, float _b) :
-      _PointXYZLAB{ {{_x, _y, _z, 1.0f}}, {{_L, _a, _b}} } {}
+                        float _l, float _a, float _b) :
+      _PointXYZLAB{ {{_x, _y, _z, 1.0f}}, {{_l, _a, _b}} } {}
 
     friend std::ostream& operator << (std::ostream& os, const PointXYZLAB& p);
     PCL_MAKE_ALIGNED_OPERATOR_NEW


### PR DESCRIPTION
From the GNU libc manual[0]:

> In addition to the names documented in this manual, reserved names include all external identifiers (global functions and variables) that begin with an underscore (‘_’) and all identifiers regardless of use that begin with either two underscores or an underscore followed by a capital letter are reserved names. This is so that the library and header files can define functions, variables, and macros for internal purposes without risk of conflict with names in user programs.

[0] https://www.gnu.org/software/libc/manual/html_node/Reserved-Names.html

This pull request fixes the following compiler error when compiling on OpenBSD:

``` cmake
FAILED: common/CMakeFiles/pcl_common.dir/src/point_types.cpp.o 
/usr/ports/pobj/pcl-1.14.0/bin/c++ -DPCLAPI_EXPORTS -I/usr/ports/pobj/pcl-1.14.0/build-amd64/include -I/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include -isystem /usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/recognition/include/pcl/recognition/3rdparty -isystem /usr/local/include -isystem /usr/local/include/eigen3 -O2 -pipe -DNDEBUG -std=c++14 -fPIC -MD -MT common/CMakeFiles/pcl_common.dir/src/point_types.cpp.o -MF common/CMakeFiles/pcl_common.dir/src/point_types.cpp.o.d -o common/CMakeFiles/pcl_common.dir/src/point_types.cpp.o -c /usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/src/point_types.cpp
In file included from /usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/src/point_types.cpp:37:
In file included from /usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/point_types.h:354:
In file included from /usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:42:
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/pcl_macros.h:397:2: error: aligned_malloc not supported on your platform
#error aligned_malloc not supported on your platform
 ^
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/pcl_macros.h:415:2: error: aligned_free not supported on your platform
#error aligned_free not supported on your platform
 ^
In file included from /usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/src/point_types.cpp:37:
In file included from /usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/point_types.h:354:
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:694:31: error: expected ')'
                        float _L, float _a, float _b) :
                              ^
/usr/include/ctype.h:46:12: note: expanded from macro '_L'
#define _L      0x02
                ^
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:693:34: note: to match this '('
    inline constexpr PointXYZLAB (float _x, float _y, float _z,
                                 ^
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:689:60: error: no matching constructor for initialization of 'pcl::PointXYZLAB'
    inline constexpr PointXYZLAB (const _PointXYZLAB &p) : PointXYZLAB{p.x, p.y, p.z, p.L, p.a, p.b} {}
                                                           ^          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:693:22: note: candidate constructor not viable: requires 4 arguments, but 6 were provided
    inline constexpr PointXYZLAB (float _x, float _y, float _z,
                     ^
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:689:22: note: candidate constructor not viable: requires single argument 'p', but 6 arguments were provided
    inline constexpr PointXYZLAB (const _PointXYZLAB &p) : PointXYZLAB{p.x, p.y, p.z, p.L, p.a, p.b} {}
                     ^
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:687:10: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 6 were provided
  struct PointXYZLAB : public _PointXYZLAB
         ^
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:687:10: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 6 were provided
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:691:22: note: candidate constructor not viable: requires 0 arguments, but 6 were provided
    inline constexpr PointXYZLAB() : PointXYZLAB{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f} {}
                     ^
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:691:38: error: no matching constructor for initialization of 'pcl::PointXYZLAB'
    inline constexpr PointXYZLAB() : PointXYZLAB{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f} {}
                                     ^          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:693:22: note: candidate constructor not viable: requires 4 arguments, but 6 were provided
    inline constexpr PointXYZLAB (float _x, float _y, float _z,
                     ^
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:689:22: note: candidate constructor not viable: requires single argument 'p', but 6 arguments were provided
    inline constexpr PointXYZLAB (const _PointXYZLAB &p) : PointXYZLAB{p.x, p.y, p.z, p.L, p.a, p.b} {}
                     ^
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:687:10: note: candidate constructor (the implicit copy constructor) not viable: requires 1 argument, but 6 were provided
  struct PointXYZLAB : public _PointXYZLAB
         ^
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:687:10: note: candidate constructor (the implicit move constructor) not viable: requires 1 argument, but 6 were provided
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:691:22: note: candidate constructor not viable: requires 0 arguments, but 6 were provided
    inline constexpr PointXYZLAB() : PointXYZLAB{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f} {}
                     ^
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:695:49: error: use of undeclared identifier '_a'
      _PointXYZLAB{ {{_x, _y, _z, 1.0f}}, {{_L, _a, _b}} } {}
                                                ^
/usr/ports/pobj/pcl-1.14.0/pcl-pcl-1.14.0/common/include/pcl/impl/point_types.hpp:695:53: error: use of undeclared identifier '_b'
      _PointXYZLAB{ {{_x, _y, _z, 1.0f}}, {{_L, _a, _b}} } {}
                                                    ^
7 errors generated.
ninja: build stopped: subcommand failed.

*** Error 1 in . (/usr/ports/devel/cmake/cmake.port.mk:46 'do-build')
*** Error 2 in . (/usr/ports/infrastructure/mk/bsd.port.mk:3055 '/usr/ports/pobj/pcl-1.14.0/build-amd64/.build_done')
*** Error 2 in /home/johannes/repos/ports/main/graphics/pcl (/usr/ports/infrastructure/mk/bsd.port.mk:2702 'all')

```