### PR TITLE
UniformSampling Filter | add a minimum number of points required for a voxel option

### DIFF
--- a/filters/include/pcl/filters/impl/uniform_sampling.hpp
+++ b/filters/include/pcl/filters/impl/uniform_sampling.hpp
@@ -138,14 +138,14 @@ pcl::UniformSampling<PointT>::applyFilter (PointCloud &output)
 
   // Second pass: go over all leaves and copy data
   output.resize (leaves_.size ());
-  int cp = 0;
+  std::size_t cp = 0;
 
   for (const auto& leaf : leaves_)
   {
     if (leaf.second.count >= min_points_per_voxel_)
       output[cp++] = (*input_)[leaf.second.idx];
   }
-  output.width = output.size ();
+  output.resize (cp);
 }
 
 #define PCL_INSTANTIATE_UniformSampling(T) template class PCL_EXPORTS pcl::UniformSampling<T>;

--- a/filters/include/pcl/filters/impl/uniform_sampling.hpp
+++ b/filters/include/pcl/filters/impl/uniform_sampling.hpp
@@ -104,6 +104,10 @@ pcl::UniformSampling<PointT>::applyFilter (PointCloud &output)
     // Compute the leaf index
     int idx = (ijk - min_b_).dot (divb_mul_);
     Leaf& leaf = leaves_[idx];
+
+    // Increment the count of points in this voxel
+    ++leaf.count;
+
     // First time we initialize the index
     if (leaf.idx == -1)
     {
@@ -137,7 +141,10 @@ pcl::UniformSampling<PointT>::applyFilter (PointCloud &output)
   int cp = 0;
 
   for (const auto& leaf : leaves_)
-    output[cp++] = (*input_)[leaf.second.idx];
+  {
+    if (leaf.second.count >= min_points_per_voxel_)
+      output[cp++] = (*input_)[leaf.second.idx];
+  }
   output.width = output.size ();
 }
 

--- a/filters/include/pcl/filters/uniform_sampling.h
+++ b/filters/include/pcl/filters/uniform_sampling.h
@@ -108,12 +108,24 @@ namespace pcl
         search_radius_ = radius;
       }
 
+      /** \brief Set the minimum number of points required for a voxel to be used.
+        * \param[in] min_points_per_voxel the minimum number of points for required for a voxel to be used
+        */
+      inline void
+      setMinimumPointsNumberPerVoxel (unsigned int min_points_per_voxel) { min_points_per_voxel_ = min_points_per_voxel; }
+
+      /** \brief Return the minimum number of points required for a voxel to be used.
+        */
+      inline unsigned int
+      getMinimumPointsNumberPerVoxel () const { return min_points_per_voxel_; }
+
     protected:
       /** \brief Simple structure to hold an nD centroid and the number of points in a leaf. */
       struct Leaf
       {
         Leaf () = default;
         int idx{-1};
+        int count{0};
       };
 
       /** \brief The 3D grid leaves. */
@@ -130,6 +142,9 @@ namespace pcl
 
       /** \brief The nearest neighbors search radius for each point. */
       double search_radius_{0.0};
+
+      /** \brief Minimum number of points per voxel for the centroid to be computed */
+      unsigned int min_points_per_voxel_{0};
 
       /** \brief Downsample a Point Cloud using a voxelized grid approach
         * \param[out] output the resultant point cloud message

--- a/filters/include/pcl/filters/uniform_sampling.h
+++ b/filters/include/pcl/filters/uniform_sampling.h
@@ -125,7 +125,7 @@ namespace pcl
       {
         Leaf () = default;
         int idx{-1};
-        int count{0};
+        unsigned int count{0};
       };
 
       /** \brief The 3D grid leaves. */
@@ -143,7 +143,7 @@ namespace pcl
       /** \brief The nearest neighbors search radius for each point. */
       double search_radius_{0.0};
 
-      /** \brief Minimum number of points per voxel for the centroid to be computed */
+      /** \brief Minimum number of points per voxel. */
       unsigned int min_points_per_voxel_{0};
 
       /** \brief Downsample a Point Cloud using a voxelized grid approach


### PR DESCRIPTION
### Description

This pull request modifies the `UniformSampling` filter to include a `min_points_per_voxel_` filter. This allows users to specify a minimum number of points that a voxel must contain to be included in the output.

These changes allow users to filter out voxels that contain too few points, which can be useful in situations where such voxels are likely to be noise.