### PR TITLE
[GPU] Remove pcl_cuda interface library as it is not necessary and was only used for some gpu applications.

### DIFF
--- a/cmake/pcl_find_cuda.cmake
+++ b/cmake/pcl_find_cuda.cmake
@@ -65,20 +65,13 @@ if(CUDA_FOUND)
     cmake_policy(SET CMP0104 NEW)
     set(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCH_BIN})
     message(STATUS "CMAKE_CUDA_ARCHITECTURES: ${CMAKE_CUDA_ARCHITECTURES}")
-    
-    #Add empty project as its not required with newer CMake
-    add_library(pcl_cuda INTERFACE)
   else()
     # Generate SASS
     set(CMAKE_CUDA_ARCHITECTURES ${CUDA_ARCH_BIN})
     # Generate PTX for last architecture
     list(GET CUDA_ARCH_BIN -1 ver)
     set(CMAKE_CUDA_FLAGS "${CMAKE_CUDA_FLAGS} -gencode arch=compute_${ver},code=compute_${ver}")
-    message(STATUS "CMAKE_CUDA_FLAGS: ${CMAKE_CUDA_FLAGS}")
-    
-    add_library(pcl_cuda INTERFACE)
-    target_include_directories(pcl_cuda INTERFACE ${CUDA_TOOLKIT_INCLUDE})
-    
+    message(STATUS "CMAKE_CUDA_FLAGS: ${CMAKE_CUDA_FLAGS}")   
   endif ()
 else()
   message(STATUS "CUDA was not found.")

--- a/gpu/kinfu/CMakeLists.txt
+++ b/gpu/kinfu/CMakeLists.txt
@@ -29,7 +29,7 @@ set(LIB_NAME "pcl_${SUBSYS_NAME}")
 include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURCE_DIR}/src")
 
 PCL_CUDA_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs} ${cuda})
-target_link_libraries(${LIB_NAME} pcl_cuda pcl_gpu_containers)
+target_link_libraries(${LIB_NAME} pcl_gpu_containers)
 
 target_compile_options(${LIB_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--ftz=true;--prec-div=false;--prec-sqrt=false>)
 

--- a/gpu/kinfu_large_scale/CMakeLists.txt
+++ b/gpu/kinfu_large_scale/CMakeLists.txt
@@ -33,7 +33,7 @@ include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include" "${CMAKE_CURRENT_SOURC
 
 PCL_CUDA_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs} ${impl_incs} ${cuda})
 
-target_link_libraries(${LIB_NAME} pcl_cuda pcl_common pcl_io pcl_gpu_utils pcl_gpu_containers pcl_gpu_octree pcl_octree pcl_filters)
+target_link_libraries(${LIB_NAME} pcl_common pcl_io pcl_gpu_utils pcl_gpu_containers pcl_gpu_octree pcl_octree pcl_filters)
 
 target_compile_options(${LIB_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--ftz=true;--prec-div=false;--prec-sqrt=false>)
 

--- a/gpu/people/CMakeLists.txt
+++ b/gpu/people/CMakeLists.txt
@@ -56,7 +56,7 @@ include_directories(
 set(LIB_NAME "pcl_${SUBSYS_NAME}")
 
 PCL_CUDA_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${hdrs} ${srcs_cuda})
-target_link_libraries(${LIB_NAME} pcl_cuda pcl_common pcl_search pcl_surface pcl_segmentation pcl_features pcl_sample_consensus pcl_gpu_utils pcl_gpu_containers ${CUDA_CUDART_LIBRARY} ${CUDA_npp_LIBRARY})
+target_link_libraries(${LIB_NAME} pcl_common pcl_search pcl_surface pcl_segmentation pcl_features pcl_sample_consensus pcl_gpu_utils pcl_gpu_containers ${CUDA_CUDART_LIBRARY} ${CUDA_npp_LIBRARY})
 
 if(UNIX OR APPLE)
   target_compile_options(${LIB_NAME} INTERFACE $<$<COMPILE_LANGUAGE:CUDA>:"-Xcompiler=-fPIC">)


### PR DESCRIPTION
CUDA_TOOLKIT_INCLUDE is used in PCL_CUDA_ADD_EXECUTABLE/LIBRARY.