### PR TITLE
Added missing PCL_NO_PRECOMPILE to feature.h

### DIFF
--- a/features/include/pcl/features/feature.h
+++ b/features/include/pcl/features/feature.h
@@ -488,4 +488,6 @@ namespace pcl
   };
 }
 
+#ifdef PCL_NO_PRECOMPILE
 #include <pcl/features/impl/feature.hpp>
+#endif


### PR DESCRIPTION
I added the `#ifdef PCL_NO_PRECOMPILE` to _features/feature.h_ to surround `#include <pcl/features/impl/feature.hpp>` at bottom of file:
`#ifdef PCL_NO_PRECOMPILE`
`#include <pcl/features/impl/feature.hpp>`
`#endif`

I found this while trying to use _PrincipalCurvaturesEstimation_ (`pcl::PrincipalCurvaturesEstimation<pcl::PointXYZ, pcl::Normal, pcl::PrincipalCurvatures> principalCurvaturesEstimation;`).
Without this _#ifdef_, got a compiler error at debug build (`error LNK2019: Verweis auf nicht aufgeloestes externes Symbol ""public: void __cdecl pcl::search::OrganizedNeighbor<struct pcl::PointXYZ>::estimateProjectionMatrix(void)" ...`) using Windows/vc-141.

I assume, the #ifdef is just missing here or is there any reason for using it everywhere else but not here?