### PR TITLE
Add option to manually set projection matrix in OrganizedNeighbor

### DIFF
--- a/common/include/pcl/common/impl/projection_matrix.hpp
+++ b/common/include/pcl/common/impl/projection_matrix.hpp
@@ -214,6 +214,10 @@ estimateProjectionMatrix (
   if (projection_matrix.coeff (0) < 0)
     projection_matrix *= -1.0;
 
+  // if the bottom row is all zeros, except for the second-to-last element, then scale the whole projection matrix (convention)
+  if(std::abs(eigen_vectors.coeff (96))<1e-7 && std::abs(eigen_vectors.coeff (108))<1e-7 && std::abs(eigen_vectors.coeff (120))>1e-5 && std::abs(eigen_vectors.coeff (132))<1e-7)
+    projection_matrix /= projection_matrix.coeffRef (10);
+
   return (residual);
 }
 

--- a/features/include/pcl/features/impl/feature.hpp
+++ b/features/include/pcl/features/impl/feature.hpp
@@ -119,14 +119,22 @@ Feature<PointInT, PointOutT>::initCompute ()
   // Check if a space search locator was given
   if (!tree_)
   {
-    if (surface_->isOrganized () && input_->isOrganized ())
+    if (surface_->isOrganized () && input_->isOrganized ()) {
       tree_.reset (new pcl::search::OrganizedNeighbor<PointInT> ());
-    else
+      if(!tree_->setInputCloud (surface_)) { // may return false if OrganizedNeighbor cannot work with the cloud, then use KdTree instead
+        tree_.reset (new pcl::search::KdTree<PointInT> (false));
+      }
+    } else {
       tree_.reset (new pcl::search::KdTree<PointInT> (false));
+    }
   }
 
-  if (tree_->getInputCloud () != surface_) // Make sure the tree searches the surface
-    tree_->setInputCloud (surface_);
+  if (tree_->getInputCloud () != surface_) { // Make sure the tree searches the surface
+    if(!tree_->setInputCloud (surface_)) {
+      PCL_ERROR ("[pcl::%s::compute] The given search method cannot work with the given input cloud/search surface.\n", getClassName ().c_str ());
+      return (false);
+    }
+  }
 
 
   // Do a fast check to see if the search parameters are well defined

--- a/search/include/pcl/search/impl/organized.hpp
+++ b/search/include/pcl/search/impl/organized.hpp
@@ -372,8 +372,13 @@ pcl::search::OrganizedNeighbor<PointT>::estimateProjectionMatrix ()
 
   // precalculate KR * KR^T needed by calculations during nn-search
   KR_KRT_ = KR_ * KR_.transpose ();
+  return true;
+}
 
-  // final test: project a few points at known image coordinates and test if the projected coordinates are close
+template<typename PointT> bool
+pcl::search::OrganizedNeighbor<PointT>::testProjectionMatrix () const
+{
+  // test: project a few points at known image coordinates and test if the projected coordinates are close
   for(std::size_t i=0; i<11; ++i) {
     const std::size_t test_index = input_->size()*i/11u;
     if (!mask_[test_index])
@@ -381,7 +386,7 @@ pcl::search::OrganizedNeighbor<PointT>::estimateProjectionMatrix ()
     const auto& test_point = (*input_)[test_index];
     pcl::PointXY q;
     if (!projectPoint(test_point, q) || std::abs(q.x-test_index%input_->width)>1 || std::abs(q.y-test_index/input_->width)>1) {
-      PCL_WARN ("[pcl::%s::estimateProjectionMatrix] Input dataset does not seem to be from a projective device! (point %zu (%g,%g,%g) projected to pixel coordinates (%g,%g), but actual pixel coordinates are (%zu,%zu))\n",
+      PCL_WARN ("[pcl::%s::testProjectionMatrix] Input dataset does not seem to be from a projective device! (point %zu (%g,%g,%g) projected to pixel coordinates (%g,%g), but actual pixel coordinates are (%zu,%zu))\n",
                 this->getName ().c_str (), test_index, test_point.x, test_point.y, test_point.z, q.x, q.y, static_cast<std::size_t>(test_index%input_->width), static_cast<std::size_t>(test_index/input_->width));
       return false;
     }


### PR DESCRIPTION
See https://github.com/PointCloudLibrary/pcl/issues/6241

- the `Feature` class now falls back to `pcl::search::KdTree` if `pcl::search::OrganizedNeighbor` cannot work correctly (if the user did not specify a search method)
- `OrganizedNeighbor` now uses `eps_` as an indicator whether the projection matrix shall be estimated or not. A negative value means to not estimate, as a negative value would not make sense anyway in `estimateProjectionMatrix()` when comparing with `residual_sqr`
- If the new `setProjectionMatrix()` is used, `OrganizedNeighbor` still does a rudimentary check whether cloud and projection matrix fit together in `setInputCloud()`