### PR TITLE
Increase accuracy of OctreePointCloudCompression

### DIFF
--- a/io/include/pcl/compression/point_coding.h
+++ b/io/include/pcl/compression/point_coding.h
@@ -169,9 +169,9 @@ class PointCoding
         PointT& point = (*outputCloud_arg)[beginIdx_arg + i];
 
         // decode point position
-        point.x = static_cast<float> (referencePoint_arg[0] + diffX * pointCompressionResolution_);
-        point.y = static_cast<float> (referencePoint_arg[1] + diffY * pointCompressionResolution_);
-        point.z = static_cast<float> (referencePoint_arg[2] + diffZ * pointCompressionResolution_);
+        point.x = static_cast<float> (referencePoint_arg[0] + (diffX+0.5) * pointCompressionResolution_);
+        point.y = static_cast<float> (referencePoint_arg[1] + (diffY+0.5) * pointCompressionResolution_);
+        point.z = static_cast<float> (referencePoint_arg[2] + (diffZ+0.5) * pointCompressionResolution_);
       }
     }
 


### PR DESCRIPTION
Change decoding so that the xyz coordinates are closer to the original values. The reasoning is that, if a value is known to be between 0 and 1, using 0.5 is a better approximation than using 0 (like before). In experiments, I measure a decrease in the point-to-point error of 7-20 percent for profiles MED_RES_ONLINE_COMPRESSION_WITHOUT_COLOR, MED_RES_ONLINE_COMPRESSION_WITH_COLOR, and MED_RES_OFFLINE_COMPRESSION_WITH_COLOR, and a decrease of up to 50 percent for profiles HIGH_RES_ONLINE_COMPRESSION_WITHOUT_COLOR, HIGH_RES_ONLINE_COMPRESSION_WITH_COLOR, and HIGH_RES_OFFLINE_COMPRESSION_WITH_COLOR. For the other profiles, this change has no effect, because they enable voxel grid downsampling.