### PR TITLE
Faster octree radiusSearch

### DIFF
--- a/octree/include/pcl/octree/impl/octree_pointcloud.hpp
+++ b/octree/include/pcl/octree/impl/octree_pointcloud.hpp
@@ -886,12 +886,9 @@ pcl::octree::OctreePointCloud<PointT, LeafContainerT, BranchContainerT, OctreeT>
   min_pt(2) = static_cast<float>(static_cast<double>(key_arg.z) * voxel_side_len +
                                  this->min_z_);
 
-  max_pt(0) = static_cast<float>(static_cast<double>(key_arg.x + 1) * voxel_side_len +
-                                 this->min_x_);
-  max_pt(1) = static_cast<float>(static_cast<double>(key_arg.y + 1) * voxel_side_len +
-                                 this->min_y_);
-  max_pt(2) = static_cast<float>(static_cast<double>(key_arg.z + 1) * voxel_side_len +
-                                 this->min_z_);
+  max_pt(0) = min_pt(0) + voxel_side_len;
+  max_pt(1) = min_pt(1) + voxel_side_len;
+  max_pt(2) = min_pt(2) + voxel_side_len;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
... by improving the check whether an octree node might contain a point within radius. Previously this was done by a sphere around the node center (some nodes were checked although that would not have been necessary), now this is done exact (like a rounded cube).

Benchmarks:
NormalEstimation (without OpenMP) with octree:
| NormalEstimation  | Old       | New        |
|-------------------|-----------|------------|
| r=0.01, cloud=milk| 914 ms    | 756 ms     |
| r=0.01, cloud=mug | 1133 ms   | 881 ms     |
| r=0.02, cloud=milk| 1979 ms   | 1784 ms    |
| r=0.02, cloud=mug | 2642 ms   | 2244 ms    |

Calling radiusSearch on every (valid) point of a cloud (r is tuned so that 5 and 50 neighbours are found on average, respectively):
| Search          | Old       | New        |
|-----------------|-----------|------------|
| r=0.0016, cloud1| 267 ms    | 175 ms     |
| r=0.0022, cloud2| 319 ms    | 210 ms     |
| r=0.0072, cloud3| 421 ms    | 293 ms     |
| r=0.005, cloud1 | 440 ms    | 356 ms     |
| r=0.0068, cloud2| 513 ms    | 441 ms     |
| r=0.024, cloud3 | 877 ms    | 873 ms     |