### PR TITLE
Fix boost hash data type

### DIFF
--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -4594,7 +4594,9 @@ pcl::visualization::PCLVisualizer::getUniqueCameraFile (int argc, char **argv)
       boost::uuids::detail::sha1::digest_type digest;
       sha1.get_digest (digest);
       sstream << ".";
-      sstream << std::hex << digest[0] << digest[1] << digest[2] << digest[3] << digest[4];
+      for (int i = 0; i < 5; ++i) {
+        sstream << std::hex << *(reinterpret_cast<unsigned int*>(&digest[0]) + i);
+      }
       sstream << ".cam";
     }
   }

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -4591,7 +4591,7 @@ pcl::visualization::PCLVisualizer::getUniqueCameraFile (int argc, char **argv)
     // Build camera filename
     if (valid)
     {
-      unsigned int digest[5];
+      boost::uuids::detail::sha1::digest_type digest;
       sha1.get_digest (digest);
       sstream << ".";
       sstream << std::hex << digest[0] << digest[1] << digest[2] << digest[3] << digest[4];


### PR DESCRIPTION
The boost data type should be used for boost::uuids::detail::sha1 (https://www.boost.org/doc/libs/1_66_0/libs/uuid/doc/uuid.html#Concept:NameHashProvider). The data type has changed from `typedef unsigned int(&digest_type)[5];` in 1.65 to `typedef unsigned char digest_type[ 20 ];` in 1.86.