### PR TITLE
add border type setting in linemod guass step

### DIFF
--- a/recognition/include/pcl/recognition/color_gradient_modality.h
+++ b/recognition/include/pcl/recognition/color_gradient_modality.h
@@ -368,7 +368,7 @@ processInputData ()
 
 	convolution.setInputCloud (rgb_input_);
 	convolution.setKernel (gaussian_kernel);
-
+  convolution.setBordersPolicy(pcl::filters::Convolution<pcl::RGB, pcl::RGB>::BORDERS_POLICY_DUPLICATE);
   convolution.convolve (*smoothed_input_);
 
   // extract color gradients


### PR DESCRIPTION
If no copied boundary expansion is performed during the Gaussian blur stage, there is a probability that non-existent color gradients will be generated at the boundary.

Added pixel expansion operation similar to opencv：https://github.com/opencv/opencv_contrib/blob/4.x/modules/rgbd/src/linemod.cpp#L270

features before:
![Snipaste_2024-08-13_16-29-30](https://github.com/user-attachments/assets/bdd34cb4-3993-45d8-b60a-e3fa1203bf0e)


features after add border duplication:

![Snipaste_2024-08-13_16-30-49](https://github.com/user-attachments/assets/24b834be-f24e-4f5f-bc5d-5364f7153db2)
