### PR TITLE
Switch from GitHub Action Checkout V3 to Checkout V4

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: pointcloudlibrary/env:22.04
-    
+
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Run clang-tidy
       run: |
@@ -19,5 +19,5 @@ jobs:
             -DBUILD_examples=ON \
             -DBUILD_simulation=ON \
             -DBUILD_global_tests=ON
-        
+
           run-clang-tidy -header-filter='.*'


### PR DESCRIPTION
Should fix the warning:
> **tidy**
> The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

`checkout@v4` is already using node20, so a simple upgrade should fix the warning.