### PR TITLE
[BUG FIX] getCorrespondenceScore must not go out-of-bounds.

### DIFF
--- a/registration/include/pcl/registration/correspondence_rejection.h
+++ b/registration/include/pcl/registration/correspondence_rejection.h
@@ -347,6 +347,12 @@ public:
   inline double
   getCorrespondenceScore(int index) override
   {
+    // Check correspondence is valid
+    if (index >= (*input_).size())
+    {
+      return (std::numeric_limits<double>::max ());
+    }
+
     if (target_cloud_updated_ && !force_no_recompute_) {
       tree_->setInputCloud(target_);
     }
@@ -363,6 +369,12 @@ public:
   inline double
   getCorrespondenceScore(const pcl::Correspondence& corr) override
   {
+    // Check correspondence is valid
+    if (corr.index_query >= (*input_).size() || corr.index_match >= (*target_).size())
+    {
+      return (std::numeric_limits<double>::max ());
+    }
+
     // Get the source and the target feature from the list
     const PointT& src = (*input_)[corr.index_query];
     const PointT& tgt = (*target_)[corr.index_match];
@@ -377,6 +389,12 @@ public:
   inline double
   getCorrespondenceScoreFromNormals(const pcl::Correspondence& corr) override
   {
+    // Check correspondence is valid
+    if (corr.index_query >= (*input_normals_).size() || corr.index_match >= (*target_normals_).size())
+    {
+      return (std::numeric_limits<double>::max ());
+    }
+
     // assert ( (input_normals_->size () != 0) && (target_normals_->size () != 0) &&
     // "Normals are not set for the input and target point clouds");
     assert(input_normals_ && target_normals_ &&

--- a/registration/include/pcl/registration/correspondence_rejection_features.h
+++ b/registration/include/pcl/registration/correspondence_rejection_features.h
@@ -257,6 +257,12 @@ protected:
     inline double
     getCorrespondenceScore(int index) override
     {
+      // Check correspondence is valid
+      if (index >= (*source_features_).size() || index >= (*target_features_).size())
+      {
+        return (std::numeric_limits<double>::max ());
+      }
+
       // If no feature representation was given, reset to the default implementation for
       // FeatureT
       if (!feature_representation_)


### PR DESCRIPTION
[BUG FIX] getCorrespondenceScore must not go out-of-bounds.

I have a quite systematic crash when using `pcl::registration::CorrespondenceRejectorMedianDistance` or `pcl::registration::CorrespondenceRejectorSurfaceNormal`.

I use it like so:
```
   std::unique_ptr<pcl::IterativeClosestPoint<PointNT, PointNT, double>> icp;
   icp = std::make_unique<pcl::IterativeClosestPoint<PointNT, PointNT, double>>();

   pcl::registration::CorrespondenceRejectorMedianDistance::Ptr rejMedDist;
   rejMedDist.reset (new pcl::registration::CorrespondenceRejectorMedianDistance);
   rejMedDist->setInputTarget<PointNT> (cloud_mst_normal);
   rejMedDist->setInputSource<PointNT> (cloud_initial_slv_normal);
   rejMedDist->setSearchMethodTarget<PointNT> (tree_mst_normal);
   rejMedDist->setMedianFactor (medianDistanceFactor);
   icp->addCorrespondenceRejector (rejMedDist);

```

If any mistake (explaining crashes ?) is obvious, I'd be glad to know.
In any cases, the attached patch seem to make things better (less often crash) but does not solve the problem (crash occurs on a regular basis).

I pushed this to let the PCL community decide if this patch is worth being merged or not.