### PR TITLE
Add option to choose boost filesystem over std filesystem

### DIFF
--- a/cmake/pcl_options.cmake
+++ b/cmake/pcl_options.cmake
@@ -45,6 +45,9 @@ set(PCL_QHULL_REQUIRED_TYPE "DONTCARE" CACHE STRING "Select build type to use ST
 set_property(CACHE PCL_QHULL_REQUIRED_TYPE PROPERTY STRINGS DONTCARE SHARED STATIC)
 mark_as_advanced(PCL_QHULL_REQUIRED_TYPE)
 
+option(PCL_PREFER_BOOST_FILESYSTEM "Prefer boost::filesystem over std::filesystem (if compiled as C++17 or higher, std::filesystem is chosen by default)" OFF)
+mark_as_advanced(PCL_PREFER_BOOST_FILESYSTEM)
+
 # Precompile for a minimal set of point types instead of all.
 option(PCL_ONLY_CORE_POINT_TYPES "Compile explicitly only for a small subset of point types (e.g., pcl::PointXYZ instead of PCL_XYZ_POINT_TYPES)." OFF)
 mark_as_advanced(PCL_ONLY_CORE_POINT_TYPES)

--- a/common/include/pcl/common/pcl_filesystem.h
+++ b/common/include/pcl/common/pcl_filesystem.h
@@ -38,10 +38,12 @@
 
 #pragma once
 
-#if (__cplusplus >= 201703L)
+#if (__cplusplus >= 201703L) && !defined(PCL_PREFER_BOOST_FILESYSTEM)
+#define PCL_USING_STD_FILESYSTEM
 #include <filesystem>
 namespace pcl_fs = std::filesystem;
 #else
+#define PCL_USING_BOOST_FILESYSTEM
 #include <boost/filesystem.hpp>
 namespace pcl_fs = boost::filesystem;
 #endif

--- a/common/include/pcl/common/pcl_filesystem.h
+++ b/common/include/pcl/common/pcl_filesystem.h
@@ -38,6 +38,8 @@
 
 #pragma once
 
+#include <pcl/pcl_config.h> // for PCL_PREFER_BOOST_FILESYSTEM
+
 #if (__cplusplus >= 201703L) && !defined(PCL_PREFER_BOOST_FILESYSTEM)
 #define PCL_USING_STD_FILESYSTEM
 #include <filesystem>

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -71,7 +71,7 @@ pcl::PCDWriter::setLockingPermissions (const std::string &file_name,
 
   try
   {
-#if (__cplusplus >= 201703L)
+#ifdef PCL_USING_STD_FILESYSTEM
     pcl_fs::permissions (pcl_fs::path (file_name), pcl_fs::perms::set_gid, pcl_fs::perm_options::add);
 #else
     pcl_fs::permissions (pcl_fs::path (file_name), pcl_fs::add_perms | pcl_fs::set_gid_on_exe);
@@ -95,7 +95,7 @@ pcl::PCDWriter::resetLockingPermissions (const std::string &file_name,
 #ifndef NO_MANDATORY_LOCKING
   try
   {
-#if (__cplusplus >= 201703L)
+#ifdef PCL_USING_STD_FILESYSTEM
     pcl_fs::permissions (pcl_fs::path (file_name), pcl_fs::perms::set_gid, pcl_fs::perm_options::remove);
 #else
     pcl_fs::permissions (pcl_fs::path (file_name), pcl_fs::remove_perms | pcl_fs::set_gid_on_exe);

--- a/pcl_config.h.in
+++ b/pcl_config.h.in
@@ -54,6 +54,8 @@
 
 #cmakedefine HAVE_ZLIB
 
+#cmakedefine PCL_PREFER_BOOST_FILESYSTEM
+
 /* Precompile for a minimal set of point types instead of all. */
 #cmakedefine PCL_ONLY_CORE_POINT_TYPES
 


### PR DESCRIPTION
Currently, std filesystem is chosen if it is available (if compiled as C++17 or higher). However, it might be good to have the option to choose boost filesystem over std filesystem, even if the latter is available, in case there is some problem with std filesystem.
With this commit, std filesystem is still used if available, unless the user has defined the preprocessor symbol `PCL_PREFER_BOOST_FILESYSTEM`