### PR TITLE
Make test_timestamp pass in all timezones

### DIFF
--- a/test/io/test_timestamp.cpp
+++ b/test/io/test_timestamp.cpp
@@ -18,7 +18,7 @@ TEST(PCL, TestTimestampGeneratorZeroFraction)
 
   const auto timestamp = pcl::getTimestamp(time);
 
-  EXPECT_EQ(timestamp, "19700101T" + getTimeOffset() + "0000");
+  EXPECT_EQ(timestamp.size(), 15);
 }
 
 TEST(PCL, TestTimestampGeneratorWithFraction)
@@ -28,7 +28,8 @@ TEST(PCL, TestTimestampGeneratorWithFraction)
 
   const auto timestamp = pcl::getTimestamp(dt);
 
-  EXPECT_EQ(timestamp, "19700101T" + getTimeOffset() + "0000.123456");
+  ASSERT_EQ(timestamp.size(), 22);
+  EXPECT_EQ(timestamp.substr(15), ".123456");
 }
 
 TEST(PCL, TestTimestampGeneratorWithSmallFraction)
@@ -38,7 +39,8 @@ TEST(PCL, TestTimestampGeneratorWithSmallFraction)
 
   const auto timestamp = pcl::getTimestamp(dt);
 
-  EXPECT_EQ(timestamp, "19700101T" + getTimeOffset() + "0000.000123");
+  ASSERT_EQ(timestamp.size(), 22);
+  EXPECT_EQ(timestamp.substr(15), ".000123");
 }
 
 TEST(PCL, TestParseTimestamp)


### PR DESCRIPTION
Fixes https://github.com/PointCloudLibrary/pcl/issues/6074
I think it would be too complex to determine exactly what 1 January 1970 midnight (UTC) would be in any possible local time zone (`pcl::getTimestamp` is based on local time zone). In American time zones for example, it would still be 31 December 1969. India has this UTC+5:30 time zone. And there are probably even more special cases. I believe it is sufficient to just test length and sub-second precision, since `TestParseTimestamp` also tests `getTimestamp`.