### PR TITLE
fixed setShapeRenderingProperties(PCL_VISUALIZER_FONT_SIZE)

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1760,7 +1760,7 @@ pcl::visualization::PCLVisualizer::setShapeRenderingProperties (
   }
   // Get the actor pointer
   vtkActor* actor = vtkActor::SafeDownCast (am_it->second);
-  if (!actor)
+  if (!actor && property != PCL_VISUALIZER_FONT_SIZE) // vtkTextActor is not a subclass of vtkActor
     return (false);
 
   switch (property)


### PR DESCRIPTION

It always returns false. Because vtkTextActor is not a subclass of vtkActor, the actor is just empty.