### PR TITLE
Detect alignment when pcl_find_sse is not called & fix detection of Eigen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,6 +104,10 @@ if(CMAKE_TIMING_VERBOSE AND UNIX)
   set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CMAKE_SOURCE_DIR}/cmake/custom_output.sh")
 endif()
 
+# check for allocation functions that return aligned memory
+include("${PCL_SOURCE_DIR}/cmake/pcl_alignment.cmake")
+PCL_CHECK_FOR_ALIGNMENT()
+
 # check for SSE flags
 include("${PCL_SOURCE_DIR}/cmake/pcl_find_sse.cmake")
 if(PCL_ENABLE_SSE AND "${CMAKE_CXX_FLAGS}" STREQUAL "${CMAKE_CXX_FLAGS_DEFAULT}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,9 @@ elseif(MINGW)
   set(CMAKE_COMPILER_IS_MINGW 1)
 endif()
 
+# Ensure try_compile sets the include paths (e.g. for Eigen3)
+set(CMAKE_TRY_COMPILE_CONFIGURATION ${CMAKE_BUILD_TYPE})
+
 # https://github.com/fish-shell/fish-shell/issues/5865
 include(CheckCXXSourceCompiles)
 CHECK_CXX_SOURCE_COMPILES("

--- a/cmake/pcl_alignment.cmake
+++ b/cmake/pcl_alignment.cmake
@@ -1,0 +1,31 @@
+###############################################################################
+# Check for the presence of _mm_malloc() and posix_memalign()
+function(PCL_CHECK_FOR_ALIGNMENT)
+  include(CheckCXXSourceCompiles)
+  if(NOT DEFINED HAVE_MM_MALLOC)
+    check_cxx_source_compiles("
+      // Intel compiler defines an incompatible _mm_malloc signature
+      #if defined(__INTEL_COMPILER)
+        #include <malloc.h>
+      #else
+        #include <mm_malloc.h>
+      #endif
+      int main()
+      {
+        void* mem = _mm_malloc (100, 16);
+        return 0;
+      }"
+      HAVE_MM_MALLOC)
+  endif()
+
+  if(NOT DEFINED HAVE_POSIX_MEMALIGN)
+    check_cxx_source_compiles("
+      #include <stdlib.h>
+      int main()
+      {
+        void* mem;
+        return posix_memalign (&mem, 16, 100);
+      }"
+      HAVE_POSIX_MEMALIGN)
+  endif()
+endfunction()

--- a/cmake/pcl_find_sse.cmake
+++ b/cmake/pcl_find_sse.cmake
@@ -23,29 +23,6 @@ function(PCL_CHECK_FOR_SSE)
   set(CMAKE_REQUIRED_FLAGS)
   set(SSE_LEVEL 0)
 
-  check_cxx_source_runs("
-    // Intel compiler defines an incompatible _mm_malloc signature
-    #if defined(__INTEL_COMPILER)
-        #include <malloc.h>
-    #else
-        #include <mm_malloc.h>
-    #endif
-    int main()
-    {
-      void* mem = _mm_malloc (100, 16);
-      return 0;
-    }"
-    HAVE_MM_MALLOC)
-
-  check_cxx_source_runs("
-    #include <stdlib.h>
-    int main()
-    {
-      void* mem;
-      return posix_memalign (&mem, 16, 100);
-    }"
-    HAVE_POSIX_MEMALIGN)
-
   if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
     set(CMAKE_REQUIRED_FLAGS "-msse4.2")
   endif()


### PR DESCRIPTION
As discussed on https://github.com/PointCloudLibrary/pcl/pull/6255, we are extracting the checks for `posix_memalign()` and `_mm_malloc()` from `pcl_find_sse.cmake` in order to always test for them. Previously, they were not checked if PCL is compiled with custom `CMAKE_CXX_FLAGS`.

The second commit fixes the test that sets `PCL_USES_EIGEN_HANDMADE_ALIGNED_MALLOC` for builds where Eigen is installed in a non-standard location (e.g. Conan, but possibly also Homebrew). The problem is that `try_compile` does not set include paths and preprocessor definitions unless `CMAKE_TRY_COMPILE_CONFIGURATION` is set (https://gitlab.kitware.com/cmake/cmake/-/issues/22414). This made the test fail at the `#include <Eigen/Core>` in https://github.com/PointCloudLibrary/pcl/blob/master/CMakeLists.txt#L454.

What worked for me is to add
```
set(CMAKE_TRY_COMPILE_CONFIGURATION ${CMAKE_BUILD_TYPE})
```
