### PR TITLE
Compile PCL as C++17 by default, switching back to C++14 currently still possible

### DIFF
--- a/.ci/azure-pipelines/azure-pipelines.yaml
+++ b/.ci/azure-pipelines/azure-pipelines.yaml
@@ -48,7 +48,7 @@ stages:
               CC: gcc
               CXX: g++
               BUILD_GPU: ON
-              CMAKE_ARGS: '-DPCL_WARNINGS_ARE_ERRORS=ON'
+              CMAKE_ARGS: '-DPCL_WARNINGS_ARE_ERRORS=ON -DCMAKE_CXX_STANDARD=14 -DCMAKE_CUDA_STANDARD=14'
             24.04 GCC:  # latest Ubuntu
               CONTAINER: env2404
               CC: gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,12 +2,22 @@
 cmake_minimum_required(VERSION 3.16.3 FATAL_ERROR)
 
 # Set target C++ standard and required compiler features
-set(CMAKE_CXX_STANDARD 14 CACHE STRING "The target C++ standard. PCL requires C++14 or higher.")
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "The target C++ standard. PCL requires C++14 or higher.")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-set(PCL_CXX_COMPILE_FEATURES cxx_std_14)
+if("${CMAKE_CXX_STANDARD}" GREATER_EQUAL 17)
+  set(PCL_CXX_COMPILE_FEATURES cxx_std_17)
+  set(PCL__cplusplus 201703L)
+  set(PCL_REQUIRES_MSC_VER 1912)
+elseif("${CMAKE_CXX_STANDARD}" EQUAL 14)
+  set(PCL_CXX_COMPILE_FEATURES cxx_std_14)
+  set(PCL__cplusplus 201402L)
+  set(PCL_REQUIRES_MSC_VER 1900)
+else()
+  message(FATAL_ERROR "Unknown or unsupported C++ standard specified")
+endif()
 
-set(CMAKE_CUDA_STANDARD 14 CACHE STRING "The target CUDA/C++ standard. PCL requires CUDA/C++ 14 or higher.")
+set(CMAKE_CUDA_STANDARD 17 CACHE STRING "The target CUDA/C++ standard. PCL requires CUDA/C++ 14 or higher.")
 set(CMAKE_CUDA_STANDARD_REQUIRED ON)
 
 set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "possible configurations" FORCE)

--- a/geometry/include/pcl/geometry/mesh_base.h
+++ b/geometry/include/pcl/geometry/mesh_base.h
@@ -1804,14 +1804,14 @@ protected:
                                 typename IndexContainerT::value_type());
     Index ind_old(0), ind_new(0);
 
-    typename ElementContainerT::const_iterator it_e_old = elements.begin();
+    auto it_e_old = elements.cbegin();
     auto it_e_new = elements.begin();
 
-    typename DataContainerT::const_iterator it_d_old = data_cloud.begin();
+    auto it_d_old = data_cloud.cbegin();
     auto it_d_new = data_cloud.begin();
 
     auto it_ind_new = new_indices.begin();
-    typename IndexContainerT::const_iterator it_ind_new_end = new_indices.end();
+    auto it_ind_new_end = new_indices.cend();
 
     while (it_ind_new != it_ind_new_end) {
       if (!this->isDeleted(ind_old)) {

--- a/io/src/openni2/openni2_device.cpp
+++ b/io/src/openni2/openni2_device.cpp
@@ -215,8 +215,8 @@ pcl::io::openni2::OpenNI2Device::isIRVideoModeSupported (const OpenNI2VideoMode&
 
   bool supported = false;
 
-  std::vector<OpenNI2VideoMode>::const_iterator it = ir_video_modes_.begin ();
-  std::vector<OpenNI2VideoMode>::const_iterator it_end = ir_video_modes_.end ();
+  auto it = ir_video_modes_.cbegin ();
+  auto it_end = ir_video_modes_.cend ();
 
   while (it != it_end && !supported)
   {
@@ -234,8 +234,8 @@ pcl::io::openni2::OpenNI2Device::isColorVideoModeSupported (const OpenNI2VideoMo
 
   bool supported = false;
 
-  std::vector<OpenNI2VideoMode>::const_iterator it = color_video_modes_.begin ();
-  std::vector<OpenNI2VideoMode>::const_iterator it_end = color_video_modes_.end ();
+  auto it = color_video_modes_.cbegin ();
+  auto it_end = color_video_modes_.cend ();
 
   while (it != it_end && !supported)
   {
@@ -253,8 +253,8 @@ pcl::io::openni2::OpenNI2Device::isDepthVideoModeSupported (const OpenNI2VideoMo
 
   bool supported = false;
 
-  std::vector<OpenNI2VideoMode>::const_iterator it = depth_video_modes_.begin ();
-  std::vector<OpenNI2VideoMode>::const_iterator it_end = depth_video_modes_.end ();
+  auto it = depth_video_modes_.cbegin ();
+  auto it_end = depth_video_modes_.cend ();
 
   while (it != it_end && !supported)
   {

--- a/io/src/openni2/openni2_timer_filter.cpp
+++ b/io/src/openni2/openni2_timer_filter.cpp
@@ -73,8 +73,8 @@ namespace pcl
         {
           double sum = 0;
 
-          std::deque<double>::const_iterator it = buffer_.begin ();
-          std::deque<double>::const_iterator it_end = buffer_.end ();
+          auto it = buffer_.cbegin ();
+          auto it_end = buffer_.cend ();
 
           while (it != it_end)
           {

--- a/io/src/openni_camera/openni_driver.cpp
+++ b/io/src/openni_camera/openni_driver.cpp
@@ -348,7 +348,7 @@ openni_wrapper::OpenNIDriver::getDeviceInfos () noexcept
   {
     libusb_device* device = devices[devIdx];
     std::uint8_t busId = libusb_get_bus_number (device);
-    std::map<unsigned char, std::map<unsigned char, unsigned> >::const_iterator busIt = bus_map_.find (busId);
+    auto busIt = bus_map_.find (busId);
     if (busIt == bus_map_.end ())
       continue;
 

--- a/octree/include/pcl/octree/impl/octree2buf_base.hpp
+++ b/octree/include/pcl/octree/impl/octree2buf_base.hpp
@@ -279,8 +279,8 @@ Octree2BufBase<LeafContainerT, BranchContainerT>::deserializeTree(
   leaf_count_ = 0;
 
   // iterator for binary tree structure vector
-  std::vector<char>::const_iterator binary_tree_in_it = binary_tree_in_arg.begin();
-  std::vector<char>::const_iterator binary_tree_in_it_end = binary_tree_in_arg.end();
+  auto binary_tree_in_it = binary_tree_in_arg.cbegin();
+  auto binary_tree_in_it_end = binary_tree_in_arg.cend();
 
   deserializeTreeRecursive(root_node_,
                            depth_mask_,
@@ -307,19 +307,17 @@ Octree2BufBase<LeafContainerT, BranchContainerT>::deserializeTree(
   OctreeKey new_key;
 
   // set data iterator to first element
-  typename std::vector<LeafContainerT*>::const_iterator leaf_container_vector_it =
-      leaf_container_vector_arg.begin();
+  auto leaf_container_vector_it = leaf_container_vector_arg.cbegin();
 
   // set data iterator to last element
-  typename std::vector<LeafContainerT*>::const_iterator leaf_container_vector_it_end =
-      leaf_container_vector_arg.end();
+  auto leaf_container_vector_it_end = leaf_container_vector_arg.cend();
 
   // we will rebuild an octree -> reset leafCount
   leaf_count_ = 0;
 
   // iterator for binary tree structure vector
-  std::vector<char>::const_iterator binary_tree_in_it = binary_tree_in_arg.begin();
-  std::vector<char>::const_iterator binary_tree_in_it_end = binary_tree_in_arg.end();
+  auto binary_tree_in_it = binary_tree_in_arg.cbegin();
+  auto binary_tree_in_it_end = binary_tree_in_arg.cend();
 
   deserializeTreeRecursive(root_node_,
                            depth_mask_,

--- a/octree/include/pcl/octree/impl/octree_base.hpp
+++ b/octree/include/pcl/octree/impl/octree_base.hpp
@@ -244,8 +244,8 @@ OctreeBase<LeafContainerT, BranchContainerT>::deserializeTree(
   deleteTree();
 
   // iterator for binary tree structure vector
-  std::vector<char>::const_iterator binary_tree_out_it = binary_tree_out_arg.begin();
-  std::vector<char>::const_iterator binary_tree_out_it_end = binary_tree_out_arg.end();
+  auto binary_tree_out_it = binary_tree_out_arg.cbegin();
+  auto binary_tree_out_it_end = binary_tree_out_arg.cend();
 
   deserializeTreeRecursive(root_node_,
                            depth_mask_,
@@ -266,19 +266,17 @@ OctreeBase<LeafContainerT, BranchContainerT>::deserializeTree(
   OctreeKey new_key;
 
   // set data iterator to first element
-  typename std::vector<LeafContainerT*>::const_iterator leaf_vector_it =
-      leaf_container_vector_arg.begin();
+  auto leaf_vector_it = leaf_container_vector_arg.cbegin();
 
   // set data iterator to last element
-  typename std::vector<LeafContainerT*>::const_iterator leaf_vector_it_end =
-      leaf_container_vector_arg.end();
+  auto leaf_vector_it_end = leaf_container_vector_arg.cend();
 
   // free existing tree before tree rebuild
   deleteTree();
 
   // iterator for binary tree structure vector
-  std::vector<char>::const_iterator binary_tree_input_it = binary_tree_in_arg.begin();
-  std::vector<char>::const_iterator binary_tree_input_it_end = binary_tree_in_arg.end();
+  auto binary_tree_input_it = binary_tree_in_arg.cbegin();
+  auto binary_tree_input_it_end = binary_tree_in_arg.cend();
 
   deserializeTreeRecursive(root_node_,
                            depth_mask_,

--- a/pcl_config.h.in
+++ b/pcl_config.h.in
@@ -3,8 +3,8 @@
 // Ensure the compiler is meeting the minimum C++ standard
 // MSVC is not checked via __cplusplus due to
 // https://developercommunity.visualstudio.com/content/problem/120156/-cplusplus-macro-still-defined-as-pre-c11-value.html
-#if defined(__cplusplus) && ((!defined(_MSC_VER) && __cplusplus < 201402L) || (defined(_MSC_VER) && _MSC_VER < 1900))
-  #error PCL requires C++14 or above
+#if defined(__cplusplus) && ((!defined(_MSC_VER) && __cplusplus < ${PCL__cplusplus}) || (defined(_MSC_VER) && _MSC_VER < ${PCL_REQUIRES_MSC_VER}) || (defined(_MSVC_LANG) && _MSVC_LANG < ${PCL__cplusplus}))
+  #error C++ standard too low (PCL requires ${PCL__cplusplus} or above)
 #endif
 
 #define BUILD_@CMAKE_BUILD_TYPE@

--- a/recognition/src/ransac_based/obj_rec_ransac.cpp
+++ b/recognition/src/ransac_based/obj_rec_ransac.cpp
@@ -420,7 +420,7 @@ pcl::recognition::ObjRecRANSAC::buildGraphOfCloseHypotheses (HypothesisOctree& h
   i = 0;
 
   // Now create the graph connectivity such that each two neighboring rotation spaces are neighbors in the graph
-  for ( std::vector<HypothesisOctree::Node*>::const_iterator hypo = hypo_leaves.begin () ; hypo != hypo_leaves.end () ; ++hypo, ++i )
+  for ( auto hypo = hypo_leaves.cbegin () ; hypo != hypo_leaves.cend () ; ++hypo, ++i )
   {
     // Compute the fitness of the graph node
     graph.getNodes ()[i]->setFitness (static_cast<int> ((*hypo)->getData ().explained_pixels_.size ()));

--- a/registration/include/pcl/registration/impl/lum.hpp
+++ b/registration/include/pcl/registration/impl/lum.hpp
@@ -268,7 +268,7 @@ LUM<PointT>::compute()
     // Update the poses
     float sum = 0.0;
     for (int vi = 1; vi != n; ++vi) {
-      Eigen::Vector6f difference_pose = static_cast<Eigen::Vector6f>(
+      auto difference_pose = static_cast<Eigen::Vector6f>(
           -incidenceCorrection(getPose(vi)).inverse() * X.segment(6 * (vi - 1), 6));
       sum += difference_pose.norm();
       setPose(vi, getPose(vi) + difference_pose);

--- a/segmentation/src/grabcut_segmentation.cpp
+++ b/segmentation/src/grabcut_segmentation.cpp
@@ -460,7 +460,7 @@ pcl::segmentation::grabcut::BoykovKolmogorov::adoptOrphans (std::deque<int>& orp
       if (cut_[jt->first] != tree_label) continue;
 
       // check edge capacity
-      const capacitated_edge::iterator kt = nodes_[jt->first].find (u);
+      const auto kt = nodes_[jt->first].find (u);
       if (((tree_label == TARGET) && (jt->second <= 0.0)) ||
           ((tree_label == SOURCE) && (kt->second <= 0.0)))
         continue;
@@ -483,7 +483,7 @@ pcl::segmentation::grabcut::BoykovKolmogorov::adoptOrphans (std::deque<int>& orp
     // free the orphan subtree and remove it from the active set
     if (b_free_orphan)
     {
-      for (capacitated_edge::const_iterator jt = nodes_[u].begin (); jt != nodes_[u].end (); ++jt)
+      for (auto jt = nodes_[u].cbegin (); jt != nodes_[u].cend (); ++jt)
       {
         if ((cut_[jt->first] == tree_label) && (parents_[jt->first].first == u))
         {

--- a/surface/include/pcl/surface/impl/marching_cubes_rbf.hpp
+++ b/surface/include/pcl/surface/impl/marching_cubes_rbf.hpp
@@ -94,9 +94,9 @@ pcl::MarchingCubesRBF<PointNT>::voxelizeData ()
         const Eigen::Vector3d point = point_f.cast<double> ();
 
         double f = 0.0;
-        std::vector<double>::const_iterator w_it (weights.begin());
-        for (std::vector<Eigen::Vector3d, Eigen::aligned_allocator<Eigen::Vector3d> >::const_iterator c_it = centers.begin ();
-             c_it != centers.end (); ++c_it, ++w_it)
+        auto w_it (weights.cbegin());
+        for (auto c_it = centers.cbegin ();
+             c_it != centers.cend (); ++c_it, ++w_it)
           f += *w_it * kernel (*c_it, point);
 
         grid_[x * res_y_*res_z_ + y * res_z_ + z] = static_cast<float>(f);

--- a/test/common/test_wrappers.cpp
+++ b/test/common/test_wrappers.cpp
@@ -108,8 +108,8 @@ TEST (PointCloud, iterators)
                      cloud.begin ()->getVector3fMap ());
   EXPECT_EQ_VECTORS ((--cloud.end ())->getVector3fMap (),
                      (--cloud.end ())->getVector3fMap ());
-  PointCloud<PointXYZ>::const_iterator pit = cloud.begin ();
-  PointCloud<PointXYZ>::VectorType::const_iterator pit2 = cloud.begin ();
+  auto pit = cloud.begin ();
+  auto pit2 = cloud.begin ();
   for (; pit < cloud.end (); ++pit2, ++pit)
     EXPECT_EQ_VECTORS (pit->getVector3fMap (), pit2->getVector3fMap ());
 }
@@ -125,8 +125,8 @@ TEST (PointCloud, insert_range)
   EXPECT_EQ (cloud.width, cloud.size ());
   EXPECT_EQ (cloud.height, 1);
   EXPECT_EQ (cloud.width, old_size + cloud2.size ());
-  PointCloud<PointXYZ>::const_iterator pit = cloud.begin ();
-  PointCloud<PointXYZ>::const_iterator pit2 = cloud2.begin ();
+  auto pit = cloud.begin ();
+  auto pit2 = cloud2.begin ();
   for (; pit2 < cloud2.end (); ++pit2, ++pit)
     EXPECT_EQ_VECTORS (pit->getVector3fMap (), pit2->getVector3fMap ());
 }

--- a/test/fuzz/build.sh
+++ b/test/fuzz/build.sh
@@ -54,7 +54,7 @@ $CXX $CXXFLAGS -DPCLAPI_EXPORTS \
         -I/src/pcl/build/include -I/src/pcl/common/include \
         -I/src/pcl/dssdk/include \
         -I/src/pcl/io/include -isystem /usr/include/eigen3 \
-        -O2 -g -DNDEBUG -fPIC -std=c++14 \
+        -O2 -g -DNDEBUG -fPIC -std=c++17 \
         -o ply_reader_fuzzer.o -c ply_reader_fuzzer.cpp
 
 $CXX $CXXFLAGS $LIB_FUZZING_ENGINE ply_reader_fuzzer.o \

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -2179,7 +2179,7 @@ void
 pcl::visualization::PCLVisualizer::resetCameraViewpoint (const std::string &id)
 {
   vtkSmartPointer<vtkMatrix4x4> camera_pose;
-  const CloudActorMap::iterator it = cloud_actor_map_->find(id);
+  const auto it = cloud_actor_map_->find(id);
   if (it != cloud_actor_map_->end ())
     camera_pose = it->second.viewpoint_transformation_;
   else


### PR DESCRIPTION
Mainly due to https://eigen.tuxfamily.org/dox/group__TopicStructHavingEigenMembers.html Before C++17, certain PCL classes/structs have to be annotated with `EIGEN_MAKE_ALIGNED_OPERATOR_NEW`. Since C++17, that macro is empty, which creates possible incompatibilities between PCL and the user project. https://github.com/PointCloudLibrary/pcl/pull/5793 implemented a workaround, which meant that the old mechanism of `EIGEN_MAKE_ALIGNED_OPERATOR_NEW` was still used in newer C++ standards. Since many compilers support C++17 now, making it the new default in PCL seems logical. According to Wikipedia, these compilers have full support for C++17: https://en.wikipedia.org/wiki/C%2B%2B17#Compiler_support
Additionally, GCC 7, Clang 4, and MSVC >= 19.12 might work since they support the relevant C++17 feature "Dynamic memory allocation for over-aligned data".
Related issue: https://github.com/PointCloudLibrary/pcl/issues/6126
With this change, PCL will be compiled as C++17 by default (previously: C++14 by default). Compiling as C++14 is currently still possible via `-DCMAKE_CXX_STANDARD=14 -DCMAKE_CUDA_STANDARD=14`.
If PCL is compiled as C++17 or newer, projects using PCL have to be compiled as C++17 or newer (this was previously not enforced). When using CMake, this is done automatically.
If PCL is compiled as C++14, projects using PCL have to be compiled as C++14 or newer. However, `EIGEN_HAS_CXX17_OVERALIGN=0` has to be defined in the user project (when using CMake, this is done automatically).

Note: MSC_VER 1912 is chosen because since that version, the C++17 feature "Dynamic memory allocation for over-aligned data" is available in MSVC. Eigen uses the same version number to determine `EIGEN_HAS_CXX17_OVERALIGN`.
The CUDA compiler on Ubuntu 20.04 (CUDA toolkit 10.1) does not work with C++17/CUDA17.

The clang-tidy warnings regarding modernize-use-auto only appeared after setting the compile default to C++17, for some reason.