### PR TITLE
Speed up PPFRegistration by using a hash function with fewer collisions

### DIFF
--- a/registration/include/pcl/registration/ppf_registration.h
+++ b/registration/include/pcl/registration/ppf_registration.h
@@ -68,15 +68,15 @@ public:
     operator()(const HashKeyStruct& s) const noexcept
     {
       /// RS hash function https://www.partow.net/programming/hashfunctions/index.html
-      std::size_t b_    = 378551;
-      std::size_t a_    = 63689;
+      std::size_t b_ = 378551;
+      std::size_t a_ = 63689;
       std::size_t hash = 0;
       hash = hash * a_ + s.first;
-      a_    = a_ * b_;
+      a_ = a_ * b_;
       hash = hash * a_ + s.second.first;
-      a_    = a_ * b_;
+      a_ = a_ * b_;
       hash = hash * a_ + s.second.second.first;
-      a_    = a_ * b_;
+      a_ = a_ * b_;
       hash = hash * a_ + s.second.second.second;
       return hash;
     }

--- a/registration/include/pcl/registration/ppf_registration.h
+++ b/registration/include/pcl/registration/ppf_registration.h
@@ -67,11 +67,18 @@ public:
     std::size_t
     operator()(const HashKeyStruct& s) const noexcept
     {
-      const std::size_t h1 = std::hash<int>{}(s.first);
-      const std::size_t h2 = std::hash<int>{}(s.second.first);
-      const std::size_t h3 = std::hash<int>{}(s.second.second.first);
-      const std::size_t h4 = std::hash<int>{}(s.second.second.second);
-      return h1 ^ (h2 << 1) ^ (h3 << 2) ^ (h4 << 3);
+      /// RS hash function https://www.partow.net/programming/hashfunctions/index.html
+      std::size_t b_    = 378551;
+      std::size_t a_    = 63689;
+      std::size_t hash = 0;
+      hash = hash * a_ + s.first;
+      a_    = a_ * b_;
+      hash = hash * a_ + s.second.first;
+      a_    = a_ * b_;
+      hash = hash * a_ + s.second.second.first;
+      a_    = a_ * b_;
+      hash = hash * a_ + s.second.second.second;
+      return hash;
     }
   };
   using FeatureHashMapType =


### PR DESCRIPTION
speed up hash search in ppf registration, change the hash function