### PR TITLE
Fix some implicit-widening-of-multiplication-result warnings

### DIFF
--- a/2d/include/pcl/2d/impl/edge.hpp
+++ b/2d/include/pcl/2d/impl/edge.hpp
@@ -259,9 +259,7 @@ Edge<PointInT, PointOutT>::suppressNonMaxima(
   const int height = edges.height;
   const int width = edges.width;
 
-  maxima.height = height;
-  maxima.width = width;
-  maxima.resize(height * width);
+  maxima.resize(edges.width, edges.height);
 
   for (auto& point : maxima)
     point.intensity = 0.0f;

--- a/common/include/pcl/common/impl/generate.hpp
+++ b/common/include/pcl/common/impl/generate.hpp
@@ -276,9 +276,7 @@ CloudGenerator<pcl::PointXY, GeneratorT>::fill (int width, int height, pcl::Poin
   if (!cloud.empty ())
     PCL_WARN ("[pcl::common::CloudGenerator] Cloud data will be erased with new data\n!");
 
-  cloud.width = width;
-  cloud.height = height;
-  cloud.resize (cloud.width * cloud.height);
+  cloud.resize (width, height);
   cloud.is_dense = true;
 
   for (auto &point : cloud)

--- a/common/include/pcl/range_image/impl/range_image.hpp
+++ b/common/include/pcl/range_image/impl/range_image.hpp
@@ -194,7 +194,7 @@ RangeImage::createFromPointCloudWithKnownSize (const PointCloudType& point_cloud
   image_offset_y_ = (std::max) (0, center_pixel_y-pixel_radius_y);
 
   points.clear ();
-  points.resize (width*height, unobserved_point);
+  points.resize (static_cast<std::size_t>(width)*static_cast<std::size_t>(height), unobserved_point);
   
   int top=height, right=-1, bottom=-1, left=width;
   doZBuffer (point_cloud, noise_level, min_range, top, right, bottom, left);

--- a/common/src/PCLPointCloud2.cpp
+++ b/common/src/PCLPointCloud2.cpp
@@ -146,13 +146,13 @@ pcl::PCLPointCloud2::concatenate (pcl::PCLPointCloud2 &cloud1, const pcl::PCLPoi
   }
   const auto data1_size = cloud1.data.size ();
   cloud1.data.resize(data1_size + cloud2.data.size ());
-  for (uindex_t cp = 0; cp < size2; ++cp)
+  for (std::size_t cp = 0; cp < size2; ++cp)
   {
     for (const auto& field_data: valid_fields)
     {
       const auto& i = field_data.idx1;
       const auto& j = field_data.idx2;
-      const auto& size = field_data.size;
+      const std::size_t size = field_data.size;
       // Leave the data for the skip fields untouched in cloud1
       // Copy only the required data from cloud2 to the correct location for cloud1
       memcpy (reinterpret_cast<char*> (&cloud1.data[data1_size + cp * cloud1.point_step + cloud1.fields[i].offset]),

--- a/common/src/gaussian.cpp
+++ b/common/src/gaussian.cpp
@@ -145,9 +145,7 @@ pcl::GaussianKernel::convolveRows (const pcl::PointCloud<float>& input,
   {
     if (output.height < input.height || output.width < input.width)
     {
-      output.width = input.width;
-      output.height = input.height;
-      output.resize (input.height * input.width);
+      output.resize (input.width, input.height);
     }
     unaliased_input = &input;
   }
@@ -189,9 +187,7 @@ pcl::GaussianKernel::convolveCols (const pcl::PointCloud<float>& input,
   {
     if (output.height < input.height || output.width < input.width)
     {
-      output.width = input.width;
-      output.height = input.height;
-      output.resize (input.height * input.width);
+      output.resize (input.width, input.height);
     }
     unaliased_input = &input;
   }

--- a/common/src/gaussian.cpp
+++ b/common/src/gaussian.cpp
@@ -145,7 +145,7 @@ pcl::GaussianKernel::convolveRows (const pcl::PointCloud<float>& input,
   {
     if (output.height < input.height || output.width < input.width)
     {
-      output.resize (input.width, input.height);
+      output.resize (static_cast<uindex_t>(input.width), static_cast<uindex_t>(input.height)); // Casting is necessary to resolve ambiguous call to resize
     }
     unaliased_input = &input;
   }
@@ -187,7 +187,7 @@ pcl::GaussianKernel::convolveCols (const pcl::PointCloud<float>& input,
   {
     if (output.height < input.height || output.width < input.width)
     {
-      output.resize (input.width, input.height);
+      output.resize (static_cast<uindex_t>(input.width), static_cast<uindex_t>(input.height)); // Casting is necessary to resolve ambiguous call to resize
     }
     unaliased_input = &input;
   }

--- a/common/src/io.cpp
+++ b/common/src/io.cpp
@@ -149,7 +149,7 @@ pcl::concatenateFields (const pcl::PCLPointCloud2 &cloud1,
 
   //the total size of extra data should be the size of data per point
   //multiplied by the total number of points in the cloud
-  std::uint32_t cloud1_unique_data_size = cloud1_unique_point_step * cloud1.width * cloud1.height; 
+  const std::size_t cloud1_unique_data_size = static_cast<std::size_t>(cloud1_unique_point_step) * cloud1.width * cloud1.height;
 
   // Point step must increase with the length of each matching field
   cloud_out.point_step = cloud2.point_step + cloud1_unique_point_step;
@@ -175,8 +175,9 @@ pcl::concatenateFields (const pcl::PCLPointCloud2 &cloud1,
   }
  
   // Iterate over each point and perform the appropriate memcpys
-  int point_offset = 0;
-  for (uindex_t cp = 0; cp < cloud_out.width * cloud_out.height; ++cp)
+  std::size_t point_offset = 0;
+  const std::size_t npts = static_cast<std::size_t>(cloud_out.width) * static_cast<std::size_t>(cloud_out.height);
+  for (std::size_t cp = 0; cp < npts; ++cp)
   {
     memcpy (&cloud_out.data[point_offset], &cloud2.data[cp * cloud2.point_step], cloud2.point_step);
     int field_offset = cloud2.point_step;
@@ -229,7 +230,7 @@ pcl::getPointCloudAsEigen (const pcl::PCLPointCloud2 &in, Eigen::MatrixXf &out)
     return (false);
   }
 
-  std::size_t npts = in.width * in.height;
+  std::size_t npts = static_cast<std::size_t>(in.width) * static_cast<std::size_t>(in.height);
   out = Eigen::MatrixXf::Ones (4, npts);
 
   Eigen::Array4i xyz_offset (in.fields[x_idx].offset, in.fields[y_idx].offset, in.fields[z_idx].offset, 0);
@@ -311,11 +312,11 @@ pcl::copyPointCloud (
   cloud_out.row_step     = cloud_in.point_step * static_cast<std::uint32_t> (indices.size ());
   cloud_out.is_dense     = cloud_in.is_dense;
 
-  cloud_out.data.resize (cloud_out.width * cloud_out.height * cloud_out.point_step);
+  cloud_out.data.resize (static_cast<std::size_t>(cloud_out.width) * static_cast<std::size_t>(cloud_out.height) * static_cast<std::size_t>(cloud_out.point_step));
 
   // Iterate over each point
   for (std::size_t i = 0; i < indices.size (); ++i)
-    memcpy (&cloud_out.data[i * cloud_out.point_step], &cloud_in.data[indices[i] * cloud_in.point_step], cloud_in.point_step);
+    memcpy (&cloud_out.data[i * cloud_out.point_step], &cloud_in.data[static_cast<std::size_t>(indices[i]) * cloud_in.point_step], cloud_in.point_step);
 }
 
 //////////////////////////////////////////////////////////////////////////
@@ -334,11 +335,11 @@ pcl::copyPointCloud (
   cloud_out.row_step     = cloud_in.point_step * static_cast<std::uint32_t> (indices.size ());
   cloud_out.is_dense     = cloud_in.is_dense;
 
-  cloud_out.data.resize (cloud_out.width * cloud_out.height * cloud_out.point_step);
+  cloud_out.data.resize (static_cast<std::size_t>(cloud_out.width) * cloud_out.height * cloud_out.point_step);
 
   // Iterate over each point
   for (std::size_t i = 0; i < indices.size (); ++i)
-    memcpy (&cloud_out.data[i * cloud_out.point_step], &cloud_in.data[indices[i] * cloud_in.point_step], cloud_in.point_step);
+    memcpy (&cloud_out.data[i * cloud_out.point_step], &cloud_in.data[static_cast<std::size_t>(indices[i]) * cloud_in.point_step], cloud_in.point_step);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/common/src/pcl_base.cpp
+++ b/common/src/pcl_base.cpp
@@ -114,12 +114,12 @@ pcl::PCLBase<pcl::PCLPointCloud2>::initCompute ()
   }
 
   // If we have a set of fake indices, but they do not match the number of points in the cloud, update them
-  if (fake_indices_ && indices_->size () != (input_->width * input_->height))
+  if (fake_indices_ && indices_->size () != (static_cast<std::size_t>(input_->width) * static_cast<std::size_t>(input_->height)))
   {
     const auto indices_size = indices_->size ();
     try
     {
-      indices_->resize (input_->width * input_->height);
+      indices_->resize (static_cast<std::size_t>(input_->width) * static_cast<std::size_t>(input_->height));
     }
     catch (const std::bad_alloc&)
     {

--- a/common/src/range_image.cpp
+++ b/common/src/range_image.cpp
@@ -238,7 +238,7 @@ RangeImage::cropImage (int borderSize, int top, int right, int bottom, int left)
   width = right-left+1; height = bottom-top+1;
   image_offset_x_ = left+oldRangeImage.image_offset_x_;
   image_offset_y_ = top+oldRangeImage.image_offset_y_;
-  points.resize (width*height);
+  points.resize (static_cast<std::size_t>(width)*static_cast<std::size_t>(height));
   
   //std::cout << oldRangeImage.width<<"x"<<oldRangeImage.height<<" -> "<<width<<"x"<<height<<"\n";
   
@@ -289,9 +289,9 @@ RangeImage::getRangesArray () const
 void 
 RangeImage::getIntegralImage (float*& integral_image, int*& valid_points_num_image) const
 {
-  integral_image = new float[width*height];
+  integral_image = new float[static_cast<std::size_t>(width)*static_cast<std::size_t>(height)];
   float* integral_image_ptr = integral_image;
-  valid_points_num_image = new int[width*height];
+  valid_points_num_image = new int[static_cast<std::size_t>(width)*static_cast<std::size_t>(height)];
   int* valid_points_num_image_ptr = valid_points_num_image;
   for (int y = 0; y < static_cast<int> (height); ++y)
   {
@@ -350,7 +350,7 @@ RangeImage::getHalfImage (RangeImage& half_image) const
   half_image.height = height/2;
   half_image.is_dense = is_dense;
   half_image.clear ();
-  half_image.resize (half_image.width*half_image.height);
+  half_image.resize (half_image.width, half_image.height);
   
   int src_start_x = 2*half_image.image_offset_x_ - image_offset_x_,
       src_start_y = 2*half_image.image_offset_y_ - image_offset_y_;
@@ -394,7 +394,7 @@ RangeImage::getSubImage (int sub_image_image_offset_x, int sub_image_image_offse
   sub_image.height = sub_image_height;
   sub_image.is_dense = is_dense;
   sub_image.clear ();
-  sub_image.resize (sub_image.width*sub_image.height);
+  sub_image.resize (sub_image.width, sub_image.height);
   
   int src_start_x = combine_pixels*sub_image.image_offset_x_ - image_offset_x_,
       src_start_y = combine_pixels*sub_image.image_offset_y_ - image_offset_y_;

--- a/common/src/range_image_planar.cpp
+++ b/common/src/range_image_planar.cpp
@@ -69,7 +69,7 @@ namespace pcl
     focal_length_x_reciprocal_ = focal_length_y_reciprocal_ = 1.0f / focal_length_x_;
     center_x_ = static_cast<float> (di_width)  / static_cast<float> (2 * skip);
     center_y_ = static_cast<float> (di_height) / static_cast<float> (2 * skip);
-    points.resize (width*height);
+    points.resize (static_cast<std::size_t>(width)*static_cast<std::size_t>(height));
     
     //std::cout << PVARN (*this);
     
@@ -130,7 +130,7 @@ namespace pcl
     focal_length_y_reciprocal_ = 1.0f / focal_length_y_;
     center_x_ = static_cast<float> (di_center_x) / static_cast<float> (skip);
     center_y_ = static_cast<float> (di_center_y) / static_cast<float> (skip);
-    points.resize (width * height);
+    points.resize (static_cast<std::size_t>(width) * static_cast<std::size_t>(height));
     
     for (int y=0; y < static_cast<int> (height); ++y)
     {
@@ -176,7 +176,7 @@ namespace pcl
     focal_length_y_reciprocal_ = 1.0f / focal_length_y_;
     center_x_ = static_cast<float> (di_center_x) / static_cast<float> (skip);
     center_y_ = static_cast<float> (di_center_y) / static_cast<float> (skip);
-    points.resize (width * height);
+    points.resize (static_cast<std::size_t>(width) * static_cast<std::size_t>(height));
 
     for (int y = 0; y < static_cast<int> (height); ++y)
     {

--- a/examples/common/example_organized_point_cloud.cpp
+++ b/examples/common/example_organized_point_cloud.cpp
@@ -53,10 +53,8 @@ main ()
   CloudType::Ptr cloud (new CloudType);
   
   // Make the cloud a 10x10 grid
-  cloud->height = 10;
-  cloud->width = 10;
   cloud->is_dense = true;
-  cloud->resize(cloud->height * cloud->width);
+  cloud->resize(10, 10);
 
   // Output the (0,0) point
   std::cout << (*cloud)(0,0) << std::endl;

--- a/examples/segmentation/example_supervoxels.cpp
+++ b/examples/segmentation/example_supervoxels.cpp
@@ -194,7 +194,7 @@ main (int argc, char ** argv)
       return (1);
     }
  
-    cloud->points.reserve (depth_dims[0] * depth_dims[1]);
+    cloud->reserve (static_cast<std::size_t>(depth_dims[0]) * static_cast<std::size_t>(depth_dims[1]));
     cloud->width = depth_dims[0];
     cloud->height = depth_dims[1];
     cloud->is_dense = false;

--- a/features/include/pcl/features/impl/brisk_2d.hpp
+++ b/features/include/pcl/features/impl/brisk_2d.hpp
@@ -107,7 +107,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::generateKernel (
     points_ += number;
 
   // set up the patterns
-  pattern_points_ = new BriskPatternPoint[points_*scales_*n_rot_];
+  pattern_points_ = new BriskPatternPoint[static_cast<std::size_t>(points_)*static_cast<std::size_t>(scales_)*static_cast<std::size_t>(n_rot_)];
   BriskPatternPoint* pattern_iterator = pattern_points_;
 
   // define the scale discretization:
@@ -223,7 +223,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
   const float yf = brisk_point.y + key_y;
   const int x = static_cast<int>(xf);
   const int y = static_cast<int>(yf);
-  const int& imagecols = image_width;
+  const std::ptrdiff_t imagecols = image_width;
 
   // get the sigma:
   const float sigma_half = brisk_point.sigma;
@@ -271,7 +271,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::smoothedIntensity
   const int scaling2 = static_cast<int> (static_cast<float>(scaling) * area / 1024.0f);
 
   // the integral image is larger:
-  const int integralcols = imagecols + 1;
+  const std::ptrdiff_t integralcols = image_width + 1;
 
   // calculate borders
   const float x_1 = xf - sigma_half;
@@ -450,7 +450,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
   const auto height = static_cast<index_t>(input_cloud_->height);
 
   // destination for intensity data; will be forwarded to BRISK
-  std::vector<unsigned char> image_data (width*height);
+  std::vector<unsigned char> image_data (static_cast<std::size_t>(width)*static_cast<std::size_t>(height));
 
   for (std::size_t i = 0; i < image_data.size (); ++i)
     image_data[i] = static_cast<unsigned char> (intensity_ ((*input_cloud_)[i]));
@@ -512,7 +512,7 @@ BRISK2DEstimation<PointInT, PointOutT, KeypointT, IntensityT>::compute (
 
   // first, calculate the integral image over the whole image:
   // current integral image
-  std::vector<int> integral ((width+1)*(height+1), 0);    // the integral image
+  std::vector<int> integral (static_cast<std::size_t>(width+1)*static_cast<std::size_t>(height+1), 0);    // the integral image
 
   for (index_t row_index = 1; row_index < height; ++row_index)
   {

--- a/features/include/pcl/features/impl/esf.hpp
+++ b/features/include/pcl/features/impl/esf.hpp
@@ -53,7 +53,7 @@ pcl::ESFEstimation<PointInT, PointOutT>::computeESF (
     PointCloudIn &pc, std::vector<float> &hist)
 {
   const int binsize = 64;
-  unsigned int sample_size = 20000;
+  const std::size_t sample_size = 20000;
   // @TODO: Replace with c++ stdlib uniform_random_generator
   srand (static_cast<unsigned int> (time (nullptr)));
   const auto maxindex = pc.size ();
@@ -269,7 +269,7 @@ pcl::ESFEstimation<PointInT, PointOutT>::computeESF (
   //float weights[10] = {1,  1,  1,  1,  1,  1,  1,  1 , 1 ,  1};
   float weights[10] = {0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 1.0f,  1.0f, 2.0f, 2.0f, 2.0f};
 
-  hist.reserve (binsize * 10);
+  hist.reserve (static_cast<std::size_t>(binsize) * 10);
   for (const float &i : h_a3_in)
     hist.push_back (i * weights[0]);
   for (const float &i : h_a3_out)

--- a/features/include/pcl/features/impl/integral_image2D.hpp
+++ b/features/include/pcl/features/impl/integral_image2D.hpp
@@ -59,10 +59,11 @@ IntegralImage2D<DataType, Dimension>::setInput (const DataType * data, unsigned 
   {
     width_  = width;
     height_ = height;
-    first_order_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
-    finite_values_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
+    const std::size_t ii_size = static_cast<std::size_t>(width_ + 1) * static_cast<std::size_t>(height_ + 1);
+    first_order_integral_image_.resize (ii_size);
+    finite_values_integral_image_.resize (ii_size);
     if (compute_second_order_integral_images_)
-      second_order_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
+      second_order_integral_image_.resize (ii_size);
   }
   computeIntegralImages (data, row_stride, element_stride);
 }
@@ -230,10 +231,11 @@ IntegralImage2D<DataType, 1>::setInput (const DataType * data, unsigned width,un
   {
     width_  = width;
     height_ = height;
-    first_order_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
-    finite_values_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
+    const std::size_t ii_size = static_cast<std::size_t>(width_ + 1) * static_cast<std::size_t>(height_ + 1);
+    first_order_integral_image_.resize (ii_size);
+    finite_values_integral_image_.resize (ii_size);
     if (compute_second_order_integral_images_)
-      second_order_integral_image_.resize ( (width_ + 1) * (height_ + 1) );
+      second_order_integral_image_.resize (ii_size);
   }
   computeIntegralImages (data, row_stride, element_stride);
 }

--- a/features/include/pcl/features/impl/pfh.hpp
+++ b/features/include/pcl/features/impl/pfh.hpp
@@ -171,7 +171,7 @@ pcl::PFHEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut 
   std::queue<std::pair<int, int> > empty;
   std::swap (key_list_, empty);
 
-  pfh_histogram_.setZero (nr_subdiv_ * nr_subdiv_ * nr_subdiv_);
+  pfh_histogram_.setZero (static_cast<Eigen::Index>(nr_subdiv_) * nr_subdiv_ * nr_subdiv_);
 
   // Allocate enough space to hold the results
   // \note This resize is irrelevant for a radiusSearch ().

--- a/features/include/pcl/features/impl/pfhrgb.hpp
+++ b/features/include/pcl/features/impl/pfhrgb.hpp
@@ -135,7 +135,7 @@ template <typename PointInT, typename PointNT, typename PointOutT> void
 pcl::PFHRGBEstimation<PointInT, PointNT, PointOutT>::computeFeature (PointCloudOut &output)
 {
   /// nr_subdiv^3 for RGB and nr_subdiv^3 for the angular features
-  pfhrgb_histogram_.setZero (2 * nr_subdiv_ * nr_subdiv_ * nr_subdiv_);
+  pfhrgb_histogram_.setZero (static_cast<Eigen::Index>(2) * nr_subdiv_ * nr_subdiv_ * nr_subdiv_);
   pfhrgb_tuple_.setZero (7);
 
   // Allocate enough space to hold the results

--- a/features/src/narf.cpp
+++ b/features/src/narf.cpp
@@ -109,9 +109,9 @@ Narf::deepCopy (const Narf& other)
   {
     surface_patch_pixel_size_ = other.surface_patch_pixel_size_;
     delete[] surface_patch_;
-    surface_patch_ = new float[surface_patch_pixel_size_*surface_patch_pixel_size_];
+    surface_patch_ = new float[static_cast<std::size_t>(surface_patch_pixel_size_)*static_cast<std::size_t>(surface_patch_pixel_size_)];
   }
-  std::copy(other.surface_patch_, other.surface_patch_ + surface_patch_pixel_size_*surface_patch_pixel_size_, surface_patch_);
+  std::copy(other.surface_patch_, other.surface_patch_ + static_cast<ptrdiff_t>(surface_patch_pixel_size_)*static_cast<ptrdiff_t>(surface_patch_pixel_size_), surface_patch_);
   surface_patch_world_size_ = other.surface_patch_world_size_;
   surface_patch_rotation_ = other.surface_patch_rotation_;
   
@@ -521,7 +521,7 @@ Narf::saveBinary (std::ostream& file) const
   pcl::saveBinary(transformation_.matrix(), file);
   file.write(reinterpret_cast<const char*>(&surface_patch_pixel_size_), sizeof(surface_patch_pixel_size_));
   file.write(reinterpret_cast<const char*>(surface_patch_),
-             surface_patch_pixel_size_*surface_patch_pixel_size_*sizeof(*surface_patch_));
+             sizeof(*surface_patch_)*surface_patch_pixel_size_*surface_patch_pixel_size_);
   file.write(reinterpret_cast<const char*>(&surface_patch_world_size_), sizeof(surface_patch_world_size_));
   file.write(reinterpret_cast<const char*>(&surface_patch_rotation_), sizeof(surface_patch_rotation_));
   file.write(reinterpret_cast<const char*>(&descriptor_size_), sizeof(descriptor_size_));
@@ -573,9 +573,9 @@ Narf::loadBinary (std::istream& file)
   pcl::loadBinary(position_.matrix(), file);
   pcl::loadBinary(transformation_.matrix(), file);
   file.read(reinterpret_cast<char*>(&surface_patch_pixel_size_), sizeof(surface_patch_pixel_size_));
-  surface_patch_ = new float[surface_patch_pixel_size_*surface_patch_pixel_size_];
+  surface_patch_ = new float[static_cast<std::size_t>(surface_patch_pixel_size_)*static_cast<std::size_t>(surface_patch_pixel_size_)];
   file.read(reinterpret_cast<char*>(surface_patch_),
-            surface_patch_pixel_size_*surface_patch_pixel_size_*sizeof(*surface_patch_));
+            sizeof(*surface_patch_)*surface_patch_pixel_size_*surface_patch_pixel_size_);
   file.read(reinterpret_cast<char*>(&surface_patch_world_size_), sizeof(surface_patch_world_size_));
   file.read(reinterpret_cast<char*>(&surface_patch_rotation_), sizeof(surface_patch_rotation_));
   file.read(reinterpret_cast<char*>(&descriptor_size_), sizeof(descriptor_size_));

--- a/features/src/range_image_border_extractor.cpp
+++ b/features/src/range_image_border_extractor.cpp
@@ -201,7 +201,7 @@ RangeImageBorderExtractor::extractBorderScoreImages ()
 float*
 RangeImageBorderExtractor::updatedScoresAccordingToNeighborValues (const float* border_scores) const
 {
-  float* new_scores = new float[range_image_->width*range_image_->height];
+  float* new_scores = new float[static_cast<std::size_t>(range_image_->width)*static_cast<std::size_t>(range_image_->height)];
   float* new_scores_ptr = new_scores;
   for (int y=0; y < static_cast<int> (range_image_->height); ++y)
     for (int x=0; x < static_cast<int> (range_image_->width); ++x)
@@ -213,7 +213,7 @@ std::vector<float>
 RangeImageBorderExtractor::updatedScoresAccordingToNeighborValues (const std::vector<float>& border_scores) const
 {
   std::vector<float> new_border_scores;
-  new_border_scores.reserve (range_image_->width*range_image_->height);
+  new_border_scores.reserve (static_cast<std::size_t>(range_image_->width)*static_cast<std::size_t>(range_image_->height));
   for (int y=0; y < static_cast<int> (range_image_->height); ++y)
     for (int x=0; x < static_cast<int> (range_image_->width); ++x)
       new_border_scores.push_back (updatedScoreAccordingToNeighborValues(x, y, border_scores.data ()));
@@ -248,15 +248,14 @@ RangeImageBorderExtractor::findAndEvaluateShadowBorders ()
 
   //MEASURE_FUNCTION_TIME;
 
-  int width  = range_image_->width,
+  std::size_t width  = range_image_->width,
       height = range_image_->height;
   shadow_border_informations_ = new ShadowBorderIndices*[width*height];
   for (int y = 0; y < static_cast<int> (height); ++y)
   {
     for (int x = 0; x < static_cast<int> (width); ++x)
     {
-      int index = y*width+x;
-      ShadowBorderIndices*& shadow_border_indices = shadow_border_informations_[index];
+      ShadowBorderIndices*& shadow_border_indices = shadow_border_informations_[y*width+x];
       shadow_border_indices = nullptr;
       int shadow_border_idx;
 
@@ -611,8 +610,8 @@ RangeImageBorderExtractor::blurSurfaceChanges ()
 
   const RangeImage& range_image = *range_image_;
 
-  auto* blurred_directions = new Eigen::Vector3f[range_image.width*range_image.height];
-  float* blurred_scores = new float[range_image.width*range_image.height];
+  auto* blurred_directions = new Eigen::Vector3f[static_cast<std::size_t>(range_image.width)*static_cast<std::size_t>(range_image.height)];
+  float* blurred_scores = new float[static_cast<std::size_t>(range_image.width)*static_cast<std::size_t>(range_image.height)];
   for (int y=0; y<static_cast<int>(range_image.height); ++y)
   {
     for (int x=0; x<static_cast<int>(range_image.width); ++x)


### PR DESCRIPTION
See https://clang.llvm.org/extra/clang-tidy/checks/bugprone/implicit-widening-of-multiplication-result.html

I applied the following rules of thumb:
- use point_cloud.resize(width, height) instead of point_cloud.resize(width*height)
- cast factors to `std::size_t` if multiplication result would be cast to `std::size_t` later anyway (e.g. used for vector.resize, vector.reserve, vector[])
- change some variables to type `std::size_t` if they otherwise had to be cast repeatedly

We actually had some reports in the past where people were working with large point types (at least 32 bytes per point) and a large number of points, so that `(bytes per point)*(height)*(width)` would overflow if done in 32 bit types (e.g. when accessing the binary data in PCLPointCloud2). Fixing the implicit-widening-of-multiplication-result warnings would prevent such kinds of problems.
Supersedes and closes https://github.com/PointCloudLibrary/pcl/pull/5911