### PR TITLE
Compatibility with clang-19

### DIFF
--- a/registration/include/pcl/registration/correspondence_rejection_features.h
+++ b/registration/include/pcl/registration/correspondence_rejection_features.h
@@ -269,9 +269,9 @@ protected:
       // Check if the representations are valid
       if (!feature_representation_->isValid(feat_src) ||
           !feature_representation_->isValid(feat_tgt)) {
-        PCL_ERROR("[pcl::registration::%s::getCorrespondenceScore] Invalid feature "
-                  "representation given!\n",
-                  this->getClassName().c_str());
+        PCL_ERROR(
+            "[pcl::registration::CorrespondenceRejectorFeatures::FeatureContainer::"
+            "getCorrespondenceScore] Invalid feature representation given!\n");
         return (std::numeric_limits<double>::max());
       }
 

--- a/surface/include/pcl/surface/3rdparty/poisson4/octree_poisson.hpp
+++ b/surface/include/pcl/surface/3rdparty/poisson4/octree_poisson.hpp
@@ -746,7 +746,10 @@ namespace pcl
       Real temp,dist2;
       if(!children){return this;}
       for(int i=0;i<Cube::CORNERS;i++){
-        temp=SquareDistance(children[i].center,p);
+        Point3D<Real> child_center;
+        Real child_width;
+        children[i].centerAndWidth(child_center, child_width);
+        temp=SquareDistance(child_center,p);
         if(!i || temp<dist2){
           dist2=temp;
           nearest=i;
@@ -807,7 +810,7 @@ namespace pcl
       children=NULL;
 
       d=node.depth ();
-      for(i=0;i<DIMENSION;i++){this->offset[i] = node.offset[i];}
+      for(i=0;i<DIMENSION;i++){this->off[i] = node.off[i];}
       if(node.children){
         initChildren();
         for(i=0;i<Cube::CORNERS;i++){children[i] = node.children[i];}
@@ -817,7 +820,7 @@ namespace pcl
 
     template <class NodeData,class Real>
     int OctNode<NodeData,Real>::CompareForwardDepths(const void* v1,const void* v2){
-      return ((const OctNode<NodeData,Real>*)v1)->depth-((const OctNode<NodeData,Real>*)v2)->depth;
+      return ((const OctNode<NodeData,Real>*)v1)->depth()-((const OctNode<NodeData,Real>*)v2)->depth();
     }
 
     template< class NodeData , class Real >
@@ -874,7 +877,7 @@ namespace pcl
 
     template <class NodeData,class Real>
     int OctNode<NodeData,Real>::CompareBackwardDepths(const void* v1,const void* v2){
-      return ((const OctNode<NodeData,Real>*)v2)->depth-((const OctNode<NodeData,Real>*)v1)->depth;
+      return ((const OctNode<NodeData,Real>*)v2)->depth()-((const OctNode<NodeData,Real>*)v1)->depth();
     }
 
     template <class NodeData,class Real>

--- a/surface/include/pcl/surface/3rdparty/poisson4/sparse_matrix.hpp
+++ b/surface/include/pcl/surface/3rdparty/poisson4/sparse_matrix.hpp
@@ -228,14 +228,18 @@ namespace pcl
     template<class T>
     void SparseMatrix<T>::SetZero()
     {
-      Resize(this->m_N, this->m_M);
+      // copied from operator *=
+      for (int i=0; i<rows; i++)
+      {
+        for(int ii=0;ii<rowSizes[i];ii++){m_ppElements[i][ii].Value=T(0);}
+      }
     }
 
     template<class T>
     void SparseMatrix<T>::SetIdentity()
     {
       SetZero();
-      for(int ij=0; ij < Min( this->Rows(), this->Columns() ); ij++)
+      for(int ij=0; ij < std::min<int>( rows, _maxEntriesPerRow ); ij++)
         (*this)(ij,ij) = T(1);
     }
 
@@ -388,7 +392,7 @@ namespace pcl
       T alpha,beta,rDotR;
       int i;
 
-      solution.Resize(M.Columns());
+      solution.Resize(bb.Dimensions());
       solution.SetZero();
 
       d=r=bb;


### PR DESCRIPTION
Fix errors reported by the upcoming clang 19. It seems like clang 19 checks these functions, even though they are not actually compiled/used anywhere (otherwise the other compilers would have complained already).
Regarding the changes in poisson4: I did my best to put something plausible there, but I am not very familiar with that code, so it might not be the best solution. But since those function are seemingly not used anywhere, it should not matter that much.

Here are the errors reported by clang 19:
```
In file included from /pcl/surface/src/poisson.cpp:40:
In file included from /pcl/surface/include/pcl/surface/impl/poisson.hpp:48:
In file included from /pcl/surface/include/pcl/surface/3rdparty/poisson4/octree_poisson.h:283:
/pcl/surface/include/pcl/surface/3rdparty/poisson4/octree_poisson.hpp:749:41: error: no member named 'center' in 'OctNode<NodeData, Real>'
  749 |         temp=SquareDistance(children[i].center,p);
      |                             ~~~~~~~~~~~ ^
/pcl/surface/include/pcl/surface/3rdparty/poisson4/octree_poisson.hpp:810:38: error: no member named 'offset' in 'OctNode<NodeData, Real>'
  810 |       for(i=0;i<DIMENSION;i++){this->offset[i] = node.offset[i];}
      |                                ~~~~  ^
/pcl/surface/include/pcl/surface/3rdparty/poisson4/octree_poisson.hpp:820:51: error: reference to non-static member function must be called
  820 |       return ((const OctNode<NodeData,Real>*)v1)->depth-((const OctNode<NodeData,Real>*)v2)->depth;
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
/pcl/surface/include/pcl/surface/3rdparty/poisson4/octree_poisson.hpp:877:51: error: reference to non-static member function must be called
  877 |       return ((const OctNode<NodeData,Real>*)v2)->depth-((const OctNode<NodeData,Real>*)v1)->depth;
      |              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~
In file included from /pcl/surface/src/poisson.cpp:40:
In file included from /pcl/surface/include/pcl/surface/impl/poisson.hpp:49:
In file included from /pcl/surface/include/pcl/surface/3rdparty/poisson4/sparse_matrix.h:185:
/pcl/surface/include/pcl/surface/3rdparty/poisson4/sparse_matrix.hpp:231:20: error: no member named 'm_N' in 'SparseMatrix<T>'
  231 |       Resize(this->m_N, this->m_M);
      |              ~~~~  ^
/pcl/surface/include/pcl/surface/3rdparty/poisson4/sparse_matrix.hpp:231:31: error: no member named 'm_M' in 'SparseMatrix<T>'
  231 |       Resize(this->m_N, this->m_M);
      |                         ~~~~  ^
/pcl/surface/include/pcl/surface/3rdparty/poisson4/sparse_matrix.hpp:238:51: error: no member named 'Columns' in 'SparseMatrix<T>'
  238 |       for(int ij=0; ij < Min( this->Rows(), this->Columns() ); ij++)
      |                                             ~~~~  ^
/pcl/surface/include/pcl/surface/3rdparty/poisson4/sparse_matrix.hpp:238:37: error: no member named 'Rows' in 'SparseMatrix<T>'
  238 |       for(int ij=0; ij < Min( this->Rows(), this->Columns() ); ij++)
      |                               ~~~~  ^
/pcl/surface/include/pcl/surface/3rdparty/poisson4/sparse_matrix.hpp:391:25: error: no member named 'Columns' in 'SparseMatrix<T>'
  391 |       solution.Resize(M.Columns());
      |                       ~ ^
[ 23%] Linking CXX executable ../../bin/pcl_example_extract_indices
9 errors generated.
gmake[2]: *** [surface/CMakeFiles/pcl_surface.dir/build.make:328: surface/CMakeFiles/pcl_surface.dir/src/poisson.cpp.o] Error 1
```
```
In file included from /pcl/registration/src/correspondence_rejection_features.cpp:40:
/pcl/registration/include/pcl/registration/correspondence_rejection_features.h:274:25: error: no member named 'getClassName' in 'FeatureContainer<FeatureT>'
  274 |                   this->getClassName().c_str());
      |                   ~~~~  ^
/pcl/common/include/pcl/console/print.h:60:70: note: expanded from macro 'PCL_ERROR'
   60 | #define PCL_ERROR(...)   pcl::console::print (pcl::console::L_ERROR, __VA_ARGS__)
      |                                                                      ^~~~~~~~~~~
1 error generated.
gmake[2]: *** [registration/CMakeFiles/pcl_registration.dir/build.make:188: registration/CMakeFiles/pcl_registration.dir/src/correspondence_rejection_features.cpp.o] Error 1
```