### PR TITLE
fix pcl::squaredEuclideanDistance already defined in grabcut_2d.cpp.obj

### DIFF
--- a/segmentation/include/pcl/segmentation/impl/grabcut_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/grabcut_segmentation.hpp
@@ -48,8 +48,8 @@ namespace pcl
 {
 
 template <>
-float squaredEuclideanDistance (const pcl::segmentation::grabcut::Color &c1,
-                                const pcl::segmentation::grabcut::Color &c2)
+inline float squaredEuclideanDistance (const pcl::segmentation::grabcut::Color &c1,
+                                       const pcl::segmentation::grabcut::Color &c2)
 {
   return ((c1.r-c2.r)*(c1.r-c2.r)+(c1.g-c2.g)*(c1.g-c2.g)+(c1.b-c2.b)*(c1.b-c2.b));
 }


### PR DESCRIPTION
Detailed error message:

```log
FAILED: bin/pcl_grabcut_2d.exe
C:\WINDOWS\system32\cmd.exe /C "cd . && "C:\Program Files\CMake\bin\cmake.exe" -E vs_link_exe --intdir=apps\CMakeFiles\pcl_grabcut_2d.dir --rc=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\rc.exe --mt=C:\PROGRA~2\WI3CF2~1\10\bin\100226~1.0\x64\mt.exe --manifests  -- C:\PROGRA~1\MIB055~1\2022\COMMUN~1\VC\Tools\MSVC\1439~1.335\bin\Hostx64\x64\link.exe  @CMakeFiles\pcl_grabcut_2d.rsp  /out:bin\pcl_grabcut_2d.exe /implib:lib\pcl_grabcut_2d.lib /pdb:bin\pcl_grabcut_2d.pdb /version:0.0 /machine:x64 /nologo /DEBUG /INCREMENTAL:NO /OPT:REF /OPT:ICF   /subsystem:console  && cd ."
LINK: command "C:\PROGRA~1\MIB055~1\2022\COMMUN~1\VC\Tools\MSVC\1439~1.335\bin\Hostx64\x64\link.exe @CMakeFiles\pcl_grabcut_2d.rsp /out:bin\pcl_grabcut_2d.exe /implib:lib\pcl_grabcut_2d.lib /pdb:bin\pcl_grabcut_2d.pdb /version:0.0 /machine:x64 /nologo /DEBUG /INCREMENTAL:NO /OPT:REF /OPT:ICF /subsystem:console /MANIFEST:EMBED,ID=1" failed (exit code 1169) with the following output:
pcl_segmentation.lib(grabcut_segmentation.cpp.obj) : error LNK2005: "float __cdecl pcl::squaredEuclideanDistance<struct pcl::segmentation::grabcut::Color,struct pcl::segmentation::grabcut::Color>(struct pcl::segmentation::grabcut::Color const &,struct pcl::segmentation::grabcut::Color const &)" (??$squaredEuclideanDistance@UColor@grabcut@segmentation@pcl@@U1234@@pcl@@YAMAEBUColor@grabcut@segmentation@0@0@Z) already defined in grabcut_2d.cpp.obj

bin\pcl_grabcut_2d.exe : fatal error LNK1169: one or more multiply defined symbols found
```
as reported in https://github.com/microsoft/vcpkg/issues/37624.