### PR TITLE
Small fix in OpenMP for loop

### DIFF
--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -92,9 +92,8 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeCovar
   if (cloud_covariances.size() < cloud->size())
     cloud_covariances.resize(cloud->size());
 
-#pragma omp parallel for default(none) num_threads(threads_) schedule(dynamic, 32)     \
-    shared(cloud, cloud_covariances, kdtree)                                           \
-        firstprivate(mean, cov, nn_indices, nn_dist_sq)
+#pragma omp parallel for num_threads(threads_) schedule(dynamic, 32)                   \
+    shared(cloud, cloud_covariances) firstprivate(mean, cov, nn_indices, nn_dist_sq)
   for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(cloud->size()); ++i) {
     const PointT& query_point = (*cloud)[i];
     // Zero out the cov and mean


### PR DESCRIPTION
One compiler complained that `‘kdtree’ is predetermined ‘shared’ for ‘shared’`. `kdtree` is a const variable, which are always shared. The solution is to remove `kdtree` from the shared clause (not explicitly declare it as shared again). Then we also have to remove `default(none)` because otherwise other compilers complain that the data sharing attribute is not explicitly defined for kdtree. Normally, `default(none)` is recommended because it forces the programmer to consider which variables should be shared and which ones private. But since the code is finished, it is okay to remove `default(none)`. Basically, this solution (no `default(none)` and don't explicitly define the const `kdtree` as shared) is the only one that works with all compilers.

Related to https://github.com/PointCloudLibrary/pcl/pull/5903
Fixes https://github.com/PointCloudLibrary/pcl/issues/6098