### PR TITLE
CI: Install cjson

### DIFF
--- a/.ci/azure-pipelines/build/macos.yaml
+++ b/.ci/azure-pipelines/build/macos.yaml
@@ -3,7 +3,7 @@ steps:
     # find the commit hash on a quick non-forced update too
     fetchDepth: 10
   - script: |
-      brew install cmake pkg-config boost eigen flann glew libusb qhull vtk glew qt5 libpcap libomp google-benchmark
+      brew install cmake pkg-config boost eigen flann glew libusb qhull vtk glew qt5 libpcap libomp google-benchmark cjson
       brew install brewsci/science/openni
       git clone https://github.com/abseil/googletest.git $GOOGLE_TEST_DIR # the official endpoint changed to abseil/googletest
       cd $GOOGLE_TEST_DIR && git checkout release-1.8.1

--- a/.dev/docker/env/Dockerfile
+++ b/.dev/docker/env/Dockerfile
@@ -34,6 +34,7 @@ RUN apt-get update \
       libboost-filesystem-dev \
       libboost-iostreams-dev \
       libboost-system-dev \
+      libcjson-dev \
       libflann-dev \
       libglew-dev \
       libgtest-dev \

--- a/.dev/docker/windows/Dockerfile
+++ b/.dev/docker/windows/Dockerfile
@@ -47,6 +47,6 @@ COPY $PLATFORM'-windows-rel.cmake' 'c:\vcpkg\triplets\'$PLATFORM'-windows-rel.cm
 
 RUN cd .\vcpkg;                                                     `
     .\bootstrap-vcpkg.bat;                                          `
-    .\vcpkg install boost-accumulators boost-asio boost-algorithm boost-filesystem boost-format boost-graph boost-interprocess boost-iostreams boost-math boost-ptr-container boost-signals2 boost-sort boost-uuid flann eigen3 qhull vtk[qt,opengl] gtest benchmark openni2 `
+    .\vcpkg install boost-accumulators boost-asio boost-algorithm boost-filesystem boost-format boost-graph boost-interprocess boost-iostreams boost-math boost-ptr-container boost-signals2 boost-sort boost-uuid flann eigen3 qhull vtk[qt,opengl] gtest benchmark openni2 cjson `
     --triplet $Env:PLATFORM-windows-rel --host-triplet $Env:PLATFORM-windows-rel --clean-after-build --x-buildtrees-root=C:\b;
 


### PR DESCRIPTION
In a future pull request, we can then make PCL use the system cjson instead of the old cjson code in the outofcore module See also https://github.com/PointCloudLibrary/pcl/issues/6080
cjson is very popular and available in basically every OS/distribution: https://repology.org/project/cjson/versions