### PR TITLE
:bug: Fix RoPS total area

### DIFF
--- a/features/include/pcl/features/impl/rops_estimation.hpp
+++ b/features/include/pcl/features/impl/rops_estimation.hpp
@@ -283,9 +283,9 @@ pcl::ROPSEstimation <PointInT, PointOutT>::computeLRF (const PointInT& point, co
   }
 
   if (std::abs (total_area) < std::numeric_limits <float>::epsilon ())
-    total_area = 1.0f / total_area;
-  else
     total_area = 1.0f;
+  else
+    total_area = 1.0f / total_area;
 
   Eigen::Matrix3f overall_scatter_matrix;
   overall_scatter_matrix.setZero ();


### PR DESCRIPTION
In ROPSEstimation implementation there's a if clause in the normalization of the total area meant to avoid a division by 0. Unfortunately the code currently in the if branch should go in the else branch and vice-versa. 
The current code does not perform any normalization unless the area is close to zero; in that case the division 1.0 / area causes the weight to explode to infinity.

This PR fixes this small but relevant bug.