### PR TITLE
Improve SSE/AVX detection on arm and when cross-compiling

### DIFF
--- a/cmake/pcl_find_avx.cmake
+++ b/cmake/pcl_find_avx.cmake
@@ -3,15 +3,15 @@
 function(PCL_CHECK_FOR_AVX)
   set(AVX_FLAGS)
 
-  include(CheckCXXSourceRuns)
+  include(CheckCXXSourceCompiles)
   
   if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_COMPILER_IS_GNUCXX OR CMAKE_COMPILER_IS_CLANG)
-    # Setting -march & -mtune just as required flags for check_cxx_source_runs,
-    # and CMAKE_REQUIRED_FLAGS will be restored after test runs.
+    # Setting -march & -mtune just as required flags for check_cxx_source_compiles,
+    # and CMAKE_REQUIRED_FLAGS will be restored after test compiles.
     set(CMAKE_REQUIRED_FLAGS "-march=native -mtune=native")
   endif()
 
-  check_cxx_source_runs("    
+  check_cxx_source_compiles("
     #include <immintrin.h>
     int main()
     {
@@ -22,7 +22,7 @@ function(PCL_CHECK_FOR_AVX)
   HAVE_AVX2)
 
   if(NOT HAVE_AVX2)
-    check_cxx_source_runs("
+    check_cxx_source_compiles("
       #include <immintrin.h>
       int main()
       {

--- a/cmake/pcl_find_sse.cmake
+++ b/cmake/pcl_find_sse.cmake
@@ -19,7 +19,7 @@ function(PCL_CHECK_FOR_SSE)
   # precision). One solution would be to use "-ffloat-store" on 32bit (see
   # http://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html), but that slows code down,
   # so the preferred solution is to try "-mpfmath=sse" first.
-  include(CheckCXXSourceRuns)
+  include(CheckCXXSourceCompiles)
   set(CMAKE_REQUIRED_FLAGS)
   set(SSE_LEVEL 0)
 
@@ -27,7 +27,7 @@ function(PCL_CHECK_FOR_SSE)
     set(CMAKE_REQUIRED_FLAGS "-msse4.2")
   endif()
 
-  check_cxx_source_runs("
+  check_cxx_source_compiles("
     #include <emmintrin.h>
     #include <nmmintrin.h>
     int main ()
@@ -56,7 +56,7 @@ function(PCL_CHECK_FOR_SSE)
       set(CMAKE_REQUIRED_FLAGS "-msse4.1")
     endif()
 
-    check_cxx_source_runs("
+    check_cxx_source_compiles("
       #include <smmintrin.h>
       int main ()
       {
@@ -81,7 +81,7 @@ function(PCL_CHECK_FOR_SSE)
       set(CMAKE_REQUIRED_FLAGS "-mssse3")
     endif()
     
-    check_cxx_source_runs("
+    check_cxx_source_compiles("
       #include <tmmintrin.h>
       int main ()
       {
@@ -104,7 +104,7 @@ function(PCL_CHECK_FOR_SSE)
       set(CMAKE_REQUIRED_FLAGS "-msse3")
     endif()
 
-    check_cxx_source_runs("
+    check_cxx_source_compiles("
       #include <pmmintrin.h>
       int main ()
       {
@@ -129,7 +129,7 @@ function(PCL_CHECK_FOR_SSE)
       set(CMAKE_REQUIRED_FLAGS "/arch:SSE2")
     endif()
 
-    check_cxx_source_runs("
+    check_cxx_source_compiles("
       #include <emmintrin.h>
       int main ()
       {
@@ -154,7 +154,7 @@ function(PCL_CHECK_FOR_SSE)
       set(CMAKE_REQUIRED_FLAGS "/arch:SSE")
     endif()
 
-    check_cxx_source_runs("
+    check_cxx_source_compiles("
       #include <xmmintrin.h>
       int main ()
       {

--- a/cmake/pcl_options.cmake
+++ b/cmake/pcl_options.cmake
@@ -66,12 +66,15 @@ mark_as_advanced(PCL_ONLY_CORE_POINT_TYPES)
 option(PCL_NO_PRECOMPILE "Do not precompile PCL code for any point types at all." OFF)
 mark_as_advanced(PCL_NO_PRECOMPILE)
 
-# Enable or Disable the check for SSE optimizations
+# Enable or Disable the check for SSE and AVX optimizations
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
+option(PCL_ENABLE_SSE "Enable or Disable SSE optimizations." OFF)
+option(PCL_ENABLE_AVX "Enable or Disable AVX optimizations." OFF)
+else()
 option(PCL_ENABLE_SSE "Enable or Disable SSE optimizations." ON)
-mark_as_advanced(PCL_ENABLE_SSE)
-
-# Enable or Disable the check for AVX optimizations
 option(PCL_ENABLE_AVX "Enable or Disable AVX optimizations." ON)
+endif()
+mark_as_advanced(PCL_ENABLE_SSE)
 mark_as_advanced(PCL_ENABLE_AVX)
 
 if(UNIX)


### PR DESCRIPTION
Change check_cxx_source_runs to check_cxx_source_compiles because running the code does not provide any additional information, and is a problem when cross-compiling. When we know that we compile for arm, we set PCL_ENABLE_SSE and PCL_ENABLE_AVX to OFF to skip the checks completely.

Follow-up on https://github.com/PointCloudLibrary/pcl/pull/6261
Fixes https://github.com/PointCloudLibrary/pcl/issues/5843
Fixes https://github.com/PointCloudLibrary/pcl/issues/6151