### PR TITLE
PCLConfig.cmake.in: Handle potentially empty ${LIB} variable

### DIFF
--- a/PCLConfig.cmake.in
+++ b/PCLConfig.cmake.in
@@ -311,17 +311,17 @@ function(find_external_library _component _lib _is_optional)
 
   string(TOUPPER "${_component}" COMPONENT)
   string(TOUPPER "${_lib}" LIB)
-  string(REGEX REPLACE "[.-]" "_" LIB ${LIB})
+  string(REGEX REPLACE "[.-]" "_" LIB "${LIB}")
   if(${LIB}_FOUND)
     list(APPEND PCL_${COMPONENT}_INCLUDE_DIRS ${${LIB}_INCLUDE_DIRS})
     set(PCL_${COMPONENT}_INCLUDE_DIRS ${PCL_${COMPONENT}_INCLUDE_DIRS} PARENT_SCOPE)
-    
+
     if(${LIB} MATCHES "VTK")
       if(${${LIB}_VERSION_MAJOR} GREATER_EQUAL 9)
         set(ISVTK9ORGREATER TRUE)
       endif()
     endif()
-    
+
     if(${LIB}_USE_FILE AND NOT ISVTK9ORGREATER )
       include(${${LIB}_USE_FILE})
     else()


### PR DESCRIPTION
Found in the wild attempting to build freecad

```
CMake Error at /usr/lib64/cmake/pcl/PCLConfig.cmake:332 (string):
  string sub-command REGEX, mode REPLACE needs at least 6 arguments total to
  command.
Call Stack (most recent call first):
  /usr/lib64/cmake/pcl/PCLConfig.cmake:545 (find_external_library)
  cMake/FreeCAD_Helpers/SetupPCL.cmake:11 (find_package)
  CMakeLists.txt:55 (SetupPCL)
```