### PR TITLE
Preparation for default hidden visibility on gcc

### DIFF
--- a/apps/3d_rec_framework/src/pipeline/global_nn_classifier.cpp
+++ b/apps/3d_rec_framework/src/pipeline/global_nn_classifier.cpp
@@ -9,13 +9,16 @@
 #include <pcl/apps/3d_rec_framework/utils/metrics.h>
 
 // Instantiation
-template class pcl::rec_3d_framework::
-    GlobalNNPipeline<flann::L1, pcl::PointXYZ, pcl::VFHSignature308>;
-template class pcl::rec_3d_framework::GlobalNNPipeline<
-    Metrics::HistIntersectionUnionDistance,
-    pcl::PointXYZ,
-    pcl::VFHSignature308>;
-template class pcl::rec_3d_framework::
-    GlobalNNPipeline<flann::L1, pcl::PointXYZ, pcl::ESFSignature640>;
+// GlobalClassifier is the parent class of GlobalNNPipeline. They must be instantiated
+// in this order, otherwise visibility attributes of the former are not applied
+// correctly.
+template class PCL_EXPORTS pcl::rec_3d_framework::GlobalClassifier<pcl::PointXYZ>;
 
-template class pcl::rec_3d_framework::GlobalClassifier<pcl::PointXYZ>;
+template class PCL_EXPORTS pcl::rec_3d_framework::
+    GlobalNNPipeline<flann::L1, pcl::PointXYZ, pcl::VFHSignature308>;
+template class PCL_EXPORTS
+    pcl::rec_3d_framework::GlobalNNPipeline<Metrics::HistIntersectionUnionDistance,
+                                            pcl::PointXYZ,
+                                            pcl::VFHSignature308>;
+template class PCL_EXPORTS pcl::rec_3d_framework::
+    GlobalNNPipeline<flann::L1, pcl::PointXYZ, pcl::ESFSignature640>;

--- a/features/include/pcl/features/moment_of_inertia_estimation.h
+++ b/features/include/pcl/features/moment_of_inertia_estimation.h
@@ -352,7 +352,7 @@ namespace pcl
   };
 }
 
-#define PCL_INSTANTIATE_MomentOfInertiaEstimation(T) template class pcl::MomentOfInertiaEstimation<T>;
+#define PCL_INSTANTIATE_MomentOfInertiaEstimation(T) template class PCL_EXPORTS pcl::MomentOfInertiaEstimation<T>;
 
 #ifdef PCL_NO_PRECOMPILE
 #include <pcl/features/impl/moment_of_inertia_estimation.hpp>

--- a/features/include/pcl/features/rops_estimation.h
+++ b/features/include/pcl/features/rops_estimation.h
@@ -227,7 +227,7 @@ namespace pcl
   };
 }
 
-#define PCL_INSTANTIATE_ROPSEstimation(InT, OutT) template class pcl::ROPSEstimation<InT, OutT>;
+#define PCL_INSTANTIATE_ROPSEstimation(InT, OutT) template class PCL_EXPORTS pcl::ROPSEstimation<InT, OutT>;
 
 #ifdef PCL_NO_PRECOMPILE
 #include <pcl/features/impl/rops_estimation.hpp>

--- a/recognition/src/implicit_shape_model.cpp
+++ b/recognition/src/implicit_shape_model.cpp
@@ -43,6 +43,6 @@
 #include <pcl/recognition/impl/implicit_shape_model.hpp>
 
 // Instantiations of specific point types
-template class pcl::features::ISMVoteList<pcl::PointXYZ>;
+template class PCL_EXPORTS pcl::features::ISMVoteList<pcl::PointXYZ>;
 
-template class pcl::ism::ImplicitShapeModelEstimation<153, pcl::PointXYZ, pcl::Normal>;
+template class PCL_EXPORTS pcl::ism::ImplicitShapeModelEstimation<153, pcl::PointXYZ, pcl::Normal>;

--- a/segmentation/include/pcl/segmentation/impl/approximate_progressive_morphological_filter.hpp
+++ b/segmentation/include/pcl/segmentation/impl/approximate_progressive_morphological_filter.hpp
@@ -266,7 +266,7 @@ pcl::ApproximateProgressiveMorphologicalFilter<PointT>::extract (Indices& ground
 }
 
 
-#define PCL_INSTANTIATE_ApproximateProgressiveMorphologicalFilter(T) template class pcl::ApproximateProgressiveMorphologicalFilter<T>;
+#define PCL_INSTANTIATE_ApproximateProgressiveMorphologicalFilter(T) template class PCL_EXPORTS pcl::ApproximateProgressiveMorphologicalFilter<T>;
 
 #endif    // PCL_SEGMENTATION_APPROXIMATE_PROGRESSIVE_MORPHOLOGICAL_FILTER_HPP_
 

--- a/segmentation/include/pcl/segmentation/impl/crf_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/crf_segmentation.hpp
@@ -595,6 +595,6 @@ pcl::CrfSegmentation<PointT>::segmentPoints (pcl::PointCloud<pcl::PointXYZRGBL> 
 
 }
 
-#define PCL_INSTANTIATE_CrfSegmentation(T) template class pcl::CrfSegmentation<T>;
+#define PCL_INSTANTIATE_CrfSegmentation(T) template class PCL_EXPORTS pcl::CrfSegmentation<T>;
 
 #endif    // PCL_CRF_SEGMENTATION_HPP_

--- a/segmentation/include/pcl/segmentation/impl/min_cut_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/min_cut_segmentation.hpp
@@ -579,6 +579,6 @@ pcl::MinCutSegmentation<PointT>::getColoredCloud ()
   return (colored_cloud);
 }
 
-#define PCL_INSTANTIATE_MinCutSegmentation(T) template class pcl::MinCutSegmentation<T>;
+#define PCL_INSTANTIATE_MinCutSegmentation(T) template class PCL_EXPORTS pcl::MinCutSegmentation<T>;
 
 #endif    // PCL_SEGMENTATION_MIN_CUT_SEGMENTATION_HPP_

--- a/segmentation/include/pcl/segmentation/impl/progressive_morphological_filter.hpp
+++ b/segmentation/include/pcl/segmentation/impl/progressive_morphological_filter.hpp
@@ -134,7 +134,7 @@ pcl::ProgressiveMorphologicalFilter<PointT>::extract (Indices& ground)
   deinitCompute ();
 }
 
-#define PCL_INSTANTIATE_ProgressiveMorphologicalFilter(T) template class pcl::ProgressiveMorphologicalFilter<T>;
+#define PCL_INSTANTIATE_ProgressiveMorphologicalFilter(T) template class PCL_EXPORTS pcl::ProgressiveMorphologicalFilter<T>;
 
 #endif    // PCL_SEGMENTATION_PROGRESSIVE_MORPHOLOGICAL_FILTER_HPP_
 

--- a/segmentation/include/pcl/segmentation/impl/region_growing.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing.hpp
@@ -705,5 +705,5 @@ pcl::RegionGrowing<PointT, NormalT>::getColoredCloudRGBA ()
   return (colored_cloud);
 }
 
-#define PCL_INSTANTIATE_RegionGrowing(T) template class pcl::RegionGrowing<T, pcl::Normal>;
+#define PCL_INSTANTIATE_RegionGrowing(T) template class PCL_EXPORTS pcl::RegionGrowing<T, pcl::Normal>;
 

--- a/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
+++ b/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
@@ -420,6 +420,6 @@ pcl::UnaryClassifier<PointT>::segment (pcl::PointCloud<pcl::PointXYZRGBL>::Ptr &
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-#define PCL_INSTANTIATE_UnaryClassifier(T) template class pcl::UnaryClassifier<T>;
+#define PCL_INSTANTIATE_UnaryClassifier(T) template class PCL_EXPORTS pcl::UnaryClassifier<T>;
 
 #endif    // PCL_UNARY_CLASSIFIER_HPP_

--- a/segmentation/src/crf_segmentation.cpp
+++ b/segmentation/src/crf_segmentation.cpp
@@ -43,6 +43,6 @@
 #include <pcl/segmentation/impl/crf_segmentation.hpp>
 
 // Instantiations of specific point types
-template class pcl::CrfSegmentation<pcl::PointXYZRGB>;
-template class pcl::CrfSegmentation<pcl::PointXYZRGBA>;
-template class pcl::CrfSegmentation<pcl::PointXYZRGBNormal>;
+template class PCL_EXPORTS pcl::CrfSegmentation<pcl::PointXYZRGB>;
+template class PCL_EXPORTS pcl::CrfSegmentation<pcl::PointXYZRGBA>;
+template class PCL_EXPORTS pcl::CrfSegmentation<pcl::PointXYZRGBNormal>;

--- a/segmentation/src/region_growing_rgb.cpp
+++ b/segmentation/src/region_growing_rgb.cpp
@@ -43,7 +43,7 @@
 #include <pcl/segmentation/impl/region_growing_rgb.hpp>
 
 // Instantiations of specific point types
-template class pcl::RegionGrowingRGB<pcl::PointXYZRGBA>;
-template class pcl::RegionGrowingRGB<pcl::PointXYZRGB>;
-template class pcl::RegionGrowingRGB<pcl::PointXYZRGBL>;
-template class pcl::RegionGrowingRGB<pcl::PointXYZRGBNormal>;
+template class PCL_EXPORTS pcl::RegionGrowingRGB<pcl::PointXYZRGBA>;
+template class PCL_EXPORTS pcl::RegionGrowingRGB<pcl::PointXYZRGB>;
+template class PCL_EXPORTS pcl::RegionGrowingRGB<pcl::PointXYZRGBL>;
+template class PCL_EXPORTS pcl::RegionGrowingRGB<pcl::PointXYZRGBNormal>;

--- a/tracking/src/coherence.cpp
+++ b/tracking/src/coherence.cpp
@@ -45,13 +45,15 @@
 #include <pcl/point_types.h>
 
 // clang-format off
-PCL_INSTANTIATE(ApproxNearestPairPointCloudCoherence, PCL_XYZ_POINT_TYPES)
 PCL_INSTANTIATE(DistanceCoherence, PCL_XYZ_POINT_TYPES)
 PCL_INSTANTIATE(HSVColorCoherence,
                 (pcl::PointXYZRGB)
                 (pcl::PointXYZRGBNormal)
                 (pcl::PointXYZRGBA))
 PCL_INSTANTIATE(NearestPairPointCloudCoherence, PCL_XYZ_POINT_TYPES)
+// NearestPairPointCloudCoherence is the parent class of ApproxNearestPairPointCloudCoherence.
+// They must be instantiated in this order, otherwise visibility attributes of the former are not applied correctly.
+PCL_INSTANTIATE(ApproxNearestPairPointCloudCoherence, PCL_XYZ_POINT_TYPES)
 PCL_INSTANTIATE(NormalCoherence, PCL_NORMAL_POINT_TYPES)
 // clang-format on
 #endif // PCL_NO_PRECOMPILE


### PR DESCRIPTION
Add PCL_EXPORTS where missing in template instantiations, change order of template instantiations where otherwise the visibility attribute of the parent class would be overwritten by the child class.
This is split off from #5779 which has become a bit large