### PR TITLE
fix registration iteration 1 mse print

### DIFF
--- a/registration/include/pcl/registration/impl/default_convergence_criteria.hpp
+++ b/registration/include/pcl/registration/impl/default_convergence_criteria.hpp
@@ -91,10 +91,17 @@ DefaultConvergenceCriteria<Scalar>::hasConverged()
   }
 
   correspondences_cur_mse_ = calculateMSE(correspondences_);
-  PCL_DEBUG("[pcl::DefaultConvergenceCriteria::hasConverged] Previous / Current MSE "
-            "for correspondences distances is: %f / %f.\n",
-            correspondences_prev_mse_,
-            correspondences_cur_mse_);
+  if (std::numeric_limits<double>::max() == correspondences_prev_mse_) {
+    PCL_DEBUG("[pcl::DefaultConvergenceCriteria::hasConverged] Previous / Current MSE "
+              "for correspondences distances is: INIT / %f.\n",
+              correspondences_cur_mse_);
+  }
+  else {
+    PCL_DEBUG("[pcl::DefaultConvergenceCriteria::hasConverged] Previous / Current MSE "
+              "for correspondences distances is: %f / %f.\n",
+              correspondences_prev_mse_,
+              correspondences_cur_mse_);
+  }
 
   // 3. The relative sum of Euclidean squared errors is smaller than a user defined
   // threshold Absolute


### PR DESCRIPTION
for registration iteration1, print mse "INIT" instead of "179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368.000000"