### PR TITLE
Small fixes

### DIFF
--- a/benchmarks/search/radius_search.cpp
+++ b/benchmarks/search/radius_search.cpp
@@ -26,7 +26,7 @@ BM_OrganizedNeighborSearch(benchmark::State& state, const std::string& file)
     int searchIdx = indices[radiusSearchIdx++ % indices.size()];
     double searchRadius = 0.1; // or any fixed radius like 0.05
 
-    std::vector<int> k_indices;
+    pcl::Indices k_indices;
     std::vector<float> k_sqr_distances;
 
     auto start_time = std::chrono::high_resolution_clock::now();

--- a/common/include/pcl/memory.h
+++ b/common/include/pcl/memory.h
@@ -52,7 +52,7 @@
 #include <type_traits>  // for std::enable_if_t, std::false_type, std::true_type
 #include <utility>  // for std::forward
 
-#if !defined(PCL_SILENCE_MALLOC_WARNING)
+#if !defined(PCL_SILENCE_MALLOC_WARNING) && !defined(__NVCC__)
 #if PCL_USES_EIGEN_HANDMADE_ALIGNED_MALLOC
 // EIGEN_DEFAULT_ALIGN_BYTES and EIGEN_MALLOC_ALREADY_ALIGNED will be set after including Eigen/Core
 // this condition is the same as in the function aligned_malloc in Memory.h in the Eigen code

--- a/cuda/common/include/pcl/cuda/cutil_math.h
+++ b/cuda/common/include/pcl/cuda/cutil_math.h
@@ -1001,10 +1001,13 @@ inline __host__ __device__ uint4 max(uint4 a, uint4 b)
 // - linear interpolation between a and b, based on value t in [0, 1] range
 ////////////////////////////////////////////////////////////////////////////////
 
+#if !defined(__cplusplus) || (__cplusplus < 202002L)
+// C++20 and higher provides std::lerp
 inline __device__ __host__ float lerp(float a, float b, float t)
 {
     return a + t*(b-a);
 }
+#endif
 inline __device__ __host__ float2 lerp(float2 a, float2 b, float t)
 {
     return a + t*(b-a);

--- a/gpu/utils/include/pcl/gpu/utils/device/functional.hpp
+++ b/gpu/utils/include/pcl/gpu/utils/device/functional.hpp
@@ -46,7 +46,6 @@ namespace pcl
     {
         // Function Objects
 
-        using thrust::unary_function;
         using thrust::binary_function;
 
         // Arithmetic Operations
@@ -79,8 +78,10 @@ namespace pcl
         using thrust::bit_or;
         using thrust::bit_xor;
 
-        template <typename T> struct bit_not : unary_function<T, T>
+        template <typename T> struct bit_not
         {
+            typedef T argument_type;
+            typedef T result_type;
             __forceinline__ __device__ T operator ()(const T& v) const {return ~v;}
         };
 


### PR DESCRIPTION
- C++20 and later provides std::lerp, in that case our definition may collide
- the SSE and AVX flags are not passed to the CUDA compiler (NVCC), so it often displays the new alignment warning -> silenced on NVCC
- thrust::unary_function is deprecated in the newest thrust/cuda release. Luckily, it is easily replaced with two typedefs