### PR TITLE
[search] Add support for nanoflann (faster alternative to pcl::search::KdTree)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,6 +354,14 @@ else()
   endif()
 endif()
 
+find_package(nanoflann 1.4.2 QUIET)
+if(TARGET nanoflann::nanoflann)
+  set(PCL_HAS_NANOFLANN 1)
+  message(STATUS "Found nanoflann")
+else()
+  message(STATUS "nanoflann was not found, so some PCL classes will not be available.")
+endif()
+
 # libusb
 option(WITH_LIBUSB "Build USB RGBD-Camera drivers" TRUE)
 if(WITH_LIBUSB)

--- a/pcl_config.h.in
+++ b/pcl_config.h.in
@@ -49,6 +49,10 @@
 
 #cmakedefine HAVE_DAVIDSDK 1
 
+#ifndef PCL_HAS_NANOFLANN
+#cmakedefine PCL_HAS_NANOFLANN 1
+#endif
+
 // SSE macros
 #cmakedefine HAVE_POSIX_MEMALIGN
 #cmakedefine HAVE_MM_MALLOC

--- a/search/CMakeLists.txt
+++ b/search/CMakeLists.txt
@@ -22,6 +22,7 @@ set(srcs
 set(incs
   "include/pcl/${SUBSYS_NAME}/search.h"
   "include/pcl/${SUBSYS_NAME}/kdtree.h"
+  "include/pcl/${SUBSYS_NAME}/kdtree_nanoflann.h"
   "include/pcl/${SUBSYS_NAME}/brute_force.h"
   "include/pcl/${SUBSYS_NAME}/organized.h"
   "include/pcl/${SUBSYS_NAME}/octree.h"

--- a/search/include/pcl/search/impl/kdtree.hpp
+++ b/search/include/pcl/search/impl/kdtree.hpp
@@ -48,12 +48,21 @@ pcl::search::KdTree<PointT,Tree>::KdTree (bool sorted)
 {
 }
 
+template <typename PointT, class Tree>
+pcl::search::KdTree<PointT,Tree>::KdTree (const std::string& name, bool sorted)
+  : pcl::search::Search<PointT> (name, sorted)
+{
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT, class Tree> void
 pcl::search::KdTree<PointT,Tree>::setPointRepresentation (
     const PointRepresentationConstPtr &point_representation)
 {
-  tree_->setPointRepresentation (point_representation);
+  if(tree_)
+    tree_->setPointRepresentation (point_representation);
+  else
+    PCL_ERROR("Calling setPointRepresentation on KdTreeNanoflann that has been cast to KdTree is not possible in this PCL version. Call setPointRepresentation directly on the KdTreeNanoflann object.\n");
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -68,7 +77,10 @@ pcl::search::KdTree<PointT,Tree>::setSortedResults (bool sorted_results)
 template <typename PointT, class Tree> void
 pcl::search::KdTree<PointT,Tree>::setEpsilon (float eps)
 {
-  tree_->setEpsilon (eps);
+  if(tree_)
+    tree_->setEpsilon (eps);
+  else
+    PCL_ERROR("Calling setEpsilon on KdTreeNanoflann that has been cast to KdTree is not possible in this PCL version. Call setEpsilon directly on the KdTreeNanoflann object.\n");
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////

--- a/search/include/pcl/search/kdtree.h
+++ b/search/include/pcl/search/kdtree.h
@@ -161,6 +161,8 @@ namespace pcl
                       std::vector<float> &k_sqr_distances,
                       unsigned int max_nn = 0) const override;
       protected:
+        /** \brief This leaves the internal tree_ object uninitialized! */
+        KdTree (const std::string& name, bool sorted);
         /** \brief A pointer to the internal KdTree object. */
         KdTreePtr tree_;
     };

--- a/search/include/pcl/search/kdtree_nanoflann.h
+++ b/search/include/pcl/search/kdtree_nanoflann.h
@@ -1,0 +1,761 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2025-, Open Perception Inc.
+ *
+ *  All rights reserved
+ */
+
+#pragma once
+
+#include <pcl/pcl_config.h>
+#if PCL_HAS_NANOFLANN
+
+#include <pcl/search/kdtree.h>
+#include <pcl/point_representation.h>
+
+#include <nanoflann.hpp>
+
+namespace pcl {
+namespace search {
+namespace internal {
+/** Helper for KdTreeNanoflann, serves as a dataset adaptor.
+ */
+template <typename T = float>
+struct PointCloudAdaptor {
+  PointCloudAdaptor(const T* data,
+                    bool delete_data,
+                    std::size_t dim,
+                    std::size_t point_count)
+  : data_(data), delete_data_(delete_data), dim_(dim), point_count_(point_count)
+  {}
+
+  ~PointCloudAdaptor()
+  {
+    if (delete_data_)
+      delete[] data_;
+  }
+
+  inline void
+  reset_adaptor(const T* data,
+                bool delete_data,
+                std::size_t dim,
+                std::size_t point_count)
+  {
+    if (delete_data_)
+      delete[] data_;
+    data_ = data;
+    delete_data_ = delete_data;
+    dim_ = dim;
+    point_count_ = point_count;
+  }
+
+  inline std::size_t
+  kdtree_get_point_count() const
+  {
+    return point_count_;
+  }
+
+  inline T
+  kdtree_get_pt(const std::size_t idx, const std::size_t dim) const
+  {
+    return data_[dim_ * idx + dim];
+  }
+
+  template <class BBOX>
+  bool
+  kdtree_get_bbox(BBOX& /* bb */) const
+  {
+    return false;
+  }
+
+private:
+  const T* data_;
+  bool delete_data_;
+  std::size_t dim_;
+  std::size_t point_count_;
+};
+
+/** Helper function for radiusSearch: must have a template specialization if the
+ * distance norm is L2
+ */
+template <typename Dist>
+float
+square_if_l2(float radius)
+{
+  return radius;
+};
+template <>
+float
+square_if_l2<nanoflann::L2_Adaptor<float,
+                                   pcl::search::internal::PointCloudAdaptor<float>,
+                                   float,
+                                   pcl::index_t>>(float radius)
+{
+  return radius * radius;
+};
+template <>
+float
+square_if_l2<
+    nanoflann::L2_Simple_Adaptor<float,
+                                 pcl::search::internal::PointCloudAdaptor<float>,
+                                 float,
+                                 pcl::index_t>>(float radius)
+{
+  return radius * radius;
+};
+} // namespace internal
+
+// for convenience/brevity
+using L1_Adaptor =
+    nanoflann::L1_Adaptor<float,
+                          pcl::search::internal::PointCloudAdaptor<float>,
+                          float,
+                          pcl::index_t>;
+using L2_Adaptor =
+    nanoflann::L2_Adaptor<float,
+                          pcl::search::internal::PointCloudAdaptor<float>,
+                          float,
+                          pcl::index_t>;
+using L2_Simple_Adaptor =
+    nanoflann::L2_Simple_Adaptor<float,
+                                 pcl::search::internal::PointCloudAdaptor<float>,
+                                 float,
+                                 pcl::index_t>;
+using SO2_Adaptor =
+    nanoflann::SO2_Adaptor<float,
+                           pcl::search::internal::PointCloudAdaptor<float>,
+                           float,
+                           pcl::index_t>;
+using SO3_Adaptor =
+    nanoflann::SO3_Adaptor<float,
+                           pcl::search::internal::PointCloudAdaptor<float>,
+                           float,
+                           pcl::index_t>;
+// TODO maybe additional adaptor with simd?
+
+/** @brief @b pcl::search::KdTreeNanoflann is a faster and flexible alternative to
+ * pcl::search::KdTree. It is based on the nanoflann library by Jose Luis Blanco-Claraco
+ * ( https://github.com/jlblancoc/nanoflann ). Since nanoflann is treated as an optional
+ * dependency to PCL, you must test the preprocessor symbol `PCL_HAS_NANOFLANN` after
+ * including `pcl/search/kdtree_nanoflann.h`.
+ * @code
+ * // Example 1: using KdTreeNanoflann in NormalEstimation:
+ * pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> ne;
+ * auto tree = pcl::make_shared<pcl::search::KdTreeNanoflann<pcl::PointXYZ>>();
+ * ne.setSearchMethod (tree);
+ * // rest as usual
+ * // Example 2: using KdTreeNanoflannn in ICP:
+ * pcl::IterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ> icp;
+ * icp.setSearchMethodSource(pcl::make_shared<pcl::search::KdTreeNanoflann<pcl::PointXYZ>>());
+ * icp.setSearchMethodTarget(pcl::make_shared<pcl::search::KdTreeNanoflann<pcl::PointXYZ>>());
+ * // rest as usual
+ * // Example 3: using a L1 distance norm:
+ * pcl::search::KdTreeNanoflann<PointXYZ, 3, pcl::search::L1_Adaptor> kdtree_nanoflann;
+ * kdtree_nanoflann.setInputCloud (my_cloud);
+ * // now ready to use kdtree_nanoflann.nearestKSearch(...) and
+ * // kdtree_nanoflann.radiusSearch(...);
+ * // Example 4: using KdTreeNanoflann with features instead of 3D points:
+ * pcl::search::KdTreeNanoflann<pcl::FPFHSignature33, 33> kdtree_nanoflann_feat;
+ * kdtree_nanoflann_feat.setInputCloud(my_features_cloud);
+ * // now ready for searching
+ * @endcode
+ *
+ * @tparam PointT Can be a point like pcl::PointXYZ or a feature like pcl::SHOT352
+ * @tparam Dim Dimension of the KdTree to build. If set to -1, it will infer the
+ * dimension at runtime from the given point representation, but with a performance
+ * penalty. Default is 3, appropriate for all xyz point types.
+ * @tparam Distance The distance to use. Possible values include pcl::L1_Adaptor
+ * (taxicab/manhattan distance), pcl::L2_Simple_Adaptor (euclidean distance, optimized
+ * for few dimensions), pcl::L2_Adaptor (euclidean distance, optimized for many
+ * dimensions), pcl::SO2_Adaptor, pcl::SO3_Adaptor. Default is pcl::L2_Simple_Adaptor
+ *
+ * @author Markus Vieth
+ * @ingroup search
+ */
+template <typename PointT,
+          std::int32_t Dim = 3,
+          typename Distance =
+              std::conditional_t<Dim >= 4, L2_Adaptor, L2_Simple_Adaptor>,
+          typename Tree = nanoflann::KDTreeSingleIndexAdaptor<
+              Distance,
+              pcl::search::internal::PointCloudAdaptor<float>,
+              Dim,
+              pcl::index_t>>
+class KdTreeNanoflann : public pcl::search::KdTree<PointT> {
+private:
+  /** The special thing here is that indices and distances are stored in _two_ vectors,
+   * not as a pair in _one_ vector.
+   */
+  template <typename _DistanceType = float, typename _IndexType = pcl::index_t>
+  class PCLRadiusResultSet {
+  public:
+    using DistanceType = _DistanceType;
+    using IndexType = _IndexType;
+
+  public:
+    const DistanceType radius;
+
+    std::vector<IndexType>& m_indices;
+    std::vector<DistanceType>& m_dists;
+    std::size_t max_results_;
+
+    explicit PCLRadiusResultSet(
+        DistanceType radius_,
+        std::vector<IndexType>& indices,
+        std::vector<DistanceType>& dists,
+        std::size_t max_results = std::numeric_limits<std::size_t>::max())
+    : radius(radius_), m_indices(indices), m_dists(dists), max_results_(max_results)
+    {
+      init();
+    }
+
+    void
+    init()
+    {
+      clear();
+      if (max_results_ != std::numeric_limits<std::size_t>::max()) {
+        m_indices.reserve(max_results_);
+        m_dists.reserve(max_results_);
+      }
+    }
+    void
+    clear()
+    {
+      m_indices.clear();
+      m_dists.clear();
+    }
+
+    size_t
+    size() const
+    {
+      return m_indices.size();
+    }
+    size_t
+    empty() const
+    {
+      return m_indices.empty();
+    }
+
+    bool
+    full() const
+    {
+      return true;
+    }
+
+    /**
+     * Called during search to add an element matching the criteria.
+     * @return true if the search should be continued, false if the results are
+     * sufficient
+     */
+    bool
+    addPoint(DistanceType dist, IndexType index)
+    {
+      if (dist < radius) {
+        m_indices.emplace_back(index);
+        m_dists.emplace_back(dist);
+      }
+      return (m_indices.size() < max_results_);
+    }
+
+    DistanceType
+    worstDist() const
+    {
+      return radius;
+    }
+
+    void
+    sort()
+    {
+      // this sort function does not do anything (yet). For now, PCLRadiusResultSet
+      // should only be used if the results do not have to be sorted. In the future, we
+      // might add sorting here if we find a really efficient way to sort both vectors
+      // simultaneously.
+    }
+  };
+
+public:
+  using PointCloud = typename Search<PointT>::PointCloud;
+  using PointCloudConstPtr = typename pcl::PointCloud<PointT>::ConstPtr;
+
+  using pcl::search::Search<PointT>::indices_;
+  using pcl::search::Search<PointT>::input_;
+  using pcl::search::Search<PointT>::getIndices;
+  using pcl::search::Search<PointT>::getInputCloud;
+  using pcl::search::Search<PointT>::nearestKSearch;
+  using pcl::search::Search<PointT>::radiusSearch;
+  using pcl::search::Search<PointT>::sorted_results_;
+  using pcl::search::Search<PointT>::name_;
+
+  using Ptr = shared_ptr<KdTreeNanoflann<PointT, Dim, Distance, Tree>>;
+  using ConstPtr = shared_ptr<const KdTreeNanoflann<PointT, Dim, Distance, Tree>>;
+
+  using KdTreePtr = shared_ptr<Tree>;
+  using KdTreeConstPtr = shared_ptr<const Tree>;
+  using PointRepresentationConstPtr = shared_ptr<const PointRepresentation<PointT>>;
+
+  /** @brief Constructor for KdTreeNanoflann.
+   *
+   * @param[in] sorted Set to true if the nearest neighbor search results
+   * need to be sorted in ascending order based on their distance to the
+   * query point (default is false, which is faster)
+   * @param[in] leaf_max_size Max number of points/samples in a leaf, can be tuned to
+   * achieve best performance. When using this for 1nn search (e.g. correspondence
+   * estimation in icp/registration), then leaf_max_size=10 is usually fastest.
+   * Otherwise, leaf_max_size=20 is a good choice.
+   * @param[in] n_thread_build Number of threads for concurrent tree build (default is
+   * 1, meaning no concurrent build)
+   */
+  KdTreeNanoflann(bool sorted,
+                  std::size_t leaf_max_size,
+                  unsigned int n_thread_build = 1)
+  : pcl::search::KdTree<PointT>("KdTreeNanoflann", sorted)
+  , leaf_max_size_(leaf_max_size)
+  , n_thread_build_(n_thread_build)
+  {}
+
+  /** @brief Constructor for KdTreeNanoflann.
+   *
+   * @param[in] sorted set to true if the nearest neighbor search results
+   * need to be sorted in ascending order based on their distance to the
+   * query point
+   *
+   */
+  KdTreeNanoflann(bool sorted = false) : KdTreeNanoflann(sorted, 15, 1) {}
+
+  /** @brief Destructor for KdTreeNanoflann. */
+  ~KdTreeNanoflann() override = default;
+
+  /** @brief Provide a pointer to the point representation to use to convert points into
+   * k-D vectors. If you want to use this function, it is recommended to do so _before_
+   * calling setInputCloud, to avoid setting up the kd-tree twice.
+   * @param[in] point_representation the const shared pointer to a PointRepresentation
+   */
+  void
+  setPointRepresentation(const PointRepresentationConstPtr& point_representation)
+  {
+    PCL_DEBUG("[KdTreeNanoflann::setPointRepresentation] "
+              "KdTreeNanoflann::setPointRepresentation called, "
+              "point_representation->getNumberOfDimensions()=%i, "
+              "point_representation->isTrivial()=%i\n",
+              point_representation->getNumberOfDimensions(),
+              point_representation->isTrivial());
+    if (Dim != -1 && Dim != point_representation->getNumberOfDimensions()) {
+      PCL_ERROR("[KdTreeNanoflann::setPointRepresentation] The given point "
+                "representation uses %i dimensions, but the nr of dimensions given as "
+                "template parameter to KdTreeNanoflann is %i.\n",
+                point_representation->getNumberOfDimensions(),
+                Dim);
+      return;
+    }
+    point_representation_ = point_representation;
+    setUpTree();
+  }
+
+  /** @brief Get a pointer to the point representation used when converting points into
+   * k-D vectors. */
+  inline PointRepresentationConstPtr
+  getPointRepresentation() const
+  {
+    return point_representation_;
+  }
+
+  /** @brief Sets whether the results have to be sorted or not.
+   * @param[in] sorted_results set to true if the radius search results should be sorted
+   */
+  void
+  setSortedResults(bool sorted_results) override
+  {
+    sorted_results_ = sorted_results;
+  }
+
+  /** @brief Set the search epsilon precision (error bound) for nearest neighbors
+   * searches.
+   * @param[in] eps precision (error bound) for nearest neighbors searches
+   */
+  void
+  setEpsilon(float eps)
+  {
+    eps_ = eps;
+  }
+
+  /** @brief Get the search epsilon precision (error bound) for nearest neighbors
+   * searches. */
+  inline float
+  getEpsilon() const
+  {
+    return eps_;
+  }
+
+  /** @brief Influences the results of radiusSearch when max_nn is not set to zero.
+   * If the parameter max_nn of radiusSearch is set to a value greater than zero, it
+   * will return _at most_ that many points. If you set `use_rknn=true`, it will always
+   * return the points _closest_ to the query point. If you set `use_rknn=false`, it may
+   * return _any_ points within the radius, which can be faster.
+   */
+  void
+  setUseRKNN(bool use_rknn)
+  {
+    use_rknn_ = use_rknn;
+  }
+
+  /** @brief Provide a pointer to the input dataset, this will build the kd-tree.
+   * @param[in] cloud the const shared pointer to a PointCloud
+   * @param[in] indices the point indices subset that is to be used from \a cloud
+   */
+  bool
+  setInputCloud(const PointCloudConstPtr& cloud,
+                const IndicesConstPtr& indices = IndicesConstPtr()) override
+  {
+    input_ = cloud;
+    indices_ = indices;
+
+    return setUpTree();
+  }
+
+  /** @brief Get pointer to internal nanoflann tree. Use with caution.
+   */
+  KdTreePtr
+  getNanoflannTree()
+  {
+    return nanoflann_tree_;
+  }
+
+  /** @brief Search for the k-nearest neighbors for the given query point.
+   * @param[in] point the given query point
+   * @param[in] k the number of neighbors to search for
+   * @param[out] k_indices the resultant indices of the neighboring points (must be
+   * resized to \a k a priori!)
+   * @param[out] k_sqr_distances the resultant squared distances to the neighboring
+   * points (must be resized to \a k a priori!)
+   * @return number of neighbors found
+   */
+  int
+  nearestKSearch(const PointT& point,
+                 int k,
+                 Indices& k_indices,
+                 std::vector<float>& k_sqr_distances) const override
+  {
+    assert(point_representation_->isValid(point) &&
+           "Invalid (NaN, Inf) point coordinates given to nearestKSearch!");
+    if (static_cast<std::size_t>(k) > adaptor_->kdtree_get_point_count())
+      k = adaptor_->kdtree_get_point_count();
+    k_indices.resize(k);
+    k_sqr_distances.resize(k);
+    float* query_point = nullptr;
+    if (!point_representation_->isTrivial()) {
+      query_point = new float[point_representation_->getNumberOfDimensions()];
+      point_representation_->vectorize(point, query_point);
+    }
+    // like nanoflann_tree_->knnSearch
+    nanoflann::KNNResultSet<float, pcl::index_t> resultSet(k);
+    resultSet.init(k_indices.data(), k_sqr_distances.data());
+    nanoflann_tree_->findNeighbors(
+        resultSet,
+        (query_point ? query_point : reinterpret_cast<const float*>(&point))
+#if NANOFLANN_VERSION < 0x150
+            ,
+        nanoflann::SearchParams()
+#endif // NANOFLANN_VERSION < 0x150
+    );
+    const auto search_result = resultSet.size();
+    delete[] query_point;
+    assert(search_result == k);
+
+    if (!identity_mapping_) {
+      for (auto& index : k_indices) {
+        index = index_mapping_[index];
+      }
+    }
+    return search_result;
+  }
+
+  /** @brief Search for all the nearest neighbors of the query point in a given radius.
+   * @param[in] point the given query point
+   * @param[in] radius the radius of the sphere bounding all of p_q's neighbors
+   * @param[out] k_indices the resultant indices of the neighboring points
+   * @param[out] k_sqr_distances the resultant squared distances to the neighboring
+   * points
+   * @param[in] max_nn if given, bounds the maximum returned neighbors to this value. If
+   * \a max_nn is set to 0 or to a number higher than the number of points in the input
+   * cloud, all neighbors in \a radius will be returned.
+   * @return number of neighbors found in radius
+   */
+  int
+  radiusSearch(const PointT& point,
+               double radius,
+               Indices& k_indices,
+               std::vector<float>& k_sqr_distances,
+               unsigned int max_nn = 0) const override
+  {
+    assert(point_representation_->isValid(point) &&
+           "Invalid (NaN, Inf) point coordinates given to radiusSearch!");
+    float* query_point = nullptr;
+    if (!point_representation_->isTrivial()) {
+      query_point = new float[point_representation_->getNumberOfDimensions()];
+      point_representation_->vectorize(point, query_point);
+    }
+    if (max_nn == 0) {
+      // return _all_ points within radius
+      // Calling this->sortResults is currently slower than sorting the vector of
+      // nanoflann::ResultItem However, if sorted results are not requested, using
+      // PCLRadiusResultSet with radiusSearchCustomCallback avoids copies and is faster
+      if (sorted_results_) {
+#if NANOFLANN_VERSION < 0x150
+        std::vector<std::pair<pcl::index_t, float>>
+            IndicesDists; // nanoflann::ResultItem was introduced in version 1.5.0
+#else
+        std::vector<nanoflann::ResultItem<pcl::index_t, float>> IndicesDists;
+#endif // NANOFLANN_VERSION < 0x150
+       // like nanoflann_tree_->radiusSearch
+        nanoflann::RadiusResultSet<float, pcl::index_t> resultSet(
+            pcl::search::internal::square_if_l2<Distance>(radius), IndicesDists);
+        nanoflann_tree_->findNeighbors(
+            resultSet,
+            (query_point ? query_point : reinterpret_cast<const float*>(&point)),
+#if NANOFLANN_VERSION < 0x150
+            {32, eps_, sorted_results_} // first parameter is ignored in older versions,
+                                        // and removed in newer versions
+#else
+            {eps_, sorted_results_}
+#endif // NANOFLANN_VERSION < 0x150
+        );
+#if NANOFLANN_VERSION < 0x160
+        // before, nanoflann did not sort in findNeighbours
+        if (sorted_results_)
+          std::sort(
+              IndicesDists.begin(), IndicesDists.end(), nanoflann::IndexDist_Sorter());
+#endif // NANOFLANN_VERSION < 0x160
+        const auto search_result = resultSet.size();
+        k_indices.resize(IndicesDists.size());
+        k_sqr_distances.resize(IndicesDists.size());
+        for (std::size_t i = 0; i < IndicesDists.size(); ++i) {
+          k_indices[i] = identity_mapping_ ? IndicesDists[i].first
+                                           : index_mapping_[IndicesDists[i].first];
+          k_sqr_distances[i] = IndicesDists[i].second;
+        }
+        delete[] query_point;
+        return search_result;
+      }
+      else {
+        PCLRadiusResultSet<float, pcl::index_t> resultSet(
+            pcl::search::internal::square_if_l2<Distance>(radius),
+            k_indices,
+            k_sqr_distances);
+        // like nanoflann_tree_->radiusSearchCustomCallback
+        nanoflann_tree_->findNeighbors(
+            resultSet,
+            (query_point ? query_point : reinterpret_cast<const float*>(&point)),
+#if NANOFLANN_VERSION < 0x150
+            {32, eps_, sorted_results_} // first parameter is ignored in older versions,
+                                        // and removed in newer versions
+#else
+            {eps_, sorted_results_}
+#endif // NANOFLANN_VERSION < 0x150
+        );
+        const auto search_result = resultSet.size();
+        if (!identity_mapping_) {
+          for (auto& index : k_indices) {
+            index = index_mapping_[index];
+          }
+        }
+        if (sorted_results_)
+          this->sortResults(k_indices, k_sqr_distances);
+        delete[] query_point;
+        return search_result;
+      }
+    }
+    else {
+      // return no more than max_nn points
+      if (use_rknn_) {
+        // return points closest to query point
+        if (static_cast<std::size_t>(max_nn) > adaptor_->kdtree_get_point_count())
+          max_nn = adaptor_->kdtree_get_point_count();
+        k_indices.resize(max_nn);
+        k_sqr_distances.resize(max_nn);
+#if NANOFLANN_VERSION < 0x151
+        // rknnSearch and RKNNResultSet were added in nanoflann 1.5.1
+        auto search_result = nanoflann_tree_->knnSearch(
+            (query_point ? query_point : reinterpret_cast<const float*>(&point)),
+            max_nn,
+            k_indices.data(),
+            k_sqr_distances.data());
+        for (auto iter = k_sqr_distances.rbegin();
+             iter != k_sqr_distances.rend() &&
+             *iter > pcl::search::internal::square_if_l2<Distance>(radius);
+             ++iter) {
+          --search_result;
+        }
+        k_indices.resize(search_result);
+        k_sqr_distances.resize(search_result);
+#else
+        // like nanoflann_tree_->rknnSearch
+        nanoflann::RKNNResultSet<float, pcl::index_t> resultSet(
+            max_nn, pcl::search::internal::square_if_l2<Distance>(radius));
+        resultSet.init(k_indices.data(), k_sqr_distances.data());
+        nanoflann_tree_->findNeighbors(
+            resultSet,
+            (query_point ? query_point : reinterpret_cast<const float*>(&point)));
+        const auto search_result = resultSet.size();
+        k_indices.resize(search_result);
+        k_sqr_distances.resize(search_result);
+#endif // NANOFLANN_VERSION < 0x151
+        if (!identity_mapping_) {
+          for (auto& index : k_indices) {
+            index = index_mapping_[index];
+          }
+        }
+        delete[] query_point;
+        return search_result;
+      }
+      else {
+        // may return any points within the radius, can be faster
+        PCLRadiusResultSet<float, pcl::index_t> resultSet(
+            pcl::search::internal::square_if_l2<Distance>(radius),
+            k_indices,
+            k_sqr_distances,
+            max_nn);
+        // like nanoflann_tree_->radiusSearchCustomCallback
+        nanoflann_tree_->findNeighbors(
+            resultSet,
+            (query_point ? query_point : reinterpret_cast<const float*>(&point)),
+#if NANOFLANN_VERSION < 0x150
+            {32, eps_, sorted_results_} // first parameter is ignored in older versions,
+                                        // and removed in newer versions
+#else
+            {eps_, sorted_results_}
+#endif // NANOFLANN_VERSION < 0x150
+        );
+        const auto search_result = resultSet.size();
+        if (!identity_mapping_) {
+          for (auto& index : k_indices) {
+            index = index_mapping_[index];
+          }
+        }
+        if (sorted_results_)
+          this->sortResults(k_indices, k_sqr_distances);
+        delete[] query_point;
+        return search_result;
+      }
+    }
+  }
+
+private:
+  /** Set up index_mapping_, adaptor_, and nanoflann_tree_, based on
+   * point_representation_, input_, and indices_.
+   */
+  bool
+  setUpTree()
+  {
+    if (!point_representation_ || !input_ || input_->empty()) {
+      PCL_ERROR("[KdTreeNanoflann::setUpTree] point representation is null or input is "
+                "null or input is empty\n");
+      return false;
+    }
+
+    const std::size_t dim = point_representation_->getNumberOfDimensions();
+    if (Dim != -1 && Dim != static_cast<int>(dim)) {
+      PCL_ERROR("[KdTreeNanoflann::setUpTree] The given point "
+                "representation uses %i dimensions, but the nr of dimensions given as "
+                "template parameter to KdTreeNanoflann is %i.\n",
+                dim,
+                Dim);
+      return false;
+    }
+    index_mapping_.clear();
+    if (indices_ && !indices_->empty()) {
+      index_mapping_.reserve(indices_->size());
+      for (const auto& index : *indices_) {
+        if (point_representation_->isValid((*input_)[index])) {
+          index_mapping_.emplace_back(index);
+        }
+      }
+    }
+    else {
+      index_mapping_.reserve(input_->size());
+      for (std::size_t index = 0; index < input_->size(); ++index) {
+        if (point_representation_->isValid((*input_)[index])) {
+          index_mapping_.emplace_back(index);
+        }
+      }
+    }
+    identity_mapping_ = true;
+    for (pcl::index_t index = 0;
+         identity_mapping_ && static_cast<std::size_t>(index) < index_mapping_.size();
+         ++index) {
+      identity_mapping_ = identity_mapping_ && index_mapping_[index] == index;
+    }
+
+    PCL_DEBUG("[KdTreeNanoflann::setUpTree] identity_mapping_=%i, "
+              "point_representation_->getNumberOfDimensions()=%lu, "
+              "point_representation_->isTrivial ()=%i\n",
+              identity_mapping_ ? 1 : 0,
+              dim,
+              point_representation_->isTrivial() ? 1 : 0);
+    if (identity_mapping_ && point_representation_->isTrivial() &&
+        sizeof(PointT) % sizeof(float) == 0) {
+      // no need to allocate memory and copy data
+      PCL_DEBUG("[KdTreeNanoflann::setUpTree] Mapping cloud directly, without "
+                "allocating memory.\n");
+      adaptor_.reset(new internal::PointCloudAdaptor<float>(
+          reinterpret_cast<const float*>(&(*input_)[0]),
+          false,
+          sizeof(PointT) / sizeof(float),
+          index_mapping_.size()));
+    }
+    else {
+      float* data = new float[dim * index_mapping_.size()];
+      float* data_itr = data;
+      for (auto& index : index_mapping_) {
+        point_representation_->vectorize((*input_)[index], data_itr);
+        data_itr += dim;
+      }
+      adaptor_.reset(new internal::PointCloudAdaptor<float>(
+          data, true, dim, index_mapping_.size()));
+    }
+    nanoflann_tree_.reset(
+        new Tree(dim,
+                 *adaptor_,
+#if NANOFLANN_VERSION >= 0x150
+                 // concurrent tree building is possible since nanoflann 1.5.0
+                 {leaf_max_size_,
+                  nanoflann::KDTreeSingleIndexAdaptorFlags::None,
+                  n_thread_build_}));
+#else
+                 {leaf_max_size_}));
+    if (n_thread_build_ != 1)
+      PCL_WARN("[KdTreeNanoflann::setUpTree] concurrent tree building is only possible "
+               "with nanoflann version 1.5.0 and newer\n");
+#endif // NANOFLANN_VERSION >= 0x150
+    return true;
+  }
+
+  KdTreePtr nanoflann_tree_;
+
+  shared_ptr<internal::PointCloudAdaptor<float>> adaptor_;
+
+  PointRepresentationConstPtr point_representation_{
+      new DefaultPointRepresentation<PointT>};
+
+  Indices index_mapping_;
+
+  bool identity_mapping_{false};
+
+  std::size_t leaf_max_size_{15};
+
+  unsigned int n_thread_build_{1};
+
+  float eps_{0.0f};
+
+  bool use_rknn_{true};
+};
+} // namespace search
+} // namespace pcl
+#ifdef PCL_NO_PRECOMPILE
+#include <pcl/search/impl/kdtree.hpp>
+#endif
+
+#else
+//#warning "KdTreeNanoflann is not available"
+#endif // PCL_HAS_NANOFLANN

--- a/test/search/CMakeLists.txt
+++ b/test/search/CMakeLists.txt
@@ -18,6 +18,13 @@ PCL_ADD_TEST(flann_search test_flann_search
              FILES test_flann_search.cpp
              LINK_WITH pcl_gtest pcl_search pcl_kdtree)
 
+if(TARGET nanoflann::nanoflann)
+PCL_ADD_TEST(kdtree_nanoflann_search test_kdtree_nanoflann_search
+             FILES test_kdtree_nanoflann.cpp
+             LINK_WITH pcl_gtest pcl_common pcl_search pcl_io pcl_features
+             ARGUMENTS "${PCL_SOURCE_DIR}/test/bun0.pcd")
+endif()
+
 PCL_ADD_TEST(organized_neighbor test_organized_search
              FILES test_organized.cpp
              LINK_WITH pcl_gtest pcl_search pcl_kdtree)

--- a/test/search/test_kdtree_nanoflann.cpp
+++ b/test/search/test_kdtree_nanoflann.cpp
@@ -1,0 +1,785 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2025-, Open Perception Inc.
+ *
+ *  All rights reserved
+ */
+
+#define PCL_NO_PRECOMPILE 1 // for MyPoint instantiations
+#include <pcl/common/distances.h>
+#include <pcl/common/io.h> // for copyPointCloud
+#include <pcl/common/time.h>
+#include <pcl/features/fpfh.h>
+#include <pcl/features/normal_3d.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/search/kdtree.h>           // for pcl::search::KdTree
+#include <pcl/search/kdtree_nanoflann.h> // for pcl::search::KdTreeNanoflann
+#include <pcl/test/gtest.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+#include <iostream>
+
+namespace pcl_tests {
+inline double
+squared_point_distance(const pcl::Narf36& p1, const pcl::Narf36& p2)
+{
+  double dist = 0.0;
+  for (std::size_t i = 0; i < 36; ++i)
+    dist += std::pow(static_cast<double>(p1.descriptor[i]) -
+                         static_cast<double>(p2.descriptor[i]),
+                     2);
+  return dist;
+}
+} // namespace pcl_tests
+
+using namespace pcl;
+
+// many of the tests are copied and adapted form test/search/test_flann_search.cpp and
+// test/kdtree/test_kdtree.cpp
+
+PointCloud<PointXYZ> cloud, cloud_big, bun0_cloud;
+
+void
+init()
+{
+  float resolution = 0.1f;
+  for (float z = -0.5f; z <= 0.5f; z += resolution)
+    for (float y = -0.5f; y <= 0.5f; y += resolution)
+      for (float x = -0.5f; x <= 0.5f; x += resolution)
+        cloud.emplace_back(static_cast<float>(rand()) / (RAND_MAX + 1.0) - 0.5,
+                           static_cast<float>(rand()) / (RAND_MAX + 1.0) - 0.5,
+                           static_cast<float>(rand()) / (RAND_MAX + 1.0) - 0.5);
+  cloud.width = cloud.size();
+  cloud.height = 1;
+
+  // Randomly create a new point cloud, use points.emplace_back
+  cloud_big.width = 640 * 480;
+  cloud_big.height = 1;
+  for (std::size_t i = 0; i < cloud_big.width * cloud_big.height; ++i)
+    cloud_big.points.emplace_back(static_cast<float>(1024 * rand() / (RAND_MAX + 1.0)),
+                                  static_cast<float>(1024 * rand() / (RAND_MAX + 1.0)),
+                                  static_cast<float>(1024 * rand() / (RAND_MAX + 1.0)));
+}
+
+TEST(PCL, KdTreeNanoflann_nearestKSearch)
+{
+  auto kdtree = pcl::make_shared<pcl::search::KdTreeNanoflann<PointXYZ>>();
+  kdtree->setInputCloud(cloud.makeShared());
+  EXPECT_EQ(kdtree->getEpsilon(), 0.0f);
+  kdtree->setEpsilon(1.23f);
+  EXPECT_EQ(kdtree->getEpsilon(), 1.23f);
+  kdtree->setEpsilon(0.0f);
+  PointXYZ test_point(0.01f, 0.01f, 0.01f);
+  unsigned int no_of_neighbors = 20;
+  std::multimap<float, int> sorted_brute_force_result;
+  for (std::size_t i = 0; i < cloud.size(); ++i) {
+    float distance = euclideanDistance(cloud[i], test_point);
+    sorted_brute_force_result.insert(std::make_pair(distance, static_cast<int>(i)));
+  }
+  float max_dist = 0.0f;
+  unsigned int counter = 0;
+  for (auto it = sorted_brute_force_result.begin();
+       it != sorted_brute_force_result.end() && counter < no_of_neighbors;
+       ++it) {
+    max_dist = std::max(max_dist, it->first);
+    ++counter;
+  }
+
+  pcl::Indices k_indices;
+  k_indices.resize(no_of_neighbors);
+  std::vector<float> k_distances;
+  k_distances.resize(no_of_neighbors);
+
+  kdtree->nearestKSearch(test_point, no_of_neighbors, k_indices, k_distances);
+
+  EXPECT_EQ(k_indices.size(), no_of_neighbors);
+
+  // Check if all found neighbors have distance smaller than max_dist
+  for (const auto& k_index : k_indices) {
+    const PointXYZ& point = cloud[k_index];
+    bool ok = euclideanDistance(test_point, point) <= max_dist;
+    if (!ok)
+      ok = (std::abs(euclideanDistance(test_point, point)) - max_dist) <= 1e-6;
+    EXPECT_TRUE(ok);
+  }
+
+  kdtree->setUseRKNN(true);
+  pcl::Indices k_indices_rknn;
+  std::vector<float> k_distances_rknn;
+  // first test with search radius bigger than farthest neighbor, results should be the
+  // same
+  kdtree->radiusSearch(test_point,
+                       max_dist + std::numeric_limits<float>::epsilon(),
+                       k_indices_rknn,
+                       k_distances_rknn,
+                       no_of_neighbors);
+  EXPECT_EQ(k_indices_rknn.size(), k_indices.size());
+  EXPECT_EQ(k_distances_rknn.size(), k_distances.size());
+  for (std::size_t i = 0;
+       i < std::min<std::size_t>(k_indices.size(), k_indices_rknn.size());
+       ++i) {
+    EXPECT_EQ(k_indices[i], k_indices_rknn[i]);
+    EXPECT_EQ(k_distances[i], k_distances_rknn[i]);
+  }
+  // then test with search radius slightly smaller than farthest neighbor, should have
+  // one neighbor less
+  kdtree->radiusSearch(test_point,
+                       max_dist - std::numeric_limits<float>::epsilon(),
+                       k_indices_rknn,
+                       k_distances_rknn,
+                       no_of_neighbors);
+  EXPECT_EQ(k_indices_rknn.size() + 1, k_indices.size());
+  EXPECT_EQ(k_distances_rknn.size() + 1, k_distances.size());
+  for (std::size_t i = 0;
+       i < std::min<std::size_t>(k_indices.size(), k_indices_rknn.size());
+       ++i) {
+    EXPECT_EQ(k_indices[i], k_indices_rknn[i]);
+    EXPECT_EQ(k_distances[i], k_distances_rknn[i]);
+  }
+}
+
+/* Test the templated NN search (for different query point types) */
+TEST(PCL, KdTreeNanoflannSearch_differentPointT)
+{
+
+  unsigned int no_of_neighbors = 20;
+
+  pcl::search::KdTreeNanoflann<PointXYZ> kdtree;
+  kdtree.setInputCloud(cloud_big.makeShared());
+
+  PointCloud<PointXYZRGB> cloud_rgb;
+
+  copyPointCloud(cloud_big, cloud_rgb);
+
+  std::vector<std::vector<float>> dists;
+  std::vector<pcl::Indices> indices;
+  kdtree.nearestKSearchT(cloud_rgb, pcl::Indices(), no_of_neighbors, indices, dists);
+
+  pcl::Indices k_indices;
+  k_indices.resize(no_of_neighbors);
+  std::vector<float> k_distances;
+  k_distances.resize(no_of_neighbors);
+
+  for (std::size_t i = 0; i < cloud_rgb.size(); ++i) {
+    kdtree.nearestKSearch(cloud_big[i], no_of_neighbors, k_indices, k_distances);
+    EXPECT_EQ(k_indices.size(), indices[i].size());
+    EXPECT_EQ(k_distances.size(), dists[i].size());
+    for (std::size_t j = 0; j < no_of_neighbors; j++) {
+      EXPECT_TRUE(k_indices[j] == indices[i][j] || k_distances[j] == dists[i][j]);
+    }
+  }
+}
+
+/* Test for KdTreeNanoflann nearestKSearch with multiple query points */
+TEST(PCL, KdTreeNanoflann_multipointKnnSearch)
+{
+
+  unsigned int no_of_neighbors = 20;
+
+  pcl::search::KdTreeNanoflann<PointXYZ> kdtree;
+  kdtree.setInputCloud(cloud_big.makeShared());
+
+  std::vector<std::vector<float>> dists;
+  std::vector<pcl::Indices> indices;
+  kdtree.nearestKSearch(cloud_big, pcl::Indices(), no_of_neighbors, indices, dists);
+
+  pcl::Indices k_indices;
+  k_indices.resize(no_of_neighbors);
+  std::vector<float> k_distances;
+  k_distances.resize(no_of_neighbors);
+
+  for (std::size_t i = 0; i < cloud_big.size(); ++i) {
+    kdtree.nearestKSearch(cloud_big[i], no_of_neighbors, k_indices, k_distances);
+    EXPECT_EQ(k_indices.size(), indices[i].size());
+    EXPECT_EQ(k_distances.size(), dists[i].size());
+    for (std::size_t j = 0; j < no_of_neighbors; j++) {
+      EXPECT_TRUE(k_indices[j] == indices[i][j] || k_distances[j] == dists[i][j]);
+    }
+  }
+}
+
+/* Test for KdTreeNanoflann nearestKSearch with multiple query points */
+TEST(PCL, KdTreeNanoflann_knnByIndex)
+{
+
+  unsigned int no_of_neighbors = 3;
+
+  pcl::search::KdTreeNanoflann<PointXYZ> kdtree;
+  kdtree.setInputCloud(cloud_big.makeShared());
+
+  std::vector<std::vector<float>> dists;
+  std::vector<pcl::Indices> indices;
+  pcl::Indices query_indices;
+  for (std::size_t i = 0; i < cloud_big.size(); i += 2) {
+    query_indices.push_back(static_cast<int>(i));
+  }
+  kdtree.nearestKSearch(cloud_big, query_indices, no_of_neighbors, indices, dists);
+
+  pcl::Indices k_indices;
+  k_indices.resize(no_of_neighbors);
+  std::vector<float> k_distances;
+  k_distances.resize(no_of_neighbors);
+
+  for (std::size_t i = 0; i < query_indices.size(); ++i) {
+    kdtree.nearestKSearch(cloud_big[2 * i], no_of_neighbors, k_indices, k_distances);
+    EXPECT_EQ(k_indices.size(), indices[i].size());
+    EXPECT_EQ(k_distances.size(), dists[i].size());
+    for (std::size_t j = 0; j < no_of_neighbors; j++) {
+      EXPECT_TRUE(k_indices[j] == indices[i][j] || k_distances[j] == dists[i][j]);
+    }
+    kdtree.nearestKSearch(
+        cloud_big, query_indices[i], no_of_neighbors, k_indices, k_distances);
+    EXPECT_EQ(k_indices.size(), indices[i].size());
+    EXPECT_EQ(k_distances.size(), dists[i].size());
+    for (std::size_t j = 0; j < no_of_neighbors; j++) {
+      EXPECT_TRUE(k_indices[j] == indices[i][j] || k_distances[j] == dists[i][j]);
+    }
+  }
+}
+
+TEST(PCL, KdTreeNanoflann_compareToKdTreeFlann)
+{
+
+  int no_of_neighbors = 3;
+  pcl::Indices k_indices;
+  k_indices.resize(no_of_neighbors);
+  std::vector<float> k_distances;
+  k_distances.resize(no_of_neighbors);
+
+  pcl::search::Search<PointXYZ>*nanoflann_search, *kdtree_search;
+
+  PointCloud<PointXYZ>::Ptr pc = cloud_big.makeShared();
+  {
+    ScopeTime scopeTime("KdTreeNanoflann build");
+    nanoflann_search = new pcl::search::KdTreeNanoflann<PointXYZ>;
+    nanoflann_search->setInputCloud(pc);
+  }
+
+  {
+    ScopeTime scopeTime("kdtree build");
+    kdtree_search = new pcl::search::KdTree<PointXYZ>();
+    kdtree_search->setInputCloud(pc);
+  }
+
+  {
+    ScopeTime scopeTime("KdTreeNanoflann nearestKSearch");
+    for (const auto& point : cloud_big.points)
+      nanoflann_search->nearestKSearch(point, no_of_neighbors, k_indices, k_distances);
+  }
+  {
+    ScopeTime scopeTime("kd tree  nearestKSearch");
+    for (const auto& point : cloud_big.points)
+      kdtree_search->nearestKSearch(point, no_of_neighbors, k_indices, k_distances);
+  }
+
+  std::vector<pcl::Indices> indices_nanoflann;
+  std::vector<std::vector<float>> dists_nanoflann;
+  std::vector<pcl::Indices> indices_tree;
+  std::vector<std::vector<float>> dists_tree;
+  indices_nanoflann.resize(cloud_big.size());
+  dists_nanoflann.resize(cloud_big.size());
+  indices_tree.resize(cloud_big.size());
+  dists_tree.resize(cloud_big.size());
+  for (std::size_t i = 0; i < cloud_big.size(); ++i) {
+    indices_nanoflann[i].resize(no_of_neighbors);
+    dists_nanoflann[i].resize(no_of_neighbors);
+    indices_tree[i].resize(no_of_neighbors);
+    dists_tree[i].resize(no_of_neighbors);
+  }
+
+  {
+    ScopeTime scopeTime("KdTreeNanoflann multi nearestKSearch");
+    nanoflann_search->nearestKSearch(
+        cloud_big, pcl::Indices(), no_of_neighbors, indices_nanoflann, dists_nanoflann);
+  }
+  {
+    ScopeTime scopeTime("kd tree multi nearestKSearch");
+    kdtree_search->nearestKSearch(
+        cloud_big, pcl::Indices(), no_of_neighbors, indices_tree, dists_tree);
+  }
+
+  ASSERT_EQ(indices_nanoflann.size(), dists_nanoflann.size());
+  ASSERT_EQ(indices_nanoflann.size(), indices_tree.size());
+  ASSERT_EQ(indices_nanoflann.size(), dists_tree.size());
+
+  for (std::size_t i = 0; i < indices_nanoflann.size(); i++) {
+    ASSERT_EQ(indices_nanoflann[i].size(), no_of_neighbors);
+    ASSERT_EQ(indices_tree[i].size(), no_of_neighbors);
+    ASSERT_EQ(dists_nanoflann[i].size(), no_of_neighbors);
+    ASSERT_EQ(dists_tree[i].size(), no_of_neighbors);
+    for (int j = 0; j < no_of_neighbors; j++) {
+
+      ASSERT_TRUE(indices_nanoflann[i][j] == indices_tree[i][j] ||
+                  dists_nanoflann[i][j] == dists_tree[i][j]);
+    }
+  }
+
+  pcl::Indices query_indices;
+  for (std::size_t i = 0; i < cloud_big.size(); i += 2)
+    query_indices.push_back(static_cast<int>(i));
+
+  {
+    ScopeTime scopeTime("KdTreeNanoflann multi nearestKSearch with indices");
+    nanoflann_search->nearestKSearch(
+        cloud_big, query_indices, no_of_neighbors, indices_nanoflann, dists_nanoflann);
+  }
+  {
+    ScopeTime scopeTime("kd tree multi nearestKSearch with indices");
+    kdtree_search->nearestKSearch(
+        cloud_big, query_indices, no_of_neighbors, indices_tree, dists_tree);
+  }
+  ASSERT_EQ(indices_nanoflann.size(), dists_nanoflann.size());
+  ASSERT_EQ(indices_nanoflann.size(), indices_tree.size());
+  ASSERT_EQ(indices_nanoflann.size(), dists_tree.size());
+
+  for (std::size_t i = 0; i < indices_nanoflann.size(); i++) {
+    ASSERT_EQ(indices_nanoflann[i].size(), no_of_neighbors);
+    ASSERT_EQ(indices_tree[i].size(), no_of_neighbors);
+    ASSERT_EQ(dists_nanoflann[i].size(), no_of_neighbors);
+    ASSERT_EQ(dists_tree[i].size(), no_of_neighbors);
+    for (int j = 0; j < no_of_neighbors; j++) {
+      ASSERT_TRUE(indices_nanoflann[i][j] == indices_tree[i][j] ||
+                  dists_nanoflann[i][j] == dists_tree[i][j]);
+    }
+  }
+
+  delete nanoflann_search;
+  delete kdtree_search;
+}
+
+// test with FPFHSignature33
+TEST(PCL, KdTreeNanoflann_features)
+{
+  using FeatureT = FPFHSignature33;
+
+  // Create shared pointers
+  pcl::PointCloud<PointXYZ>::Ptr cloud_source_ptr;
+  cloud_source_ptr = bun0_cloud.makeShared();
+
+  // first estimate normals
+  PointCloud<Normal>::Ptr normals(new PointCloud<Normal>);
+  pcl::NormalEstimation<PointXYZ, Normal> norm_est;
+  norm_est.setRadiusSearch(0.05);
+  norm_est.setInputCloud(cloud_source_ptr);
+  norm_est.compute(*normals);
+
+  // then estimate features
+  PointCloud<FeatureT>::Ptr features_source(new PointCloud<FeatureT>);
+  pcl::FPFHEstimation<PointXYZ, Normal, FeatureT> fpfh_est;
+  fpfh_est.setRadiusSearch(0.05);
+  fpfh_est.setInputCloud(cloud_source_ptr);
+  fpfh_est.setInputNormals(normals);
+  fpfh_est.compute(*features_source);
+
+  pcl::search::KdTree<FeatureT> kdtree;
+  kdtree.setInputCloud(features_source);
+
+  pcl::search::KdTreeNanoflann<FeatureT, -1> kdtree_nanoflann;
+  kdtree_nanoflann.setInputCloud(features_source);
+
+  pcl::Indices indices, indices_nanoflann;
+  std::vector<float> dists, dists_nanoflann;
+
+  // test nearestKSearch
+  ASSERT_TRUE(std::isfinite((*features_source)[10].histogram[0]));
+  kdtree.nearestKSearch((*features_source)[10], 10, indices, dists);
+  kdtree_nanoflann.nearestKSearch(
+      (*features_source)[10], 10, indices_nanoflann, dists_nanoflann);
+  ASSERT_EQ(indices.size(), indices_nanoflann.size());
+  ASSERT_EQ(dists.size(), dists_nanoflann.size());
+  ASSERT_EQ(indices.size(), dists.size());
+  for (std::size_t i = 0; i < indices.size(); ++i) {
+    EXPECT_EQ(indices[i], indices_nanoflann[i]);
+    EXPECT_NEAR(dists[i], dists_nanoflann[i], 1e-4);
+  }
+
+  ASSERT_TRUE(std::isfinite((*features_source)[99].histogram[0]));
+  kdtree.nearestKSearch((*features_source)[99], 5, indices, dists);
+  kdtree_nanoflann.nearestKSearch(
+      (*features_source)[99], 5, indices_nanoflann, dists_nanoflann);
+  ASSERT_EQ(indices.size(), indices_nanoflann.size());
+  ASSERT_EQ(dists.size(), dists_nanoflann.size());
+  ASSERT_EQ(indices.size(), dists.size());
+  for (std::size_t i = 0; i < indices.size(); ++i) {
+    EXPECT_EQ(indices[i], indices_nanoflann[i]);
+    EXPECT_NEAR(dists[i], dists_nanoflann[i], 1e-4);
+  }
+}
+
+// test with Narf36, because it has a non-trivial point representation
+TEST(PCL, KdTreeNanoflann_Narf36)
+{
+  using FeatureT = pcl::Narf36;
+  auto feature_cloud = pcl::make_shared<pcl::PointCloud<FeatureT>>();
+  feature_cloud->resize(1000);
+  for (auto& feature : *feature_cloud) {
+    feature.x = 20.0 * rand() / RAND_MAX - 10.0;
+    feature.y = 20.0 * rand() / RAND_MAX - 10.0;
+    feature.z = 20.0 * rand() / RAND_MAX - 10.0;
+    feature.roll = M_PI * rand() / RAND_MAX;
+    feature.pitch = M_PI * rand() / RAND_MAX;
+    feature.yaw = M_PI * rand() / RAND_MAX;
+    for (float& desc : feature.descriptor) {
+      desc = 2.0 * rand() / RAND_MAX - 1.0;
+    }
+  }
+  pcl::search::KdTree<FeatureT> kdtree;
+  kdtree.setInputCloud(feature_cloud);
+
+  pcl::search::KdTreeNanoflann<FeatureT, 36> kdtree_nanoflann;
+  kdtree_nanoflann.setSortedResults(true);
+  kdtree_nanoflann.setInputCloud(feature_cloud);
+
+  pcl::Indices indices, indices_nanoflann;
+  std::vector<float> dists, dists_nanoflann;
+
+  // test nearestKSearch
+  for (std::size_t j = 0; j < feature_cloud->size(); ++j) {
+    const int k = static_cast<int>(99.0 * rand() / RAND_MAX + 1);
+    kdtree.nearestKSearch((*feature_cloud)[j], k, indices, dists);
+    kdtree_nanoflann.nearestKSearch(
+        (*feature_cloud)[j], k, indices_nanoflann, dists_nanoflann);
+    ASSERT_EQ(indices.size(), indices_nanoflann.size());
+    ASSERT_EQ(dists.size(), dists_nanoflann.size());
+    ASSERT_EQ(indices.size(), dists.size());
+    ASSERT_EQ(indices_nanoflann.size(), dists_nanoflann.size());
+    for (std::size_t i = 0; i < indices.size(); ++i) {
+      // sometimes, two neighbors have almost the same distance to the query point, but
+      // are switched due to limited floating point accuracy.
+      if ((i + 1) < indices.size() && indices[i] != indices_nanoflann[i] &&
+          indices[i + 1] != indices_nanoflann[i + 1] &&
+          (indices[i] == indices_nanoflann[i + 1] ||
+           indices[i + 1] == indices_nanoflann[i]) &&
+          std::abs(dists[i] - dists_nanoflann[i + 1]) < 1e-4 &&
+          std::abs(dists[i + 1] - dists_nanoflann[i]) < 1e-4) {
+        std::swap(indices[i], indices[i + 1]);
+        std::swap(dists[i], dists[i + 1]);
+      }
+    }
+    if (!indices.empty() && indices.back() != indices_nanoflann.back() &&
+        std::abs(dists.back() - dists_nanoflann.back()) < 1e-5 &&
+        std::abs(pcl_tests::squared_point_distance((*feature_cloud)[j],
+                                                   (*feature_cloud)[indices.back()]) -
+                 pcl_tests::squared_point_distance(
+                     (*feature_cloud)[j], (*feature_cloud)[indices_nanoflann.back()])) <
+            1e-5) {
+      indices_nanoflann.back() = indices.back();
+    }
+    for (std::size_t i = 0; i < indices.size(); ++i) {
+      EXPECT_EQ(indices[i], indices_nanoflann[i]);
+      EXPECT_NEAR(dists[i], dists_nanoflann[i], 1e-4);
+    }
+  }
+
+  // test radiusSearch
+  for (std::size_t i = 0; i < feature_cloud->size(); ++i) {
+    const float radius = 3.5 + static_cast<float>(rand()) / RAND_MAX;
+    kdtree.radiusSearch((*feature_cloud)[i], radius, indices, dists);
+    kdtree_nanoflann.radiusSearch(
+        (*feature_cloud)[i], radius, indices_nanoflann, dists_nanoflann);
+    if (indices.size() > indices_nanoflann.size()) {
+      if (std::abs(pcl_tests::squared_point_distance((*feature_cloud)[i],
+                                                     (*feature_cloud)[indices.back()]) -
+                   static_cast<double>(radius) * static_cast<double>(radius)) < 1e-5) {
+        indices.pop_back();
+        dists.pop_back();
+      }
+    }
+    else if (indices.size() < indices_nanoflann.size()) {
+      if (std::abs(
+              pcl_tests::squared_point_distance(
+                  (*feature_cloud)[i], (*feature_cloud)[indices_nanoflann.back()]) -
+              static_cast<double>(radius) * static_cast<double>(radius)) < 1e-5) {
+        indices_nanoflann.pop_back();
+        dists_nanoflann.pop_back();
+      }
+    }
+    ASSERT_EQ(indices.size(), indices_nanoflann.size());
+    ASSERT_EQ(dists.size(), dists_nanoflann.size());
+    ASSERT_EQ(indices.size(), dists.size());
+    ASSERT_EQ(indices_nanoflann.size(), dists_nanoflann.size());
+    for (std::size_t i = 0;
+         i < std::min<std::size_t>(indices.size(), indices_nanoflann.size());
+         ++i) {
+      // sometimes, two neighbors have almost the same distance to the query point, but
+      // are switched to due limited floating point accuracy.
+      if ((i + 1) < indices.size() && indices[i] != indices_nanoflann[i] &&
+          indices[i + 1] != indices_nanoflann[i + 1] &&
+          indices[i] == indices_nanoflann[i + 1] &&
+          indices[i + 1] == indices_nanoflann[i] &&
+          std::abs(dists[i] - dists_nanoflann[i + 1]) < 1e-4 &&
+          std::abs(dists[i + 1] - dists_nanoflann[i]) < 1e-4) {
+        std::swap(indices[i], indices[i + 1]);
+        std::swap(dists[i], dists[i + 1]);
+      }
+      EXPECT_EQ(indices[i], indices_nanoflann[i])
+          << "i=" << i << ", dists[i]=" << dists[i]
+          << ", dists_nanoflann[i]=" << dists_nanoflann[i] << std::endl;
+      ;
+      EXPECT_NEAR(dists[i], dists_nanoflann[i], 1e-4);
+    }
+  }
+}
+
+template <typename PointT>
+double
+manhattanDistance(const PointT& a, const PointT& b)
+{
+  return std::abs(static_cast<double>(a.x) - static_cast<double>(b.x)) +
+         std::abs(static_cast<double>(a.y) - static_cast<double>(b.y)) +
+         std::abs(static_cast<double>(a.z) - static_cast<double>(b.z));
+}
+
+// test with L1/manhattan distance instead of L2/euclidean distance
+TEST(PCL, KdTreeNanoflann_nearestKSearch_L1)
+{
+  pcl::search::KdTreeNanoflann<PointXYZ, 3, pcl::search::L1_Adaptor> kdtree_nanoflann;
+  kdtree_nanoflann.setInputCloud(bun0_cloud.makeShared());
+
+  kdtree_nanoflann.setSortedResults(true);
+  PointXYZ test_point = bun0_cloud[rand() % bun0_cloud.size()];
+  const unsigned int no_of_neighbors = 20;
+  std::multimap<double, int> sorted_brute_force_result;
+  for (std::size_t i = 0; i < bun0_cloud.size(); ++i) {
+    auto distance = manhattanDistance(bun0_cloud[i], test_point);
+    sorted_brute_force_result.emplace(distance, i);
+  }
+
+  pcl::Indices k_indices;
+  std::vector<float> k_distances;
+
+  EXPECT_EQ(no_of_neighbors,
+            kdtree_nanoflann.nearestKSearch(
+                test_point, no_of_neighbors, k_indices, k_distances));
+  EXPECT_EQ(k_indices.size(), no_of_neighbors);
+  EXPECT_EQ(k_distances.size(), no_of_neighbors);
+  unsigned int counter = 0;
+  for (auto it = sorted_brute_force_result.begin();
+       it != sorted_brute_force_result.end() && counter < no_of_neighbors;
+       ++it, ++counter) {
+    EXPECT_EQ(k_indices[counter], it->second);
+    EXPECT_NEAR(k_distances[counter], it->first, 1e-6);
+  }
+
+  // test radius search
+  const float search_radius = 10 * std::next(sorted_brute_force_result.begin())->first;
+  kdtree_nanoflann.radiusSearch(test_point, search_radius, k_indices, k_distances);
+  EXPECT_EQ(k_indices.size(), k_distances.size());
+  counter = 0;
+  for (auto it = sorted_brute_force_result.begin();
+       it != sorted_brute_force_result.end() && it->first <= search_radius;
+       ++it, ++counter) {
+    // sometimes, two neighbors have almost the same distance to the query point, but
+    // are switched to due limited floating point accuracy.
+    if ((counter + 1) < k_indices.size() && k_indices[counter] != it->second &&
+        k_indices[counter + 1] != std::next(it)->second &&
+        k_indices[counter] == std::next(it)->second &&
+        k_indices[counter + 1] == it->second &&
+        std::abs(k_distances[counter] - std::next(it)->first) < 1e-6 &&
+        std::abs(k_distances[counter + 1] - it->first) < 1e-6) {
+      std::swap(k_indices[counter], k_indices[counter + 1]);
+      std::swap(k_distances[counter], k_distances[counter + 1]);
+    }
+    EXPECT_EQ(k_indices[counter], it->second);
+    EXPECT_NEAR(k_distances[counter], it->first, 1e-6);
+  }
+  EXPECT_EQ(k_indices.size(), counter);
+}
+
+struct MyPoint : public PointXYZ {
+  MyPoint(float x, float y, float z)
+  {
+    this->x = x;
+    this->y = y;
+    this->z = z;
+  }
+};
+
+class MyPointRepresentationXY : public PointRepresentation<MyPoint> {
+public:
+  MyPointRepresentationXY() { this->nr_dimensions_ = 2; }
+
+  void
+  copyToFloatArray(const MyPoint& p, float* out) const override
+  {
+    out[0] = p.x;
+    out[1] = p.y;
+  }
+};
+
+TEST(PCL, KdTreeNanoflann_setPointRepresentation)
+{
+  PointCloud<MyPoint>::Ptr random_cloud(new PointCloud<MyPoint>());
+  random_cloud->points.emplace_back(86.6f, 42.1f, 92.4f);
+  random_cloud->points.emplace_back(63.1f, 18.4f, 22.3f);
+  random_cloud->points.emplace_back(35.5f, 72.5f, 37.3f);
+  random_cloud->points.emplace_back(99.7f, 37.0f, 8.7f);
+  random_cloud->points.emplace_back(22.4f, 84.1f, 64.0f);
+  random_cloud->points.emplace_back(65.2f, 73.4f, 18.0f);
+  random_cloud->points.emplace_back(60.4f, 57.1f, 4.5f);
+  random_cloud->points.emplace_back(38.7f, 17.6f, 72.3f);
+  random_cloud->points.emplace_back(14.2f, 95.7f, 34.7f);
+  random_cloud->points.emplace_back(2.5f, 26.5f, 66.0f);
+
+  auto kdtree = pcl::make_shared<pcl::search::KdTreeNanoflann<MyPoint, -1>>();
+  kdtree->setInputCloud(random_cloud);
+  EXPECT_EQ(3, kdtree->getPointRepresentation()->getNumberOfDimensions());
+  MyPoint p(50.0f, 50.0f, 50.0f);
+
+  // Find k nearest neighbors
+  constexpr int k = 10;
+  pcl::Indices k_indices(k);
+  std::vector<float> k_distances(k);
+  kdtree->nearestKSearch(p, k, k_indices, k_distances);
+  for (int i = 0; i < k; ++i) {
+    // Compare to ground truth values, computed independently
+    static const int gt_indices[10] = {2, 7, 5, 1, 4, 6, 9, 0, 8, 3};
+    static const float gt_distances[10] = {877.8f,
+                                           1674.7f,
+                                           1802.6f,
+                                           1937.5f,
+                                           2120.6f,
+                                           2228.8f,
+                                           3064.5f,
+                                           3199.7f,
+                                           3604.2f,
+                                           4344.8f};
+    EXPECT_EQ(k_indices[i], gt_indices[i]);
+    EXPECT_NEAR(k_distances[i], gt_distances[i], 0.1);
+  }
+
+  // Find k nearest neighbors with a different point representation
+  pcl::search::KdTreeNanoflann<MyPoint, -1>::PointRepresentationConstPtr ptrep(
+      new MyPointRepresentationXY);
+  kdtree->setPointRepresentation(ptrep);
+  EXPECT_EQ(2, kdtree->getPointRepresentation()->getNumberOfDimensions());
+  kdtree->nearestKSearch(p, k, k_indices, k_distances);
+  for (int i = 0; i < k; ++i) {
+    // Compare to ground truth values, computed independently
+    static const int gt_indices[10] = {6, 2, 5, 1, 7, 0, 4, 3, 9, 8};
+    static const float gt_distances[10] = {158.6f,
+                                           716.5f,
+                                           778.6f,
+                                           1170.2f,
+                                           1177.5f,
+                                           1402.0f,
+                                           1924.6f,
+                                           2639.1f,
+                                           2808.5f,
+                                           3370.1f};
+    EXPECT_EQ(k_indices[i], gt_indices[i]);
+    EXPECT_NEAR(k_distances[i], gt_distances[i], 0.1);
+  }
+
+  // Go back to the default, this time with the values rescaled
+  DefaultPointRepresentation<MyPoint> point_rep;
+  float alpha[3] = {1.0f, 2.0f, 3.0f};
+  point_rep.setRescaleValues(alpha);
+  kdtree->setPointRepresentation(point_rep.makeShared());
+  EXPECT_EQ(3, kdtree->getPointRepresentation()->getNumberOfDimensions());
+  kdtree->nearestKSearch(p, k, k_indices, k_distances);
+  for (int i = 0; i < k; ++i) {
+    // Compare to ground truth values, computed independently
+    static const int gt_indices[10] = {2, 9, 4, 7, 1, 5, 8, 0, 3, 6};
+    static const float gt_distances[10] = {3686.9f,
+                                           6769.2f,
+                                           7177.0f,
+                                           8802.3f,
+                                           11071.5f,
+                                           11637.3f,
+                                           11742.4f,
+                                           17769.0f,
+                                           18497.3f,
+                                           18942.0f};
+    EXPECT_EQ(k_indices[i], gt_indices[i]);
+    EXPECT_NEAR(k_distances[i], gt_distances[i], 0.1);
+  }
+}
+
+// test with nanoflann::KDTreeSingleIndexDynamicAdaptor (allows to dynamically
+// add/remove points)
+TEST(PCL, KdTreeNanoflann_dynamic)
+{
+  pcl::console::setVerbosityLevel(pcl::console::L_VERBOSE);
+  using Distance = pcl::search::L2_Simple_Adaptor;
+  constexpr std::int32_t Dim = 3;
+  pcl::search::KdTreeNanoflann<PointXYZ,
+                               Dim,
+                               Distance,
+                               nanoflann::KDTreeSingleIndexDynamicAdaptor<
+                                   Distance,
+                                   pcl::search::internal::PointCloudAdaptor<float>,
+                                   Dim,
+                                   pcl::index_t>>
+      kdtree_nanoflann;
+  kdtree_nanoflann.setSortedResults(true);
+  auto input_cloud = bun0_cloud.makeShared();
+  input_cloud->reserve(input_cloud->size() + 1); // reserve space for one more point
+  kdtree_nanoflann.setInputCloud(input_cloud);
+
+  pcl::PointXYZ test_point = (*input_cloud)[rand() % input_cloud->size()];
+  const unsigned int no_of_neighbors = 20;
+  std::multimap<double, int> sorted_brute_force_result;
+  for (std::size_t i = 0; i < input_cloud->size(); ++i) {
+    auto distance = squaredEuclideanDistance((*input_cloud)[i], test_point);
+    sorted_brute_force_result.emplace(distance, i);
+  }
+
+  pcl::Indices k_indices;
+  std::vector<float> k_distances;
+
+  EXPECT_EQ(no_of_neighbors,
+            kdtree_nanoflann.nearestKSearch(
+                test_point, no_of_neighbors, k_indices, k_distances));
+  EXPECT_EQ(k_indices.size(), no_of_neighbors);
+  EXPECT_EQ(k_distances.size(), no_of_neighbors);
+  unsigned int counter = 0;
+  for (auto it = sorted_brute_force_result.begin();
+       it != sorted_brute_force_result.end() && counter < no_of_neighbors;
+       ++it, ++counter) {
+    EXPECT_EQ(k_indices[counter], it->second);
+    EXPECT_NEAR(k_distances[counter], it->first, 1e-6);
+  }
+
+  kdtree_nanoflann.getNanoflannTree()->removePoint(k_indices[0]);
+  input_cloud->push_back(test_point);
+  kdtree_nanoflann.getNanoflannTree()->addPoints(input_cloud->size() - 1,
+                                                 input_cloud->size() - 1);
+  sorted_brute_force_result.erase(sorted_brute_force_result.begin());
+  sorted_brute_force_result.emplace(0.0, input_cloud->size() - 1);
+
+  EXPECT_EQ(no_of_neighbors,
+            kdtree_nanoflann.nearestKSearch(
+                test_point, no_of_neighbors, k_indices, k_distances));
+  EXPECT_EQ(k_indices.size(), no_of_neighbors);
+  EXPECT_EQ(k_distances.size(), no_of_neighbors);
+  counter = 0;
+  for (auto it = sorted_brute_force_result.begin();
+       it != sorted_brute_force_result.end() && counter < no_of_neighbors;
+       ++it, ++counter) {
+    EXPECT_EQ(k_indices[counter], it->second);
+    EXPECT_NEAR(k_distances[counter], it->first, 1e-6);
+  }
+}
+
+int
+main(int argc, char** argv)
+{
+  const auto seed = time(nullptr);
+  std::cout << "seed=" << seed << std::endl;
+  srand(seed);
+  testing::InitGoogleTest(&argc, argv);
+  init();
+
+  if (argc < 2 || pcl::io::loadPCDFile(argv[1], bun0_cloud) < 0) {
+    std::cerr << "Failed to read test file. Please download `bun0.pcd` and pass its "
+                 "path to the test."
+              << std::endl;
+    return (-1);
+  }
+
+  return (RUN_ALL_TESTS());
+}

--- a/test/search/test_kdtree_nanoflann.cpp
+++ b/test/search/test_kdtree_nanoflann.cpp
@@ -587,6 +587,19 @@ TEST(PCL, KdTreeNanoflann_nearestKSearch_L1)
     EXPECT_NEAR(k_distances[counter], it->first, 1e-6);
   }
   EXPECT_EQ(k_indices.size(), counter);
+  // test unsorted radius search
+  kdtree_nanoflann.setSortedResults(false);
+  k_indices.clear();
+  k_distances.clear();
+  kdtree_nanoflann.radiusSearch(test_point, search_radius, k_indices, k_distances);
+  EXPECT_EQ(k_indices.size(), k_distances.size());
+  for (auto it = sorted_brute_force_result.begin();
+       it != sorted_brute_force_result.end() && it->first <= search_radius;
+       ++it) {
+    auto pos = std::find(k_indices.begin(), k_indices.end(), it->second);
+    ASSERT_NE(pos, k_indices.end()); // must be found
+    EXPECT_NEAR(it->first, k_distances[std::distance(k_indices.begin(), pos)], 1e-6);
+  }
 }
 
 struct MyPoint : public PointXYZ {
@@ -703,7 +716,6 @@ TEST(PCL, KdTreeNanoflann_setPointRepresentation)
 // add/remove points)
 TEST(PCL, KdTreeNanoflann_dynamic)
 {
-  pcl::console::setVerbosityLevel(pcl::console::L_VERBOSE);
   using Distance = pcl::search::L2_Simple_Adaptor;
   constexpr std::int32_t Dim = 3;
   pcl::search::KdTreeNanoflann<PointXYZ,

--- a/test/search/test_search.cpp
+++ b/test/search/test_search.cpp
@@ -42,6 +42,7 @@
 #include <pcl/search/brute_force.h>
 #include <pcl/search/kdtree.h>
 #include <pcl/search/flann_search.h>
+#include <pcl/search/kdtree_nanoflann.h>
 #include <pcl/search/organized.h>
 #include <pcl/search/octree.h>
 #include <pcl/io/pcd_io.h>
@@ -117,6 +118,10 @@ pcl::search::KdTree<pcl::PointXYZ> KDTree;
 
 /** \brief instance of FlannSearch search method to be tested*/
 pcl::search::FlannSearch<pcl::PointXYZ> FlannSearch;
+
+#if PCL_HAS_NANOFLANN
+pcl::search::KdTreeNanoflann<pcl::PointXYZ> KDTreeNanoflann;
+#endif
 
 /** \brief instance of Octree search method to be tested*/
 pcl::search::Octree<pcl::PointXYZ> octree_search (0.1);
@@ -656,17 +661,26 @@ main (int argc, char** argv)
   
   brute_force.setSortedResults (true);
   KDTree.setSortedResults (true);
+#if PCL_HAS_NANOFLANN
+  KDTreeNanoflann.setSortedResults (true);
+#endif
   octree_search.setSortedResults (true);
   organized.setSortedResults (true);
   
   unorganized_search_methods.push_back (&brute_force);
   unorganized_search_methods.push_back (&KDTree);
   unorganized_search_methods.push_back (&FlannSearch);
+#if PCL_HAS_NANOFLANN
+  unorganized_search_methods.push_back (&KDTreeNanoflann);
+#endif
   unorganized_search_methods.push_back (&octree_search);
   
   organized_search_methods.push_back (&brute_force);
   organized_search_methods.push_back (&KDTree);
   organized_search_methods.push_back (&FlannSearch);
+#if PCL_HAS_NANOFLANN
+  organized_search_methods.push_back (&KDTreeNanoflann);
+#endif
   organized_search_methods.push_back (&octree_search);
   organized_search_methods.push_back (&organized);
   


### PR DESCRIPTION
# Design considerations
The new `KdTreeNanoflann` should be usable in all situations where currently the FLANN-based kd-tree is used and all parameters etc of the new class should be configurable. At the same time, the existing classes should be changed as little as possible.
The feature classes accept a `pcl::search::Search` object, while the registration classes use a `pcl::search::KdTree<PointTarget>` object, which is actually `pcl::search::KdTree<PointTarget, pcl::KdTreeFLANN<PointTarget>>` (default for second template parameter).
I decided to make `KdTreeNanoflann` inherit from `pcl::search::KdTree<PointT, pcl::KdTreeFLANN<PointT>>`, that way it can be used almost everywhere, and existing classes do not have to be changed.

## Limitation
There is one minor limitation which is, I believe, not solvable without breaking the ABI. `pcl::search::KdTree` has a few methods, most notably `setPointRepresentation`, which should be overridden by `KdTreeNanoflann`, but these methods are not marked `virtual`. So the dynamic (runtime) dispatch does not work. Adding the `virtual` keyword would break ABI. For example, the following would not work:
```cpp
pcl::IterativeClosestPoint<PointNormalT, PointNormalT> reg;
// pass KdTreeNanoflann as search method. Since the registration classes internally store the
// search method as a pcl::search::KdTree (parent class of KdTreeNanoflann), it will be cast
reg.setSearchMethodTarget(pcl::make_shared<pcl::search::KdTreeNanoflann<pcl::PointXYZ>>());
// reg will call setPointRepresentation on the search method, but since setPointRepresentation
// in KdTree is not marked virtual, dynamic dispatch does not work and setPointRepresentation
// of KdTree is called, instead of setPointRepresentation of KdTreeNanoflann (which would be correct).
reg.setPointRepresentation (pcl::make_shared<const MyPointRepresentation> (point_representation));
```
There is however an easy workaround:
```cpp
pcl::IterativeClosestPoint<PointNormalT, PointNormalT> reg;
auto kdtree_nanoflann = pcl::make_shared<pcl::search::KdTreeNanoflann<pcl::PointXYZ>>();
kdtree_nanoflann->setPointRepresentation(pcl::make_shared<const MyPointRepresentation> (point_representation));
reg.setSearchMethodTarget(kdtree_nanoflann);
```
Since it would be great to merge this PR as soon as possible and have the new KdTreeNanoflann class included in the PCL 1.15.1 release (no ABI break possible), I would suggest to accept this limitation for now, and after the PCL 1.15.1 release when breaking ABI is acceptable, we can remove this limitation by adding `virtual` to the functions in `pcl::search::KdTree` and `override` to the corresponding functions in `pcl::search::KdTreeNanoflann`.

# Notes
- Since the new class is header-only, meaning it is compiled in the user project instead of when building PCL, it is important to enable optimizations when compiling the user code, e.g. `-DCMAKE_BUILD_TYPE=RelWithDebInfo` or `-DCMAKE_BUILD_TYPE=Release`, or choosing the "Release" config in Visual Studio.
- nanoflann versions currently tested in CI pipeline: 1.4.2 (Ubuntu 22.04), 1.5.4 (Ubuntu 24.04), 1.5.5 (Winx86), 1.7.1 (macOS and Winx64). Additionally, I am testing 1.6.0 locally.

# How to use
## Example 1: using KdTreeNanoflann in NormalEstimation:
```cpp
pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> ne;
auto tree = pcl::make_shared<pcl::search::KdTreeNanoflann<pcl::PointXYZ>>();
ne.setSearchMethod (tree);
// rest as usual
```
## Example 2: using KdTreeNanoflann in ICP:
```cpp
pcl::IterativeClosestPoint<pcl::PointXYZ, pcl::PointXYZ> icp;
icp.setSearchMethodSource(pcl::make_shared<pcl::search::KdTreeNanoflann<pcl::PointXYZ>>());
icp.setSearchMethodTarget(pcl::make_shared<pcl::search::KdTreeNanoflann<pcl::PointXYZ>>());
// rest as usual
```
## Example 3: using a L1 distance norm:
```cpp
pcl::search::KdTreeNanoflann<PointXYZ, 3, pcl::search::L1_Adaptor> kdtree_nanoflann;
kdtree_nanoflann.setInputCloud (my_cloud);
// now ready to use kdtree_nanoflann.nearestKSearch(...) and
// kdtree_nanoflann.radiusSearch(...);
```
## Example 4: using KdTreeNanoflann with features instead of 3D points:
```cpp
pcl::search::KdTreeNanoflann<pcl::FPFHSignature33, 33> kdtree_nanoflann_feat;
kdtree_nanoflann_feat.setInputCloud(my_features_cloud);
// now ready for searching
```

# Benchmarks
I did some benchmarks to get an idea how the new `KdTreeNanoflann`  compares to the FLANN based `KdTree`. Of course, these depend a lot on the processor, the point clouds used, and other factors. Switching to `KdTreeNanoflann` reduces the time spent to:
NormalEstimation (small radius): 75-78%
NormalEstimation (large radius): 76-78%
EuclideanClusterExtraction: 75-80%
RadiusOutlierRemoval: 25-40%
ICP (does nearestKSearch with k=1): 30-50%
NormalEstimation (small k): 85-90%
NormalEstimation (large k): 91-97%
1nn search (tree building not included): 29-32%
5nn search (tree building not included): 48-49%
50nn search (tree building not included): 83-85%
radius (small radius, sorted, tree building not included): 49-53%
radius (small radius, unsorted, tree building not included): 39-42%
radius (large radius, sorted, tree building not included): 77-81%
radius (large radius, unsorted, tree building not included): 63-65%
Where 100% refers to the time taken with `pcl::search::KdTree`, so e.g. 50% would be twice as fast as before.

# To discuss for the future
- some classes, e.g. SampleConsensusPrerejective and SampleConsensusInitialAlignment, use `pcl::search::KdTree` or `pcl::KdtreeFLANN` for searching and do not offer a way to change this. We could consider adding the option to pass in another search method (e.g. KdTreeNanoflann)
- we could consider making KdTreeNanoflann the default for unorganized point clouds when the user did not specify a search method (currently it is `pcl::search::KdTree` for unorganized clouds)
- Maybe add explicit instantiations in pcl_search? If yes, for which template parameters?