### PR TITLE
Fix perception_pcl_ros dockerfile for release pipeline

### DIFF
--- a/.dev/docker/perception_pcl_ros/Dockerfile
+++ b/.dev/docker/perception_pcl_ros/Dockerfile
@@ -1,12 +1,12 @@
 # flavor appears twice, once for the FOR, once for the contents since
 # Dockerfile seems to reset arguments after a FOR appears
-ARG flavor="melodic"
+ARG flavor="noetic"
 FROM ros:${flavor}-robot
 
-ARG flavor="melodic"
+ARG flavor="noetic"
 ARG workspace="/root/catkin_ws"
 
-COPY ${flavor}_rosinstall.yaml ${workspace}/src/.rosinstall
+COPY melodic_rosinstall.yaml ${workspace}/src/.rosinstall
 
 # Be careful:
 # * ROS uses Python2
@@ -17,10 +17,12 @@ COPY ${flavor}_rosinstall.yaml ${workspace}/src/.rosinstall
 RUN sed -i "s/^# deb-src/deb-src/" /etc/apt/sources.list \
  && apt update \
  && apt install -y \
+    git \
+    libboost-iostreams-dev \
     libeigen3-dev \
     libflann-dev \
     libqhull-dev \
-    python-pip \
+    python3-pip \
     ros-${flavor}-tf2-eigen \
  && pip install -U pip \
  && pip install catkin_tools \

--- a/.dev/docker/perception_pcl_ros/Dockerfile
+++ b/.dev/docker/perception_pcl_ros/Dockerfile
@@ -6,7 +6,7 @@ FROM ros:${flavor}-robot
 ARG flavor="noetic"
 ARG workspace="/root/catkin_ws"
 
-COPY melodic_rosinstall.yaml ${workspace}/src/.rosinstall
+COPY ${flavor}_rosinstall.yaml ${workspace}/src/.rosinstall
 
 # Be careful:
 # * ROS uses Python2

--- a/.dev/docker/perception_pcl_ros/noetic_rosinstall.yaml
+++ b/.dev/docker/perception_pcl_ros/noetic_rosinstall.yaml
@@ -1,0 +1,12 @@
+- git:
+    local-name: 'noetic/perception_pcl'
+    uri: 'https://github.com/ros-perception/perception_pcl'
+    version: 'melodic-devel'
+- git:
+    local-name: 'noetic/pcl_msgs'
+    uri: 'https://github.com/ros-perception/pcl_msgs'
+    version: 'noetic-devel'
+- git:
+    local-name: 'pcl'
+    uri: 'https://github.com/PointCloudLibrary/pcl'
+    version: 'master'


### PR DESCRIPTION
Ros noetic is the last ROS 1 release that is still supported (but only until May this year)
Needs to be fixed so that release pipeline can finish successfully: https://dev.azure.com/PointCloudLibrary/pcl/_build/results?buildId=25053&view=results