### PR TITLE
Fix ABI compatibility problems for 1.14.1 release

### DIFF
--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -711,8 +711,8 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
       // Tokenize the line
       pcl::split (st, line, "\t\r ");
 
-      // Ignore comments and lines with only whitespace
-      if (st.empty() || st[0] == "#")
+      // Ignore comments
+      if (st[0] == "#")
         continue;
       // Vertex
       if (st[0] == "v")

--- a/io/src/pcd_io.cpp
+++ b/io/src/pcd_io.cpp
@@ -677,13 +677,7 @@ pcl::PCDReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
   pcl::console::TicToc tt;
   tt.tic ();
 
-  if (file_name.empty ())
-  {
-    PCL_ERROR ("[pcl::PCDReader::read] No file name given!\n");
-    return (-1);
-  }
-
-  if (!pcl_fs::exists (file_name))
+  if (file_name.empty () || !pcl_fs::exists (file_name))
   {
     PCL_ERROR ("[pcl::PCDReader::read] Could not find file '%s'.\n", file_name.c_str ());
     return (-1);

--- a/registration/include/pcl/registration/impl/transformation_estimation_svd.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_svd.hpp
@@ -211,7 +211,7 @@ TransformationEstimationSVD<PointSource, PointTarget, Scalar>::
   Eigen::Matrix<Scalar, 3, 3> R = v * u.transpose();
 
   // Return the correct transformation
-  transformation_matrix.template topLeftCorner<3, 3>() = R;
+  transformation_matrix.topLeftCorner(3, 3) = R;
   const Eigen::Matrix<Scalar, 3, 1> Rc(R * centroid_src.template head<3>());
   transformation_matrix.template block<3, 1>(0, 3) =
       centroid_tgt.template head<3>() - Rc;


### PR DESCRIPTION
Partially revert https://github.com/PointCloudLibrary/pcl/pull/5974 and https://github.com/PointCloudLibrary/pcl/pull/5988 and https://github.com/PointCloudLibrary/pcl/pull/5907 After the 1.14.1 release, we can re-apply these changes. The ABI checker reported:
`The parameter file_name became passed in r12 register instead of r13. Applications will read the wrong memory block instead of the parameter value.` and `The parameter cloud_tgt_demean became passed in r12 register instead of r13.` These changes are not super important, so I think it doesn't hurt to temporarily revert them to achieve 100% ABI compatibility between 1.14.0 and 1.14.1.