### PR TITLE
fix build with latest Eigen

### DIFF
--- a/common/include/pcl/common/distances.h
+++ b/common/include/pcl/common/distances.h
@@ -62,7 +62,7 @@ namespace pcl
     * \ingroup common
     */
   PCL_EXPORTS void
-  lineToLineSegment (const Eigen::VectorXf &line_a, const Eigen::VectorXf &line_b, 
+  lineToLineSegment (const Eigen::VectorXf &line_a, const Eigen::VectorXf &line_b,
                      Eigen::Vector4f &pt1_seg, Eigen::Vector4f &pt2_seg);
 
   /** \brief Get the square distance from a point to a line (represented by a point and a direction)
@@ -76,7 +76,7 @@ namespace pcl
   {
     // Calculate the distance from the point to the line
     // D = ||(P2-P1) x (P1-P0)|| / ||P2-P1|| = norm (cross (p2-p1, p1-p0)) / norm(p2-p1)
-    return (line_dir.cross3 (line_pt - pt)).squaredNorm () / line_dir.squaredNorm ();
+    return (line_dir.cross3 (Eigen::Vector4f(line_pt - pt))).squaredNorm () / line_dir.squaredNorm ();
   }
 
   /** \brief Get the square distance from a point to a line (represented by a point and a direction)
@@ -92,7 +92,7 @@ namespace pcl
   {
     // Calculate the distance from the point to the line
     // D = ||(P2-P1) x (P1-P0)|| / ||P2-P1|| = norm (cross (p2-p1, p1-p0)) / norm(p2-p1)
-    return (line_dir.cross3 (line_pt - pt)).squaredNorm () / sqr_length;
+    return (line_dir.cross3 (Eigen::Vector4f(line_pt - pt))).squaredNorm () / sqr_length;
   }
 
   /** \brief Obtain the maximum segment in a given set of points, and return the minimum and maximum points.
@@ -103,7 +103,7 @@ namespace pcl
     * \ingroup common
     */
   template <typename PointT> double inline
-  getMaxSegment (const pcl::PointCloud<PointT> &cloud, 
+  getMaxSegment (const pcl::PointCloud<PointT> &cloud,
                  PointT &pmin, PointT &pmax)
   {
     double max_dist = std::numeric_limits<double>::min ();
@@ -114,8 +114,8 @@ namespace pcl
     {
       for (std::size_t j = i; j < cloud.size (); ++j)
       {
-        // Compute the distance 
-        double dist = (cloud[i].getVector4fMap () - 
+        // Compute the distance
+        double dist = (cloud[i].getVector4fMap () -
                        cloud[j].getVector4fMap ()).squaredNorm ();
         if (dist <= max_dist)
           continue;
@@ -133,7 +133,7 @@ namespace pcl
     pmax = cloud[i_max];
     return (std::sqrt (max_dist));
   }
- 
+
   /** \brief Obtain the maximum segment in a given set of points, and return the minimum and maximum points.
     * \param[in] cloud the point cloud dataset
     * \param[in] indices a set of point indices to use from \a cloud
@@ -154,8 +154,8 @@ namespace pcl
     {
       for (std::size_t j = i; j < indices.size (); ++j)
       {
-        // Compute the distance 
-        double dist = (cloud[indices[i]].getVector4fMap () - 
+        // Compute the distance
+        double dist = (cloud[indices[i]].getVector4fMap () -
                        cloud[indices[j]].getVector4fMap ()).squaredNorm ();
         if (dist <= max_dist)
           continue;

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_line.hpp
@@ -126,7 +126,7 @@ pcl::SampleConsensusModelLine<PointT>::getDistancesToModel (
     // Calculate the distance from the point to the line
     // D = ||(P2-P1) x (P1-P0)|| / ||P2-P1|| = norm (cross (p2-p1, p2-p0)) / norm(p2-p1)
     // Need to estimate sqrt here to keep MSAC and friends general
-    distances[i] = sqrt ((line_pt - (*input_)[(*indices_)[i]].getVector4fMap ()).cross3 (line_dir).squaredNorm ());
+    distances[i] = sqrt (Eigen::Vector4f(line_pt - (*input_)[(*indices_)[i]].getVector4fMap ()).cross3 (line_dir).squaredNorm ());
   }
 }
 
@@ -156,7 +156,7 @@ pcl::SampleConsensusModelLine<PointT>::selectWithinDistance (
   {
     // Calculate the distance from the point to the line
     // D = ||(P2-P1) x (P1-P0)|| / ||P2-P1|| = norm (cross (p2-p1, p2-p0)) / norm(p2-p1)
-    double sqr_distance = (line_pt - (*input_)[(*indices_)[i]].getVector4fMap ()).cross3 (line_dir).squaredNorm ();
+    double sqr_distance = Eigen::Vector4f(line_pt - (*input_)[(*indices_)[i]].getVector4fMap ()).cross3 (line_dir).squaredNorm ();
 
     if (sqr_distance < sqr_threshold)
     {
@@ -190,7 +190,7 @@ pcl::SampleConsensusModelLine<PointT>::countWithinDistance (
   {
     // Calculate the distance from the point to the line
     // D = ||(P2-P1) x (P1-P0)|| / ||P2-P1|| = norm (cross (p2-p1, p2-p0)) / norm(p2-p1)
-    double sqr_distance = (line_pt - (*input_)[(*indices_)[i]].getVector4fMap ()).cross3 (line_dir).squaredNorm ();
+    double sqr_distance = Eigen::Vector4f(line_pt - (*input_)[(*indices_)[i]].getVector4fMap ()).cross3 (line_dir).squaredNorm ();
 
     if (sqr_distance < sqr_threshold)
       nr_p++;
@@ -340,7 +340,7 @@ pcl::SampleConsensusModelLine<PointT>::doSamplesVerifyModel (
   {
     // Calculate the distance from the point to the line
     // D = ||(P2-P1) x (P1-P0)|| / ||P2-P1|| = norm (cross (p2-p1, p2-p0)) / norm(p2-p1)
-    if ((line_pt - (*input_)[index].getVector4fMap ()).cross3 (line_dir).squaredNorm () > sqr_threshold)
+    if (Eigen::Vector4f(line_pt - (*input_)[index].getVector4fMap ()).cross3 (line_dir).squaredNorm () > sqr_threshold)
       return (false);
   }
 
@@ -350,4 +350,3 @@ pcl::SampleConsensusModelLine<PointT>::doSamplesVerifyModel (
 #define PCL_INSTANTIATE_SampleConsensusModelLine(T) template class PCL_EXPORTS pcl::SampleConsensusModelLine<T>;
 
 #endif    // PCL_SAMPLE_CONSENSUS_IMPL_SAC_MODEL_LINE_H_
-

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_stick.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_stick.hpp
@@ -127,7 +127,7 @@ pcl::SampleConsensusModelStick<PointT>::getDistancesToModel (
   {
     // Calculate the distance from the point to the line
     // D = ||(P2-P1) x (P1-P0)|| / ||P2-P1|| = norm (cross (p2-p1, p2-p0)) / norm(p2-p1)
-    float sqr_distance = (line_pt - (*input_)[(*indices_)[i]].getVector4fMap ()).cross3 (line_dir).squaredNorm ();
+    float sqr_distance = Eigen::Vector4f(line_pt - (*input_)[(*indices_)[i]].getVector4fMap ()).cross3 (line_dir).squaredNorm ();
 
     if (sqr_distance < sqr_threshold)
     {
@@ -394,7 +394,7 @@ pcl::SampleConsensusModelStick<PointT>::doSamplesVerifyModel (
   {
     // Calculate the distance from the point to the line
     // D = ||(P2-P1) x (P1-P0)|| / ||P2-P1|| = norm (cross (p2-p1, p2-p0)) / norm(p2-p1)
-    if ((line_pt - (*input_)[index].getVector4fMap ()).cross3 (line_dir).squaredNorm () > sqr_threshold)
+    if (Eigen::Vector4f(line_pt - (*input_)[index].getVector4fMap ()).cross3 (line_dir).squaredNorm () > sqr_threshold)
     {
       return (false);
     }
@@ -406,4 +406,3 @@ pcl::SampleConsensusModelStick<PointT>::doSamplesVerifyModel (
 #define PCL_INSTANTIATE_SampleConsensusModelStick(T) template class PCL_EXPORTS pcl::SampleConsensusModelStick<T>;
 
 #endif    // PCL_SAMPLE_CONSENSUS_IMPL_SAC_MODEL_STICK_H_
-


### PR DESCRIPTION
With the latest Eigen, building PCL failed due to the following error:
```
/home/daizhirui/.cache/paru/clone/pcl-git/src/pcl/common/include/pcl/common/distances.h:79:29:   required from here
/usr/include/eigen3/Eigen/src/Geometry/arch/Geometry_SIMD.h:70:62: error: ‘Alignment’ is not a member of ‘Eigen::internal::traits<Eigen::CwiseBinaryOp<Eigen::internal::scalar_difference_op<float, float>, const Eigen::Matrix<float, 4, 1>, const Eigen::Matrix<float, 4, 1> > >’
   70 |     Packet4f b = rhs_eval.template packet<traits<VectorRhs>::Alignment, Packet4f>(0);
      |
```

This error can be fixed by casting some intermediate results to their proper types in advance.