### PR TITLE
fix: Initialization with correct signedness

### DIFF
--- a/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
@@ -187,7 +187,7 @@ protected:
 
   /** \brief The maximum number of labels we can find in this pointcloud (default =
    * MAXINT)*/
-  unsigned int max_label_{std::numeric_limits<int>::max()};
+  unsigned int max_label_{std::numeric_limits<unsigned int>::max()};
 
   /** \brief Class getName method. */
   virtual std::string

--- a/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
+++ b/segmentation/include/pcl/segmentation/extract_labeled_clusters.h
@@ -187,6 +187,7 @@ protected:
 
   /** \brief The maximum number of labels we can find in this pointcloud (default =
    * MAXINT)*/
+  PCL_DEPRECATED(1, 18, "this member variable is unused")
   unsigned int max_label_{std::numeric_limits<unsigned int>::max()};
 
   /** \brief Class getName method. */


### PR DESCRIPTION
Referencing issue 6110
https://github.com/PointCloudLibrary/pcl/issues/6110

Problem:
A max range of int is implicitly casted to unsigned int. This may cause an overflow and the semantic meaning of max is lost.

Simple solution: Changed the respective line and ran the tests