### PR TITLE
Make UniformSampling inherit from FilterIndices instead of Filter

### DIFF
--- a/filters/include/pcl/filters/impl/uniform_sampling.hpp
+++ b/filters/include/pcl/filters/impl/uniform_sampling.hpp
@@ -74,25 +74,25 @@ pcl::UniformSampling<PointT>::applyFilter (Indices &indices)
   divb_mul_ = Eigen::Vector4i (1, div_b_[0], div_b_[0] * div_b_[1], 0);
 
   // First pass: build a set of leaves with the point index closest to the leaf center
-  for (std::size_t cp = 0; cp < indices_->size (); ++cp)
+  for (const auto& cp : *indices_)
   {
     if (!input_->is_dense)
     {
       // Check if the point is invalid
-      if (!std::isfinite ((*input_)[(*indices_)[cp]].x) || 
-          !std::isfinite ((*input_)[(*indices_)[cp]].y) || 
-          !std::isfinite ((*input_)[(*indices_)[cp]].z))
+      if (!std::isfinite ((*input_)[cp].x) || 
+          !std::isfinite ((*input_)[cp].y) || 
+          !std::isfinite ((*input_)[cp].z))
       {
         if (extract_removed_indices_)
-          (*removed_indices_)[rii++] = (*indices_)[cp];
+          (*removed_indices_)[rii++] = cp;
         continue;
       }
     }
 
     Eigen::Vector4i ijk = Eigen::Vector4i::Zero ();
-    ijk[0] = static_cast<int> (std::floor ((*input_)[(*indices_)[cp]].x * inverse_leaf_size_[0]));
-    ijk[1] = static_cast<int> (std::floor ((*input_)[(*indices_)[cp]].y * inverse_leaf_size_[1]));
-    ijk[2] = static_cast<int> (std::floor ((*input_)[(*indices_)[cp]].z * inverse_leaf_size_[2]));
+    ijk[0] = static_cast<int> (std::floor ((*input_)[cp].x * inverse_leaf_size_[0]));
+    ijk[1] = static_cast<int> (std::floor ((*input_)[cp].y * inverse_leaf_size_[1]));
+    ijk[2] = static_cast<int> (std::floor ((*input_)[cp].z * inverse_leaf_size_[2]));
 
     // Compute the leaf index
     int idx = (ijk - min_b_).dot (divb_mul_);
@@ -104,7 +104,7 @@ pcl::UniformSampling<PointT>::applyFilter (Indices &indices)
     // First time we initialize the index
     if (leaf.idx == -1)
     {
-      leaf.idx = (*indices_)[cp];
+      leaf.idx = cp;
       continue;
     }
 
@@ -112,7 +112,7 @@ pcl::UniformSampling<PointT>::applyFilter (Indices &indices)
     Eigen::Vector4f voxel_center = (ijk.cast<float>() + Eigen::Vector4f::Constant(0.5)) * search_radius_;
     voxel_center[3] = 0;
     // Check to see if this point is closer to the leaf center than the previous one we saved
-    float diff_cur   = ((*input_)[(*indices_)[cp]].getVector4fMap () - voxel_center).squaredNorm ();
+    float diff_cur   = ((*input_)[cp].getVector4fMap () - voxel_center).squaredNorm ();
     float diff_prev  = ((*input_)[leaf.idx].getVector4fMap ()        - voxel_center).squaredNorm ();
 
     // If current point is closer, copy its index instead
@@ -120,12 +120,12 @@ pcl::UniformSampling<PointT>::applyFilter (Indices &indices)
     {
       if (extract_removed_indices_)
         (*removed_indices_)[rii++] = leaf.idx;
-      leaf.idx = (*indices_)[cp];
+      leaf.idx = cp;
     }
     else
     {
       if (extract_removed_indices_)
-        (*removed_indices_)[rii++] = (*indices_)[cp];
+        (*removed_indices_)[rii++] = cp;
     }
   }
 

--- a/filters/include/pcl/filters/impl/uniform_sampling.hpp
+++ b/filters/include/pcl/filters/impl/uniform_sampling.hpp
@@ -40,6 +40,7 @@
 
 #include <pcl/common/common.h>
 #include <pcl/filters/uniform_sampling.h>
+#include <pcl/common/point_tests.h>
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
@@ -79,9 +80,7 @@ pcl::UniformSampling<PointT>::applyFilter (Indices &indices)
     if (!input_->is_dense)
     {
       // Check if the point is invalid
-      if (!std::isfinite ((*input_)[cp].x) || 
-          !std::isfinite ((*input_)[cp].y) || 
-          !std::isfinite ((*input_)[cp].z))
+      if (!pcl::isXYZFinite ((*input_)[cp]))
       {
         if (extract_removed_indices_)
           (*removed_indices_)[rii++] = cp;

--- a/filters/include/pcl/filters/impl/uniform_sampling.hpp
+++ b/filters/include/pcl/filters/impl/uniform_sampling.hpp
@@ -128,8 +128,10 @@ pcl::UniformSampling<PointT>::applyFilter (Indices &indices)
         (*removed_indices_)[rii++] = cp;
     }
   }
+  removed_indices_->resize(rii);
 
   // Second pass: go over all leaves and copy data
+  indices.resize (leaves_.size ());
   for (const auto& leaf : leaves_)
   {
     if (leaf.second.count >= min_points_per_voxel_)
@@ -137,7 +139,6 @@ pcl::UniformSampling<PointT>::applyFilter (Indices &indices)
   }
  
   indices.resize (oii);
-  removed_indices_->resize(rii);
   if(negative_){
      indices.swap(*removed_indices_);
   }

--- a/filters/include/pcl/filters/impl/uniform_sampling.hpp
+++ b/filters/include/pcl/filters/impl/uniform_sampling.hpp
@@ -130,8 +130,6 @@ pcl::UniformSampling<PointT>::applyFilter (Indices &indices)
   }
 
   // Second pass: go over all leaves and copy data
-  std::size_t cp = 0;
-
   for (const auto& leaf : leaves_)
   {
     if (leaf.second.count >= min_points_per_voxel_)

--- a/filters/include/pcl/filters/uniform_sampling.h
+++ b/filters/include/pcl/filters/uniform_sampling.h
@@ -71,6 +71,7 @@ namespace pcl
     using Filter<PointT>::getClassName;
 
     public:
+      using Ptr = shared_ptr<UniformSampling<PointT> >;
       using ConstPtr = shared_ptr<const UniformSampling<PointT> >;
 
       PCL_MAKE_ALIGNED_OPERATOR_NEW

--- a/filters/include/pcl/filters/uniform_sampling.h
+++ b/filters/include/pcl/filters/uniform_sampling.h
@@ -39,7 +39,7 @@
 
 #pragma once
 
-#include <pcl/filters/filter.h>
+#include <pcl/filters/filter_indices.h>
 
 #include <unordered_map>
 
@@ -57,9 +57,11 @@ namespace pcl
     * \ingroup filters
     */ 
   template <typename PointT>
-  class UniformSampling: public Filter<PointT>
+  class UniformSampling: public FilterIndices<PointT>
   {
-    using PointCloud = typename Filter<PointT>::PointCloud;
+    using PointCloud = typename FilterIndices<PointT>::PointCloud;
+
+    using FilterIndices<PointT>::negative_;
 
     using Filter<PointT>::filter_name_;
     using Filter<PointT>::input_;
@@ -69,14 +71,13 @@ namespace pcl
     using Filter<PointT>::getClassName;
 
     public:
-      using Ptr = shared_ptr<UniformSampling<PointT> >;
       using ConstPtr = shared_ptr<const UniformSampling<PointT> >;
 
       PCL_MAKE_ALIGNED_OPERATOR_NEW
 
       /** \brief Empty constructor. */
       UniformSampling (bool extract_removed_indices = false) :
-        Filter<PointT>(extract_removed_indices),
+        FilterIndices<PointT>(extract_removed_indices),
         leaves_ (),
         leaf_size_ (Eigen::Vector4f::Zero ()),
         inverse_leaf_size_ (Eigen::Vector4f::Zero ()),
@@ -120,6 +121,7 @@ namespace pcl
       inline unsigned int
       getMinimumPointsNumberPerVoxel () const { return min_points_per_voxel_; }
 
+      
     protected:
       /** \brief Simple structure to hold an nD centroid and the number of points in a leaf. */
       struct Leaf
@@ -147,11 +149,11 @@ namespace pcl
       /** \brief Minimum number of points per voxel. */
       unsigned int min_points_per_voxel_{0};
 
-      /** \brief Downsample a Point Cloud using a voxelized grid approach
-        * \param[out] output the resultant point cloud message
+      /** \brief Filtered results are indexed by an indices array.
+        * \param[out] indices The resultant indices.
         */
       void
-      applyFilter (PointCloud &output) override;
+      applyFilter (Indices &indices) override;
   };
 }
 

--- a/test/filters/test_uniform_sampling.cpp
+++ b/test/filters/test_uniform_sampling.cpp
@@ -73,11 +73,8 @@ TEST(UniformSampling, extractRemovedIndices)
   pcl::Indices indices;
   us.filter(indices);
 
-  for (std::size_t i = 0; i < indices.size(); ++i)
+  for (const auto& outputIndex : indices)
   {
-    // Find the index of the point in the output cloud
-    int outputIndex = indices[i];
-
     // Check if the point exists in the output cloud
     bool found = false;
     for (std::size_t j = 0; j < output.size(); ++j)

--- a/test/filters/test_uniform_sampling.cpp
+++ b/test/filters/test_uniform_sampling.cpp
@@ -62,15 +62,19 @@ TEST(UniformSampling, extractRemovedIndices)
   // the output cloud and the rest in removed indices.
 
   pcl::UniformSampling<pcl::PointXYZ> us(true); // extract removed indices
-  us.setInputCloud(xyz);
   us.setRadiusSearch(0.1);
   pcl::PointCloud<pcl::PointXYZ> output;
+  pcl::Indices indices;
+  
+  //empty input cloud
+  us.filter(output);
+  us.filter(indices);
 
+  us.setInputCloud(xyz);
   //cloud
   us.filter(output);
 
   //indices
-  pcl::Indices indices;
   us.filter(indices);
 
   for (const auto& outputIndex : indices)

--- a/test/filters/test_uniform_sampling.cpp
+++ b/test/filters/test_uniform_sampling.cpp
@@ -66,15 +66,14 @@ TEST(UniformSampling, extractRemovedIndices)
   pcl::PointCloud<pcl::PointXYZ> output;
   pcl::Indices indices;
   
-  //empty input cloud
+  // Empty input cloud
   us_ptr->filter(output);
   us_ptr->filter(indices);
 
   us_ptr->setInputCloud(xyz);
-  //cloud
+  // Cloud
   us_ptr->filter(output);
-
-  //indices
+  // Indices
   us_ptr->filter(indices);
 
   for (const auto& outputIndex : indices)
@@ -109,7 +108,7 @@ TEST(UniformSampling, extractRemovedIndices)
   EXPECT_EQ (int (removed_indices->size ()), 1000);
   EXPECT_EQ (int (output.size ()), int (xyz->size() - 1000));
 
-  //Organized
+  // Organized
   us_ptr->setKeepOrganized (true);
   us_ptr->setNegative (false);
   us_ptr->filter(output);

--- a/test/filters/test_uniform_sampling.cpp
+++ b/test/filters/test_uniform_sampling.cpp
@@ -77,11 +77,11 @@ TEST(UniformSampling, extractRemovedIndices)
   {
     // Check if the point exists in the output cloud
     bool found = false;
-    for (std::size_t j = 0; j < output.size(); ++j)
+    for (const auto& j : output)
     {
-      if (output[j].x == (*xyz)[outputIndex].x &&
-          output[j].y == (*xyz)[outputIndex].y &&
-          output[j].z == (*xyz)[outputIndex].z)
+      if (j.x == (*xyz)[outputIndex].x &&
+          j.y == (*xyz)[outputIndex].y &&
+          j.z == (*xyz)[outputIndex].z)
       {
         found = true;
         break;

--- a/test/filters/test_uniform_sampling.cpp
+++ b/test/filters/test_uniform_sampling.cpp
@@ -61,21 +61,21 @@ TEST(UniformSampling, extractRemovedIndices)
   // sure that each cell has at least one point. As a result, we expect 1000 points in
   // the output cloud and the rest in removed indices.
 
-  pcl::UniformSampling<pcl::PointXYZ> us(true); // extract removed indices
-  us.setRadiusSearch(0.1);
+  pcl::UniformSampling<pcl::PointXYZ>::Ptr us_ptr(new pcl::UniformSampling<pcl::PointXYZ>(true));// extract removed indices
+  us_ptr->setRadiusSearch(0.1);
   pcl::PointCloud<pcl::PointXYZ> output;
   pcl::Indices indices;
   
   //empty input cloud
-  us.filter(output);
-  us.filter(indices);
+  us_ptr->filter(output);
+  us_ptr->filter(indices);
 
-  us.setInputCloud(xyz);
+  us_ptr->setInputCloud(xyz);
   //cloud
-  us.filter(output);
+  us_ptr->filter(output);
 
   //indices
-  us.filter(indices);
+  us_ptr->filter(indices);
 
   for (const auto& outputIndex : indices)
   {
@@ -96,24 +96,24 @@ TEST(UniformSampling, extractRemovedIndices)
     ASSERT_TRUE(found);
   }
 
-  auto removed_indices = us.getRemovedIndices();
+  auto removed_indices = us_ptr->getRemovedIndices();
   ASSERT_EQ(output.size(), 1000);
   EXPECT_EQ(int(removed_indices->size()), int(xyz->size() - 1000));
   std::set<int> removed_indices_set(removed_indices->begin(), removed_indices->end());
   ASSERT_EQ(removed_indices_set.size(), removed_indices->size());
 
   // Negative
-  us.setNegative (true);
-  us.filter(output);
-  removed_indices = us.getRemovedIndices ();
+  us_ptr->setNegative (true);
+  us_ptr->filter(output);
+  removed_indices = us_ptr->getRemovedIndices ();
   EXPECT_EQ (int (removed_indices->size ()), 1000);
   EXPECT_EQ (int (output.size ()), int (xyz->size() - 1000));
 
   //Organized
-  us.setKeepOrganized (true);
-  us.setNegative (false);
-  us.filter(output);
-  removed_indices = us.getRemovedIndices ();
+  us_ptr->setKeepOrganized (true);
+  us_ptr->setNegative (false);
+  us_ptr->filter(output);
+  removed_indices = us_ptr->getRemovedIndices ();
   EXPECT_EQ (int (removed_indices->size ()), int(xyz->size() - 1000));
   for (std::size_t i = 0; i < removed_indices->size (); ++i)
   {
@@ -126,10 +126,10 @@ TEST(UniformSampling, extractRemovedIndices)
   EXPECT_EQ (output.height, xyz->height);
 
   // Check input cloud with nan values
-  us.setInputCloud (output.makeShared ());
-  us.setRadiusSearch(2);
-  us.filter (output);
-  removed_indices = us.getRemovedIndices ();
+  us_ptr->setInputCloud (output.makeShared ());
+  us_ptr->setRadiusSearch(2);
+  us_ptr->filter (output);
+  removed_indices = us_ptr->getRemovedIndices ();
   EXPECT_EQ (int (removed_indices->size ()), output.size()-1);
 }
 


### PR DESCRIPTION
finish https://github.com/PointCloudLibrary/pcl/issues/6051

Please let me know if there is anything that needs to be modified