### PR TITLE
Add support for musl libc which returns aligned memory

### DIFF
--- a/pcl_config.h.in
+++ b/pcl_config.h.in
@@ -100,3 +100,5 @@
 
 #cmakedefine HAVE_QVTK 1
 
+/* musl libc returns aligned memory from malloc() but Eigen does not detect that */
+#cmakedefine EIGEN_MALLOC_ALREADY_ALIGNED 1


### PR DESCRIPTION
This patch adds a parameter `WITH_MUSL` that, when enabled, makes PCL go the `std::malloc` route in `pcl_macros.h`. This is valid because musl libc returns aligned memory from `malloc()` (https://www.openwall.com/lists/musl/2019/07/07/1).

Unfortunately, musl intentionally does not want to be detected, so it looks like we're forced to detect it outside the build (e.g. check for `/etc/alpine-release` as a proxy for musl libc) and pass the info into the build, like this patch is doing.

See also https://catfox.life/2022/04/16/the-musl-preprocessor-debate/ and https://stackoverflow.com/questions/58177815/how-to-actually-detect-musl-libc for some background on why there is no `__MUSL__` or similar preprocessor macro.

With this patch, PCL can be built on Alpine Linux, which uses musl libc.