### PR TITLE
Remove unnecessary PCL_EXPORTS in common

### DIFF
--- a/common/include/pcl/common/colors.h
+++ b/common/include/pcl/common/colors.h
@@ -98,7 +98,7 @@ namespace pcl
    * www.srgb.com, www.color.org/srgb.html
    */
   template <typename T, std::uint8_t bits = 8>
-  PCL_EXPORTS inline std::array<T, 1 << bits>
+  inline std::array<T, 1 << bits>
   RGB2sRGB_LUT() noexcept
   {
     static_assert(std::is_floating_point<T>::value, "LUT value must be a floating point");
@@ -144,7 +144,7 @@ namespace pcl
    * Reference: Billmeyer and Saltzman’s Principles of Color Technology
    */
   template <typename T, std::size_t discretizations = 4000>
-  PCL_EXPORTS inline const std::array<T, discretizations>&
+  inline const std::array<T, discretizations>&
   XYZ2LAB_LUT() noexcept
   {
     static_assert(std::is_floating_point<T>::value, "LUT value must be a floating point");

--- a/common/include/pcl/common/intersections.h
+++ b/common/include/pcl/common/intersections.h
@@ -86,13 +86,13 @@ namespace pcl
     * \param[in] angular_tolerance tolerance in radians
     * \return true if succeeded/planes aren't parallel
     */
-  template <typename Scalar> PCL_EXPORTS bool
+  template <typename Scalar> bool
   planeWithPlaneIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a,
                               const Eigen::Matrix<Scalar, 4, 1> &plane_b,
                               Eigen::Matrix<Scalar, Eigen::Dynamic, 1> &line,
                               double angular_tolerance = 0.1);
 
-  PCL_EXPORTS inline bool
+  inline bool
   planeWithPlaneIntersection (const Eigen::Vector4f &plane_a,
                               const Eigen::Vector4f &plane_b,
                               Eigen::VectorXf &line,
@@ -101,7 +101,7 @@ namespace pcl
     return (planeWithPlaneIntersection<float> (plane_a, plane_b, line, angular_tolerance));
   }
 
-  PCL_EXPORTS inline bool
+  inline bool
   planeWithPlaneIntersection (const Eigen::Vector4d &plane_a,
                               const Eigen::Vector4d &plane_b,
                               Eigen::VectorXd &line,
@@ -121,7 +121,7 @@ namespace pcl
     * \param[out] intersection_point the three coordinates x, y, z of the intersection point
     * \return true if succeeded/planes aren't parallel
     */
-  template <typename Scalar> PCL_EXPORTS bool
+  template <typename Scalar> bool
   threePlanesIntersection (const Eigen::Matrix<Scalar, 4, 1> &plane_a,
                            const Eigen::Matrix<Scalar, 4, 1> &plane_b,
                            const Eigen::Matrix<Scalar, 4, 1> &plane_c,
@@ -129,7 +129,7 @@ namespace pcl
                            double determinant_tolerance = 1e-6);
 
 
-  PCL_EXPORTS inline bool
+  inline bool
   threePlanesIntersection (const Eigen::Vector4f &plane_a,
                            const Eigen::Vector4f &plane_b,
                            const Eigen::Vector4f &plane_c,
@@ -140,7 +140,7 @@ namespace pcl
                                             intersection_point, determinant_tolerance));
   }
 
-  PCL_EXPORTS inline bool
+  inline bool
   threePlanesIntersection (const Eigen::Vector4d &plane_a,
                            const Eigen::Vector4d &plane_b,
                            const Eigen::Vector4d &plane_c,

--- a/common/include/pcl/common/io.h
+++ b/common/include/pcl/common/io.h
@@ -277,7 +277,7 @@ namespace pcl
     * \ingroup common
     */
   template <typename PointT>
-  PCL_EXPORTS bool
+  bool
   concatenate (const pcl::PointCloud<PointT> &cloud1,
                const pcl::PointCloud<PointT> &cloud2,
                pcl::PointCloud<PointT> &cloud_out)
@@ -295,7 +295,7 @@ namespace pcl
     * \return true if successful, false otherwise
     * \ingroup common
     */
-  PCL_EXPORTS inline bool
+  inline bool
   concatenate (const pcl::PCLPointCloud2 &cloud1,
                const pcl::PCLPointCloud2 &cloud2,
                pcl::PCLPointCloud2 &cloud_out)
@@ -310,7 +310,7 @@ namespace pcl
     * \return true if successful, false otherwise
     * \ingroup common
     */
-  PCL_EXPORTS inline bool
+  inline bool
   concatenate (const pcl::PolygonMesh &mesh1,
                const pcl::PolygonMesh &mesh2,
                pcl::PolygonMesh &mesh_out)

--- a/common/include/pcl/point_cloud.h
+++ b/common/include/pcl/point_cloud.h
@@ -169,7 +169,7 @@ namespace pcl
     * \author Patrick Mihelich, Radu B. Rusu
     */
   template <typename PointT>
-  class PCL_EXPORTS PointCloud
+  class PointCloud
   {
     public:
       /** \brief Default constructor. Sets \ref is_dense to true, \ref width
@@ -921,5 +921,3 @@ namespace pcl
     return (s);
   }
 }
-
-#define PCL_INSTANTIATE_PointCloud(T) template class PCL_EXPORTS pcl::PointCloud<T>;


### PR DESCRIPTION
When:
* a method was templated
* the full definition was present in the header

Except for any range_image files.

See #5779 for reference.