### PR TITLE
Preparation for hidden visibility on gcc

### DIFF
--- a/common/include/pcl/common/intersections.h
+++ b/common/include/pcl/common/intersections.h
@@ -86,7 +86,7 @@ namespace pcl
     * \param[in] angular_tolerance tolerance in radians
     * \return true if succeeded/planes aren't parallel
     */
-  PCL_EXPORTS template <typename Scalar> bool
+  template <typename Scalar> PCL_EXPORTS bool
   planeWithPlaneIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a,
                               const Eigen::Matrix<Scalar, 4, 1> &plane_b,
                               Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &line,
@@ -121,7 +121,7 @@ namespace pcl
     * \param[out] intersection_point the three coordinates x, y, z of the intersection point
     * \return true if succeeded/planes aren't parallel
     */
-  PCL_EXPORTS template <typename Scalar> bool
+  template <typename Scalar> PCL_EXPORTS bool
   threePlanesIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a,
                            const Eigen::Matrix<Scalar, 4, 1> &plane_b,
                            const Eigen::Matrix<Scalar, 4, 1> &plane_c,

--- a/filters/include/pcl/filters/impl/voxel_grid.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid.hpp
@@ -211,16 +211,6 @@ pcl::getMinMax3D (const typename pcl::PointCloud<PointT>::ConstPtr &cloud,
   max_pt = max_p;
 }
 
-struct cloud_point_index_idx 
-{
-  unsigned int idx;
-  unsigned int cloud_point_index;
-
-  cloud_point_index_idx() = default;
-  cloud_point_index_idx (unsigned int idx_, unsigned int cloud_point_index_) : idx (idx_), cloud_point_index (cloud_point_index_) {}
-  bool operator < (const cloud_point_index_idx &p) const { return (idx < p.idx); }
-};
-
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::VoxelGrid<PointT>::applyFilter (PointCloud &output)
@@ -273,7 +263,7 @@ pcl::VoxelGrid<PointT>::applyFilter (PointCloud &output)
   divb_mul_ = Eigen::Vector4i (1, div_b_[0], div_b_[0] * div_b_[1], 0);
 
   // Storage for mapping leaf and pointcloud indexes
-  std::vector<cloud_point_index_idx> index_vector;
+  std::vector<internal::cloud_point_index_idx> index_vector;
   index_vector.reserve (indices_->size ());
 
   // If we don't want to process the entire cloud, but rather filter points far away from the viewpoint first...
@@ -350,7 +340,7 @@ pcl::VoxelGrid<PointT>::applyFilter (PointCloud &output)
 
   // Second pass: sort the index_vector vector using value representing target cell as index
   // in effect all points belonging to the same output cell will be next to each other
-  auto rightshift_func = [](const cloud_point_index_idx &x, const unsigned offset) { return x.idx >> offset; };
+  auto rightshift_func = [](const internal::cloud_point_index_idx &x, const unsigned offset) { return x.idx >> offset; };
   boost::sort::spreadsort::integer_sort(index_vector.begin(), index_vector.end(), rightshift_func);
   
   // Third pass: count output cells

--- a/filters/include/pcl/filters/voxel_grid.h
+++ b/filters/include/pcl/filters/voxel_grid.h
@@ -866,6 +866,21 @@ namespace pcl
       void
       applyFilter (PCLPointCloud2 &output) override;
   };
+
+  namespace internal
+  {
+    /** \brief Used internally in voxel grid classes.
+      */
+    struct cloud_point_index_idx
+    {
+      unsigned int idx;
+      unsigned int cloud_point_index;
+
+      cloud_point_index_idx() = default;
+      cloud_point_index_idx (unsigned int idx_, unsigned int cloud_point_index_) : idx (idx_), cloud_point_index (cloud_point_index_) {}
+      bool operator < (const cloud_point_index_idx &p) const { return (idx < p.idx); }
+    };
+  }
 }
 
 #ifdef PCL_NO_PRECOMPILE

--- a/filters/src/voxel_grid.cpp
+++ b/filters/src/voxel_grid.cpp
@@ -420,7 +420,7 @@ pcl::VoxelGrid<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
   div_b_ = max_b_ - min_b_ + Eigen::Vector4i::Ones ();
   div_b_[3] = 0;
 
-  std::vector<cloud_point_index_idx> index_vector;
+  std::vector<internal::cloud_point_index_idx> index_vector;
   index_vector.reserve (indices_->size());
 
   // Create the first xyz_offset, and set up the division multiplier
@@ -545,7 +545,7 @@ pcl::VoxelGrid<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &output)
 
   // Second pass: sort the index_vector vector using value representing target cell as index
   // in effect all points belonging to the same output cell will be next to each other
-  auto rightshift_func = [](const cloud_point_index_idx &x, const unsigned offset) { return x.idx >> offset; };
+  auto rightshift_func = [](const internal::cloud_point_index_idx &x, const unsigned offset) { return x.idx >> offset; };
   boost::sort::spreadsort::integer_sort(index_vector.begin(), index_vector.end(), rightshift_func);
 
   // Third pass: count output cells

--- a/filters/src/voxel_grid_label.cpp
+++ b/filters/src/voxel_grid_label.cpp
@@ -37,8 +37,9 @@
  */
 
 #include <map>
+#include <pcl/common/common.h> // for getMinMax3D
 #include <pcl/filters/voxel_grid_label.h>
-#include <pcl/filters/impl/voxel_grid.hpp>
+#include <boost/mpl/size.hpp> // for boost::mpl::size
 
 //////////////////////////////////////////////////////////////////////////////
 void
@@ -111,7 +112,7 @@ pcl::VoxelGridLabel::applyFilter (PointCloud &output)
   int label_index = -1;
   label_index = pcl::getFieldIndex<PointXYZRGBL> ("label", fields);
 
-  std::vector<cloud_point_index_idx> index_vector;
+  std::vector<internal::cloud_point_index_idx> index_vector;
   index_vector.reserve(input_->size());
 
   // If we don't want to process the entire cloud, but rather filter points far away from the viewpoint first...

--- a/registration/include/pcl/registration/transformation_estimation_svd.h
+++ b/registration/include/pcl/registration/transformation_estimation_svd.h
@@ -55,7 +55,7 @@ namespace registration {
  * \ingroup registration
  */
 template <typename PointSource, typename PointTarget, typename Scalar = float>
-class TransformationEstimationSVD
+class PCL_EXPORTS TransformationEstimationSVD
 : public TransformationEstimation<PointSource, PointTarget, Scalar> {
 public:
   using Ptr = shared_ptr<TransformationEstimationSVD<PointSource, PointTarget, Scalar>>;

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_normal_plane.hpp
@@ -42,7 +42,6 @@
 #define PCL_SAMPLE_CONSENSUS_IMPL_SAC_MODEL_NORMAL_PLANE_H_
 
 #include <pcl/sample_consensus/sac_model_normal_plane.h>
-#include <pcl/sample_consensus/impl/sac_model_plane.hpp> // for dist4, dist8
 #include <pcl/common/common.h> // for getAngle3D
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_plane.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_plane.hpp
@@ -117,36 +117,6 @@ pcl::SampleConsensusModelPlane<PointT>::computeModelCoefficients (
   return (true);
 }
 
-#define AT(POS) ((*input_)[(*indices_)[(POS)]])
-
-#ifdef __AVX__
-// This function computes the distances of 8 points to the plane
-template <typename PointT> inline __m256 pcl::SampleConsensusModelPlane<PointT>::dist8 (const std::size_t i, const __m256 &a_vec, const __m256 &b_vec, const __m256 &c_vec, const __m256 &d_vec, const __m256 &abs_help) const
-{
-  // The andnot-function realizes an abs-operation: the sign bit is removed
-  return _mm256_andnot_ps (abs_help,
-        _mm256_add_ps (_mm256_add_ps (_mm256_mul_ps (a_vec, _mm256_set_ps (AT(i  ).x, AT(i+1).x, AT(i+2).x, AT(i+3).x, AT(i+4).x, AT(i+5).x, AT(i+6).x, AT(i+7).x)),
-                                      _mm256_mul_ps (b_vec, _mm256_set_ps (AT(i  ).y, AT(i+1).y, AT(i+2).y, AT(i+3).y, AT(i+4).y, AT(i+5).y, AT(i+6).y, AT(i+7).y))),
-                       _mm256_add_ps (_mm256_mul_ps (c_vec, _mm256_set_ps (AT(i  ).z, AT(i+1).z, AT(i+2).z, AT(i+3).z, AT(i+4).z, AT(i+5).z, AT(i+6).z, AT(i+7).z)),
-                                      d_vec))); // TODO this could be replaced by three fmadd-instructions (if available), but the speed gain would probably be minimal
-}
-#endif // ifdef __AVX__
-
-#ifdef __SSE__
-// This function computes the distances of 4 points to the plane
-template <typename PointT> inline __m128 pcl::SampleConsensusModelPlane<PointT>::dist4 (const std::size_t i, const __m128 &a_vec, const __m128 &b_vec, const __m128 &c_vec, const __m128 &d_vec, const __m128 &abs_help) const
-{
-  // The andnot-function realizes an abs-operation: the sign bit is removed
-  return _mm_andnot_ps (abs_help,
-        _mm_add_ps (_mm_add_ps (_mm_mul_ps (a_vec, _mm_set_ps (AT(i  ).x, AT(i+1).x, AT(i+2).x, AT(i+3).x)),
-                                _mm_mul_ps (b_vec, _mm_set_ps (AT(i  ).y, AT(i+1).y, AT(i+2).y, AT(i+3).y))),
-                    _mm_add_ps (_mm_mul_ps (c_vec, _mm_set_ps (AT(i  ).z, AT(i+1).z, AT(i+2).z, AT(i+3).z)),
-                                d_vec))); // TODO this could be replaced by three fmadd-instructions (if available), but the speed gain would probably be minimal
-}
-#endif // ifdef __SSE__
-
-#undef AT
-
 //////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
 pcl::SampleConsensusModelPlane<PointT>::getDistancesToModel (

--- a/tracking/include/pcl/tracking/nearest_pair_point_cloud_coherence.h
+++ b/tracking/include/pcl/tracking/nearest_pair_point_cloud_coherence.h
@@ -11,7 +11,8 @@ namespace tracking {
  * \ingroup tracking
  */
 template <typename PointInT>
-class NearestPairPointCloudCoherence : public PointCloudCoherence<PointInT> {
+class PCL_EXPORTS NearestPairPointCloudCoherence
+: public PointCloudCoherence<PointInT> {
 public:
   using PointCloudCoherence<PointInT>::getClassName;
   using PointCloudCoherence<PointInT>::coherence_name_;

--- a/visualization/include/pcl/visualization/common/ren_win_interact_map.h
+++ b/visualization/include/pcl/visualization/common/ren_win_interact_map.h
@@ -38,6 +38,8 @@
 
 #pragma once
 
+#include <pcl/pcl_exports.h>
+
 #include <map>
 #include <string>
 
@@ -53,7 +55,7 @@ namespace pcl
 {
   namespace visualization
   {
-    class RenWinInteract
+    class PCL_EXPORTS RenWinInteract
     {
       public:
 


### PR DESCRIPTION
In voxel_grid_label.cpp, the implementation of `VoxelGrid` (from voxel_grid.hpp) must be hidden, otherwise `VoxelGrid` is instantiated again, but with the wrong visibility attributes (would overwrite the correct instantiation from `voxel_grid.cpp`). Same thing in sac_model_normal_plane.hpp: the implementation of `SampleConsensusModelPlane` must be hidden. The implementations of `dist8` and `dist4` are moved from sac_model_plane.hpp to sac_model_plane.h so that they are available when `SampleConsensusModelNormalPlane` is instantiated and the compiler can optimize.

Split off from https://github.com/PointCloudLibrary/pcl/pull/5779