### PR TITLE
change parse_argument bool to just set if exists

### DIFF
--- a/common/src/parse.cpp
+++ b/common/src/parse.cpp
@@ -215,12 +215,8 @@ pcl::console::parse_argument (int argc, const char * const * argv, const char * 
 int
 pcl::console::parse_argument (int argc, const char * const * argv, const char * str, bool &val)
 {
-  long int dummy;
-  const auto ret = parse_argument (argc, argv, str, dummy);
-  if (ret != -1)
-  {
-    val = static_cast<bool> (dummy);
-  }
+  int ret = find_argument (argc, argv, str);
+  val = ret != -1;
   return ret;
 }
 


### PR DESCRIPTION
take no 2nd arg.
so .e.g
```
bool b = true; 
pcl::console::parse_argument(argc, argv, "-b", b);
```
requires only -b, not -b 1 to set b.

the workaround is to use `bool b = pcl::console::find_switch(argc, argv, "-b");` if you not need the return index.

