### PR TITLE
Add missing chrono includes

### DIFF
--- a/apps/src/ppf_object_recognition.cpp
+++ b/apps/src/ppf_object_recognition.cpp
@@ -9,6 +9,7 @@
 #include <pcl/segmentation/sac_segmentation.h>
 #include <pcl/visualization/pcl_visualizer.h>
 
+#include <chrono>
 #include <thread>
 
 using namespace pcl;

--- a/examples/stereo/example_stereo_baseline.cpp
+++ b/examples/stereo/example_stereo_baseline.cpp
@@ -1,3 +1,4 @@
+#include <chrono>
 #include <thread>
 
 #include <pcl/stereo/stereo_matching.h>

--- a/tools/obj_rec_ransac_accepted_hypotheses.cpp
+++ b/tools/obj_rec_ransac_accepted_hypotheses.cpp
@@ -58,6 +58,7 @@
 #include <vtkHedgeHog.h>
 #include <vtkMatrix4x4.h>
 #include <algorithm>
+#include <chrono>
 #include <cstdio>
 #include <thread>
 #include <vector>

--- a/tools/obj_rec_ransac_hash_table.cpp
+++ b/tools/obj_rec_ransac_hash_table.cpp
@@ -53,6 +53,7 @@
 #include <vtkDataArray.h>
 #include <vtkPointData.h>
 #include <vtkGlyph3D.h>
+#include <chrono>
 #include <cstdio>
 #include <thread>
 

--- a/tools/obj_rec_ransac_model_opps.cpp
+++ b/tools/obj_rec_ransac_model_opps.cpp
@@ -52,6 +52,7 @@
 #include <vtkDataArray.h>
 #include <vtkPointData.h>
 #include <vtkHedgeHog.h>
+#include <chrono>
 #include <cstdio>
 #include <thread>
 

--- a/tools/obj_rec_ransac_orr_octree.cpp
+++ b/tools/obj_rec_ransac_orr_octree.cpp
@@ -63,6 +63,7 @@
 #include <vtkRenderWindow.h>
 #include <vector>
 #include <list>
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>

--- a/tools/obj_rec_ransac_orr_octree_zprojection.cpp
+++ b/tools/obj_rec_ransac_orr_octree_zprojection.cpp
@@ -62,6 +62,7 @@
 #include <vtkCubeSource.h>
 #include <vtkPointData.h>
 #include <vector>
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <cstdio>

--- a/tools/obj_rec_ransac_result.cpp
+++ b/tools/obj_rec_ransac_result.cpp
@@ -57,6 +57,7 @@
 #include <vtkRenderer.h>
 #include <vtkRenderWindow.h>
 #include <vtkTransform.h>
+#include <chrono>
 #include <cstdio>
 #include <list>
 #include <thread>

--- a/tools/obj_rec_ransac_scene_opps.cpp
+++ b/tools/obj_rec_ransac_scene_opps.cpp
@@ -53,6 +53,7 @@
 #include <vtkDataArray.h>
 #include <vtkPointData.h>
 #include <vtkHedgeHog.h>
+#include <chrono>
 #include <cstdio>
 #include <thread>
 

--- a/visualization/include/pcl/visualization/impl/registration_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/registration_visualizer.hpp
@@ -38,6 +38,7 @@
 
 #pragma once
 
+#include <chrono>
 #include <thread>
 
 


### PR DESCRIPTION
Fixes build failure when using MSVC STL 17.13 and newer (see https://github.com/microsoft/STL/releases/tag/vs-2022-17.13 ) 
See also https://github.com/microsoft/vcpkg/issues/44047