### PR TITLE
Set better default for RRANSAC and RMSAC

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/impl/rmsac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/rmsac.hpp
@@ -72,7 +72,8 @@ pcl::RandomizedMEstimatorSampleConsensus<PointT>::computeModel (int debug_verbos
   const unsigned max_skip = max_iterations_ * 10;
   
   // Number of samples to try randomly
-  std::size_t fraction_nr_points = pcl_lrint (static_cast<double>(sac_model_->getIndices ()->size ()) * fraction_nr_pretest_ / 100.0);
+  const std::size_t fraction_nr_points = (fraction_nr_pretest_ < 0.0 ? nr_samples_pretest_ : pcl_lrint (static_cast<double>(sac_model_->getIndices ()->size ()) * fraction_nr_pretest_ / 100.0));
+  PCL_DEBUG ("[pcl::RandomizedMEstimatorSampleConsensus::computeModel] Using %lu points for RMSAC pre-test.\n", fraction_nr_points);
 
   // Iterate
   while (iterations_ < k && skipped_count < max_skip)

--- a/sample_consensus/include/pcl/sample_consensus/impl/rransac.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/rransac.hpp
@@ -71,7 +71,8 @@ pcl::RandomizedRandomSampleConsensus<PointT>::computeModel (int debug_verbosity_
   const unsigned max_skip = max_iterations_ * 10;
 
   // Number of samples to try randomly
-  const std::size_t fraction_nr_points = pcl_lrint (static_cast<double>(sac_model_->getIndices ()->size ()) * fraction_nr_pretest_ / 100.0);
+  const std::size_t fraction_nr_points = (fraction_nr_pretest_ < 0.0 ? nr_samples_pretest_ : pcl_lrint (static_cast<double>(sac_model_->getIndices ()->size ()) * fraction_nr_pretest_ / 100.0));
+  PCL_DEBUG ("[pcl::RandomizedRandomSampleConsensus::computeModel] Using %lu points for RRANSAC pre-test.\n", fraction_nr_points);
 
   // Iterate
   while (iterations_ < k)

--- a/sample_consensus/include/pcl/sample_consensus/rmsac.h
+++ b/sample_consensus/include/pcl/sample_consensus/rmsac.h
@@ -75,7 +75,8 @@ namespace pcl
         */
       RandomizedMEstimatorSampleConsensus (const SampleConsensusModelPtr &model) 
         : SampleConsensus<PointT> (model)
-        , fraction_nr_pretest_ (10.0) // Number of samples to try randomly in percents
+        , fraction_nr_pretest_ (-1.0)
+        , nr_samples_pretest_ (1)
       {
         // Maximum number of trials before we give up.
         max_iterations_ = 10000;
@@ -87,7 +88,8 @@ namespace pcl
         */
       RandomizedMEstimatorSampleConsensus (const SampleConsensusModelPtr &model, double threshold) 
         : SampleConsensus<PointT> (model, threshold)
-        , fraction_nr_pretest_ (10.0) // Number of samples to try randomly in percents
+        , fraction_nr_pretest_ (-1.0)
+        , nr_samples_pretest_ (1)
       {
         // Maximum number of trials before we give up.
         max_iterations_ = 10000;
@@ -100,18 +102,41 @@ namespace pcl
       computeModel (int debug_verbosity_level = 0) override;
 
       /** \brief Set the percentage of points to pre-test.
+        * This is an alternative to setNrSamplesPretest.
         * \param[in] nr_pretest percentage of points to pre-test
         */
       inline void 
-      setFractionNrPretest (double nr_pretest) { fraction_nr_pretest_ = nr_pretest; }
+      setFractionNrPretest (double nr_pretest)
+      {
+        fraction_nr_pretest_ = nr_pretest;
+        nr_samples_pretest_ = 0;
+      }
 
       /** \brief Get the percentage of points to pre-test. */
       inline double 
       getFractionNrPretest () const { return (fraction_nr_pretest_); }
 
+      /** \brief Set the absolute number of points to pre-test.
+        * This is an alternative to setFractionNrPretest.
+        * \param[in] nr_pretest absolute number of points to pre-test
+        */
+      inline void
+      setNrSamplesPretest (std::size_t nr_pretest)
+      {
+        nr_samples_pretest_ = nr_pretest;
+        fraction_nr_pretest_ = -1.0;
+      }
+
+      /** \brief Get the absolute number of points to pre-test. */
+      inline std::size_t
+      getNrSamplesPretest () const { return (nr_samples_pretest_); }
+
     private:
-      /** \brief Number of samples to randomly pre-test, in percents. */
+      /** \brief Number of samples to randomly pre-test, in percents. This is an alternative and mutually exclusive to nr_samples_pretest_. */
       double fraction_nr_pretest_;
+
+      /** \brief Absolute number of samples to randomly pre-test. This is an alternative and mutually exclusive to fraction_nr_pretest_. */
+      std::size_t nr_samples_pretest_;
   };
 }
 

--- a/sample_consensus/include/pcl/sample_consensus/rransac.h
+++ b/sample_consensus/include/pcl/sample_consensus/rransac.h
@@ -79,7 +79,8 @@ namespace pcl
         */
       RandomizedRandomSampleConsensus (const SampleConsensusModelPtr &model) 
         : SampleConsensus<PointT> (model)
-        , fraction_nr_pretest_ (10.0) // Number of samples to try randomly in percents
+        , fraction_nr_pretest_ (-1.0)
+        , nr_samples_pretest_ (1)
       {
         // Maximum number of trials before we give up.
         max_iterations_ = 10000;
@@ -91,7 +92,8 @@ namespace pcl
         */
       RandomizedRandomSampleConsensus (const SampleConsensusModelPtr &model, double threshold) 
         : SampleConsensus<PointT> (model, threshold)
-        , fraction_nr_pretest_ (10.0) // Number of samples to try randomly in percents
+        , fraction_nr_pretest_ (-1.0)
+        , nr_samples_pretest_ (1)
       {
         // Maximum number of trials before we give up.
         max_iterations_ = 10000;
@@ -104,18 +106,41 @@ namespace pcl
       computeModel (int debug_verbosity_level = 0) override;
 
       /** \brief Set the percentage of points to pre-test.
+        * This is an alternative to setNrSamplesPretest.
         * \param[in] nr_pretest percentage of points to pre-test
         */
       inline void 
-      setFractionNrPretest (double nr_pretest) { fraction_nr_pretest_ = nr_pretest; }
+      setFractionNrPretest (double nr_pretest)
+      {
+        fraction_nr_pretest_ = nr_pretest;
+        nr_samples_pretest_ = 0;
+      }
 
       /** \brief Get the percentage of points to pre-test. */
       inline double 
       getFractionNrPretest () const { return (fraction_nr_pretest_); }
 
+      /** \brief Set the absolute number of points to pre-test.
+        * This is an alternative to setFractionNrPretest.
+        * \param[in] nr_pretest absolute number of points to pre-test
+        */
+      inline void
+      setNrSamplesPretest (std::size_t nr_pretest)
+      {
+        nr_samples_pretest_ = nr_pretest;
+        fraction_nr_pretest_ = -1.0;
+      }
+
+      /** \brief Get the absolute number of points to pre-test. */
+      inline std::size_t
+      getNrSamplesPretest () const { return (nr_samples_pretest_); }
+
     private:
-      /** \brief Number of samples to randomly pre-test, in percents. */
+      /** \brief Number of samples to randomly pre-test, in percents. This is an alternative and mutually exclusive to nr_samples_pretest_. */
       double fraction_nr_pretest_;
+
+      /** \brief Absolute number of samples to randomly pre-test. This is an alternative and mutually exclusive to fraction_nr_pretest_. */
+      std::size_t nr_samples_pretest_;
   };
 }
 


### PR DESCRIPTION
RRANSAC is a faster variant of RANSAC. It performs a pretest before counting all inliers of a candidate model (this is the costly part of RANSAC). The pretest consists of choosing a number of random sample points and then testing if _all_ these points are inliers. If just one is an outlier, the candidate model is discarded. The previous default was to choose 10 percent of all points for this pretest, which is far too much, and the probability of a candidate model (even a good one!) not being discarded is near zero. Therefore RRANSAC fails to find a model in many cases. The new default is to use one point for the pretest. This has a good chance of rejecting very bad models, but not reject any good models. This is a good default for many different datasets.

The same is done for RMSAC, which is a faster variant of MSAC. MSAC uses a different way to judge the quality of a candidate model than RANSAC, but works very similarly otherwise.