### PR TITLE
Make the dependency of "outofcore" on "visualization" optional.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -461,6 +461,11 @@ else()
 endif()
 unset(CMAKE_REQUIRED_LIBRARIES)
 
+### --[ Set variables for pcl_config.h
+if (BUILD_visualization)
+  set(PCL_VISUALIZATION_AVAILABLE TRUE)
+endif()
+
 ### ---[ Create the config.h file
 set(pcl_config_h_in "${CMAKE_CURRENT_SOURCE_DIR}/pcl_config.h.in")
 set(pcl_config_h "${CMAKE_CURRENT_BINARY_DIR}/include/pcl/pcl_config.h")
@@ -468,6 +473,7 @@ configure_file("${pcl_config_h_in}" "${pcl_config_h}")
 PCL_ADD_INCLUDES(common "" "${pcl_config_h}")
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/include")
 
+## ---[ PCL modules
 collect_subproject_directory_names("${PCL_SOURCE_DIR}" "CMakeLists.txt" PCL_MODULES_NAMES PCL_MODULES_DIRS doc)
 set(PCL_MODULES_NAMES_UNSORTED ${PCL_MODULES_NAMES})
 topological_sort(PCL_MODULES_NAMES PCL_ _DEPENDS)

--- a/outofcore/CMakeLists.txt
+++ b/outofcore/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(SUBSYS_NAME outofcore)
 set(SUBSYS_DESC "Point cloud outofcore library")
+if(BUILD_visualization)
 set(SUBSYS_DEPS common io filters octree visualization)
+else()
+set(SUBSYS_DEPS common io filters octree)
+endif()
 
 if(NOT TARGET Boost::filesystem)
   set(DEFAULT FALSE)
@@ -70,9 +74,13 @@ endif()
 
 set(LIB_NAME "pcl_${SUBSYS_NAME}")
 
-PCL_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs} ${impl_incs} ${visualization_incs})
-#PCL_ADD_SSE_FLAGS("${LIB_NAME}")
-target_link_libraries("${LIB_NAME}" pcl_common pcl_visualization ${Boost_SYSTEM_LIBRARY})
+if(BUILD_visualization)
+  PCL_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs} ${impl_incs} ${visualization_incs})
+  target_link_libraries("${LIB_NAME}" pcl_common pcl_visualization ${Boost_SYSTEM_LIBRARY})
+else()
+  PCL_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs} ${impl_incs})
+  target_link_libraries("${LIB_NAME}" pcl_common ${Boost_SYSTEM_LIBRARY})
+endif()
 if(HAVE_CJSON)
   target_link_libraries("${LIB_NAME}" ${CJSON_LIBRARIES})
 endif()
@@ -81,7 +89,9 @@ PCL_MAKE_PKGCONFIG(${LIB_NAME} COMPONENT ${SUBSYS_NAME} DESC ${SUBSYS_DESC} PCL_
 # Install include files
 PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}" ${incs})
 PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}/impl" ${impl_incs})
-PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}/visualization" ${visualization_incs})
+if(BUILD_visualization)
+  PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}/visualization" ${visualization_incs})
+endif()
 
 if(BUILD_tools)
   add_subdirectory(tools)

--- a/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
+++ b/outofcore/include/pcl/outofcore/impl/octree_base_node.hpp
@@ -51,7 +51,9 @@
 
 #include <pcl/common/common.h>
 #include <pcl/common/utils.h> // pcl::utils::ignore
+#ifdef PCL_VISUALIZATION_AVAILABLE
 #include <pcl/visualization/common/common.h>
+#endif
 #include <pcl/outofcore/octree_base_node.h>
 #include <pcl/filters/random_sample.h>
 #include <pcl/filters/extract_indices.h>
@@ -1199,7 +1201,7 @@ namespace pcl
     }
 
 ////////////////////////////////////////////////////////////////////////////////
-
+#ifdef PCL_VISUALIZATION_AVAILABLE
     template<typename Container, typename PointT> void
     OutofcoreOctreeBaseNode<Container, PointT>::queryFrustum (const double planes[24], const Eigen::Vector3d &eye, const Eigen::Matrix4d &view_projection_matrix, std::list<std::string>& file_names, const std::uint32_t query_depth, const bool skip_vfc_check)
     {
@@ -1310,6 +1312,7 @@ namespace pcl
         }
       }
     }
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
     template<typename ContainerT, typename PointT> void

--- a/outofcore/include/pcl/outofcore/octree_base_node.h
+++ b/outofcore/include/pcl/outofcore/octree_base_node.h
@@ -161,8 +161,15 @@ namespace pcl
         void
         queryFrustum (const double planes[24], std::list<std::string>& file_names, const std::uint32_t query_depth, const bool skip_vfc_check = false);
 
+        /** \warning This function is only available if the visualization module is available and the preprocessor symbol `PCL_VISUALIZATION_AVAILABLE` is defined.
+         */
+#ifdef PCL_VISUALIZATION_AVAILABLE
         void
         queryFrustum (const double planes[24], const Eigen::Vector3d &eye, const Eigen::Matrix4d &view_projection_matrix, std::list<std::string>& file_names, const std::uint32_t query_depth, const bool skip_vfc_check = false);
+#else
+        void
+        queryFrustum (const double planes[24], const Eigen::Vector3d &eye, const Eigen::Matrix4d &view_projection_matrix, std::list<std::string>& file_names, const std::uint32_t query_depth, const bool skip_vfc_check = false) = delete;
+#endif
 
         //point extraction
         /** \brief Recursively add points that fall into the queried bounding box up to the \b query_depth 

--- a/pcl_config.h.in
+++ b/pcl_config.h.in
@@ -100,3 +100,4 @@
 
 #cmakedefine HAVE_QVTK 1
 
+#cmakedefine PCL_VISUALIZATION_AVAILABLE


### PR DESCRIPTION
I would like to propose the following patch, to make the `outofcore` component not depend on the `visualization` component, because that brings in a pretty large dependency chain via VTK.

I noticed that `outofcore` needs only a single method from `visualization`, which is [this overload](https://pointclouds.org/documentation/classpcl_1_1outofcore_1_1_outofcore_octree_base_node.html#a8dd41e01aa45b28c1ed836e71bdb5a83) of `queryFrustum`.

I'm not sure if my approach to make this dependency optional in CMake is correct. But it seems to work fine on my end.

What it does is:
* if `visualization` is enabled, and `outofcore` is enabled, the latter will be built as normal
* if `visualization` is disabled, but `outofcore` is enabled, the latter will be built without the method.
