### PR TITLE
Simulation: replace gluErrorString with switch-case

### DIFF
--- a/simulation/src/glsl_shader.cpp
+++ b/simulation/src/glsl_shader.cpp
@@ -160,7 +160,28 @@ pcl::simulation::gllib::getGLError()
   GLenum error = glGetError();
   while (error != GL_NO_ERROR) {
     last_error = error;
-    std::cout << "Error: OpenGL: " << gluErrorString(error) << std::endl;
+    switch (error) {
+    case GL_INVALID_ENUM:
+      std::cout << "Error: OpenGL: GL_INVALID_ENUM" << std::endl;
+      break;
+    case GL_INVALID_VALUE:
+      std::cout << "Error: OpenGL: GL_INVALID_VALUE" << std::endl;
+      break;
+    case GL_INVALID_OPERATION:
+      std::cout << "Error: OpenGL: GL_INVALID_OPERATION" << std::endl;
+      break;
+    case GL_STACK_OVERFLOW:
+      std::cout << "Error: OpenGL: GL_STACK_OVERFLOW" << std::endl;
+      break;
+    case GL_STACK_UNDERFLOW:
+      std::cout << "Error: OpenGL: GL_STACK_UNDERFLOW" << std::endl;
+      break;
+    case GL_OUT_OF_MEMORY:
+      std::cout << "Error: OpenGL: GL_OUT_OF_MEMORY" << std::endl;
+      break;
+    default:
+      std::cout << "Error: OpenGL: Unknown error" << std::endl;
+    }
     error = glGetError();
   }
   return last_error;


### PR DESCRIPTION
Due to problems on vcpkg, see https://github.com/microsoft/vcpkg/issues/44058 
macOS also considers this function deprecated, see https://stackoverflow.com/questions/29583953