### PR TITLE
Remove deprecated readdir_r

### DIFF
--- a/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
@@ -15324,11 +15324,8 @@ const wchar_t* ON_FileIterator::NextFile()
       NULL is returned and errno is not changed. If an error occurs,
       NULL is returned and errno is set appropriately.
     */
-    errno = 0;
     struct dirent* dp = 0;
     dp = readdir(m_dir);
-    if ( 0 != errno )
-      break;
     if ( 0 == dp )
       break;
     if ( 0 == dp->d_name[0] )

--- a/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
+++ b/surface/src/3rdparty/opennurbs/opennurbs_archive.cpp
@@ -15318,14 +15318,23 @@ const wchar_t* ON_FileIterator::NextFile()
   for(;;)
   {
     current_file_attributes = 0;
+    /*
+      from readdir man page:
+      If the end of the directory stream is reached,
+      NULL is returned and errno is not changed. If an error occurs,
+      NULL is returned and errno is set appropriately.
+    */
+    errno = 0;
     struct dirent* dp = 0;
-    int readdir_errno = readdir_r(m_dir, &m_dirent, &dp);
-    if ( 0 !=  readdir_errno )
+    dp = readdir(m_dir);
+    if ( 0 != errno )
       break;
     if ( 0 == dp )
       break;
-    if ( 0 == m_dirent.d_name[0] )
+    if ( 0 == dp->d_name[0] )
       break;
+
+    m_dirent = *dp;
 
     if ( IsDotOrDotDotDir(m_dirent.d_name) )
       continue;


### PR DESCRIPTION
`readdir_r` was deprecated in GNU glibc 2.23 and later and is replaced by `readdir`.