### PR TITLE
gpu_kinfu_large_scale: fix bad dependency on vtk.pc

### DIFF
--- a/gpu/kinfu_large_scale/CMakeLists.txt
+++ b/gpu/kinfu_large_scale/CMakeLists.txt
@@ -37,7 +37,7 @@ target_link_libraries(${LIB_NAME} pcl_cuda pcl_common pcl_io pcl_gpu_utils pcl_g
 
 target_compile_options(${LIB_NAME} PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--ftz=true;--prec-div=false;--prec-sqrt=false>)
 
-PCL_MAKE_PKGCONFIG(${LIB_NAME} COMPONENT ${SUBSYS_NAME} DESC ${SUBSYS_DESC} PCL_DEPS ${SUBSYS_DEPS} EXT_DEPS ${EXT_DEPS})
+PCL_MAKE_PKGCONFIG(${LIB_NAME} COMPONENT ${SUBSYS_NAME} DESC ${SUBSYS_DESC} PCL_DEPS ${SUBSYS_DEPS} EXT_DEPS "")
 
 # Install include files
 PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_PATH}" ${incs})


### PR DESCRIPTION
vtk.pc does not exist, so vtk should not appear in PCL_MAKE_PKGCONFIG as an external dependency

See also:
https://github.com/PointCloudLibrary/pcl/commit/fa56699510a926d0c669afc1e346b4be2dc9e855
https://github.com/microsoft/vcpkg/issues/37655