### PR TITLE
Fix `surface` and `kdtree` CMake includes configuration

### DIFF
--- a/kdtree/CMakeLists.txt
+++ b/kdtree/CMakeLists.txt
@@ -27,9 +27,9 @@ set(impl_incs
 )
 
 set(LIB_NAME "pcl_${SUBSYS_NAME}")
-include_directories("${CMAKE_CURRENT_SOURCE_DIR}/include")
 PCL_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs} ${impl_incs})
 target_link_libraries("${LIB_NAME}" pcl_common FLANN::FLANN)
+target_include_directories("${LIB_NAME}" PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 set(EXT_DEPS flann)
 PCL_MAKE_PKGCONFIG(${LIB_NAME} COMPONENT ${SUBSYS_NAME} DESC ${SUBSYS_DESC} PCL_DEPS ${SUBSYS_DEPS} EXT_DEPS ${EXT_DEPS})
 

--- a/surface/CMakeLists.txt
+++ b/surface/CMakeLists.txt
@@ -175,13 +175,10 @@ set(impl_incs
 
 set(LIB_NAME "pcl_${SUBSYS_NAME}")
 
-include_directories(
-  "${CMAKE_CURRENT_SOURCE_DIR}/include"
-  "${CMAKE_CURRENT_SOURCE_DIR}"
-)
 PCL_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs} ${impl_incs} ${VTK_SMOOTHING_INCLUDES} ${POISSON_INCLUDES} ${OPENNURBS_INCLUDES} ${ON_NURBS_INCLUDES})
 
 target_link_libraries("${LIB_NAME}" pcl_common pcl_search pcl_kdtree pcl_octree ${ON_NURBS_LIBRARIES})
+target_include_directories("${LIB_NAME}" PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 if(VTK_FOUND)
   if(${VTK_VERSION} VERSION_GREATER_EQUAL 9.0)


### PR DESCRIPTION
When configuring PCL with FetchContent, linking target `pcl_surface` does not add include directories. It happens because include directories are added at global scope in PCL CMake configuration which is not applied when loading with FetchContent. The same happens for `pcl_kdtree`.

Instead of adding include directories at global scope, I suggest to add them in the target so linking target automatically adds them.