### PR TITLE
Update __func__ and __PRETTY_FUNCTION__ defines for MSVC

### DIFF
--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -216,7 +216,7 @@
     #define NOMINMAX
   #endif
 
-  #define __PRETTY_FUNCTION__ __FUNCTION__
+  #define __PRETTY_FUNCTION__ __FUNCSIG__
 #endif
 #endif // defined _WIN32
 

--- a/common/include/pcl/pcl_macros.h
+++ b/common/include/pcl/pcl_macros.h
@@ -217,7 +217,6 @@
   #endif
 
   #define __PRETTY_FUNCTION__ __FUNCTION__
-  #define __func__ __FUNCTION__
 #endif
 #endif // defined _WIN32
 


### PR DESCRIPTION
This change updates the function name preprocessor defines for modern MSVC. Specifically:
* remove `#define __func__` because MSVC has supported this standard define since Visual Studio 2015, and pcl only supports Visual Studio 2017 and newer.
* alias `__PRETTY_FUNCTION__` to MSVC's `__FUNCSIG__` instead of the previous alias to `__FUNCTION__`, because the former is a better match.

Note: I haven't tested this change.

Fixes #6220