### PR TITLE
Faster organized radius search

### DIFF
--- a/search/include/pcl/search/impl/organized.hpp
+++ b/search/include/pcl/search/impl/organized.hpp
@@ -82,7 +82,7 @@ pcl::search::OrganizedNeighbor<PointT>::radiusSearch (const               PointT
   {
     for (; idx < xEnd; ++idx)
     {
-      if (!mask_[idx] || !isFinite ((*input_)[idx]))
+      if (!mask_[idx])
         continue;
 
       float dist_x = (*input_)[idx].x - query.x;


### PR DESCRIPTION
By checking the finite-ness of all points once, before doing any searches. This avoids calling isFinite repeatedly on the same points in radiusSearch. Benchmark: NormalEstimation with OrganizedNeighbor and radius search now takes 89 percent of the time it took before (so 11 percent faster).