### PR TITLE
Allow type conversion in fromPCLPointCloud2

### DIFF
--- a/test/common/test_io.cpp
+++ b/test/common/test_io.cpp
@@ -296,6 +296,82 @@ TEST (toPCLPointCloud2NoPadding, PointXYZI)
   }
 }
 
+TEST(PCL, fromPCLPointCloud2CastingXYZI)
+{
+  // test fromPCLPointCloud2, but in PCLPointCloud2 the fields have different types than in PointXYZI
+  pcl::PCLPointCloud2 msg;
+  msg.height = 2;
+  msg.width = 2;
+  msg.fields.resize(4);
+  msg.fields[0].name = "x";
+  msg.fields[0].offset = 0;
+  msg.fields[0].datatype = pcl::PCLPointField::FLOAT64;
+  msg.fields[0].count = 1;
+  msg.fields[1].name = "y";
+  msg.fields[1].offset = 8;
+  msg.fields[1].datatype = pcl::PCLPointField::FLOAT64;
+  msg.fields[1].count = 1;
+  msg.fields[2].name = "z";
+  msg.fields[2].offset = 16;
+  msg.fields[2].datatype = pcl::PCLPointField::FLOAT64;
+  msg.fields[2].count = 1;
+  msg.fields[3].name = "intensity";
+  msg.fields[3].offset = 24;
+  msg.fields[3].datatype = pcl::PCLPointField::UINT16;
+  msg.fields[3].count = 1;
+  msg.point_step = 32;
+  msg.row_step = 32*msg.width;
+  msg.data.resize(32*msg.width*msg.height);
+  for(std::size_t i=0; i<msg.width*msg.height; ++i) {
+    msg.at<double>(i, 0) = 1.0*i;
+    msg.at<double>(i, 8) = -1.6*i;
+    msg.at<double>(i, 16) = -3.141*i;
+    msg.at<std::uint16_t>(i, 24) = 123*i;
+  }
+  pcl::PointCloud<pcl::PointXYZI> cloud;
+  pcl::fromPCLPointCloud2(msg, cloud);
+  for(std::size_t i=0; i<msg.width*msg.height; ++i) {
+    EXPECT_EQ(cloud[i].x, 1.0f*i);
+    EXPECT_EQ(cloud[i].y, -1.6f*i);
+    EXPECT_EQ(cloud[i].z, -3.141f*i);
+    EXPECT_EQ(cloud[i].intensity, 123.0f*i);
+  }
+}
+
+TEST(PCL, fromPCLPointCloud2CastingSHOT352)
+{
+  // test whether casting also works if point type contains arrays
+  pcl::PCLPointCloud2 msg;
+  msg.height = 2;
+  msg.width = 2;
+  msg.fields.resize(2);
+  msg.fields[0].name = "shot";
+  msg.fields[0].offset = 0;
+  msg.fields[0].datatype = pcl::PCLPointField::INT64;
+  msg.fields[0].count = 352;
+  msg.fields[1].name = "rf";
+  msg.fields[1].offset = 352*8;
+  msg.fields[1].datatype = pcl::PCLPointField::FLOAT64;
+  msg.fields[1].count = 9;
+  msg.point_step = (352*8+9*8);
+  msg.row_step = msg.point_step*msg.width;
+  msg.data.resize(msg.point_step*msg.width*msg.height);
+  for(std::size_t i=0; i<msg.width*msg.height; ++i) {
+    for(std::size_t j=0; j<352; ++j)
+      msg.at<std::int64_t>(i, 8*j) = 1000*i+j;
+    for(std::size_t j=0; j<9; ++j)
+      msg.at<double>(i, 352*8+8*j) = (10*i+j)/10.0;
+  }
+  pcl::PointCloud<pcl::SHOT352> cloud;
+  pcl::fromPCLPointCloud2(msg, cloud);
+  for(std::size_t i=0; i<msg.width*msg.height; ++i) {
+    for(std::size_t j=0; j<352; ++j)
+      EXPECT_EQ(cloud[i].descriptor[j], 1000*i+j);
+    for(std::size_t j=0; j<9; ++j)
+      EXPECT_EQ(cloud[i].rf[j], (10*i+j)/10.0f);
+  }
+}
+
 /* ---[ */
 int
 main (int argc, char** argv)


### PR DESCRIPTION
These changes enable automatic type conversion/casting, for example if x, y, z are of double type (but the PCL point types use float). This also takes effect if data is loaded from a file. Previously fields without an exact match were left empty.
The prints now look like this, for example:
```
Failed to find exact match for field 'x'.
Failed to find exact match for field 'y'.
Failed to find exact match for field 'z'.
Will try to cast field 'x' (original type is double). You may loose precision during casting. Make sure that this is acceptable or choose a different point type.
Will try to cast field 'y' (original type is double). You may loose precision during casting. Make sure that this is acceptable or choose a different point type.
Will try to cast field 'z' (original type is double). You may loose precision during casting. Make sure that this is acceptable or choose a different point type.
```
Fixes https://github.com/PointCloudLibrary/pcl/issues/5639
