### PR TITLE
Use noalias() where possible

### DIFF
--- a/common/include/pcl/common/impl/centroid.hpp
+++ b/common/include/pcl/common/impl/centroid.hpp
@@ -696,7 +696,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   //[0    , 1             ]
   Eigen::Matrix<Scalar, 4, 4> transform = Eigen::Matrix<Scalar, 4, 4>::Identity();
   transform.template topLeftCorner<3, 3>() = obb_rotational_matrix.transpose();
-  transform.template topRightCorner<3, 1>() =-transform.template topLeftCorner<3, 3>()*centroid;
+  transform.template topRightCorner<3, 1>().noalias() =-transform.template topLeftCorner<3, 3>()*centroid;
 
   //when Scalar==double on a Windows 10 machine and MSVS:
   //if you substitute the following Scalars with floats you get a 20% worse processing time, if with 2 PointT 55% worse
@@ -786,7 +786,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   obb_dimensions(1) = obb_max_pointy - obb_min_pointy;
   obb_dimensions(2) = obb_max_pointz - obb_min_pointz;
 
-  obb_center = centroid + obb_rotational_matrix * shift;//position of the OBB center in the same reference Oxyz of the point cloud
+  obb_center.noalias() = centroid + obb_rotational_matrix * shift;//position of the OBB center in the same reference Oxyz of the point cloud
 
   return (point_count);
 }
@@ -830,7 +830,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   //[0    , 1             ]
   Eigen::Matrix<Scalar, 4, 4> transform = Eigen::Matrix<Scalar, 4, 4>::Identity();
   transform.template topLeftCorner<3, 3>() = obb_rotational_matrix.transpose();
-  transform.template topRightCorner<3, 1>() =-transform.template topLeftCorner<3, 3>()*centroid;
+  transform.template topRightCorner<3, 1>().noalias() =-transform.template topLeftCorner<3, 3>()*centroid;
 
   //when Scalar==double on a Windows 10 machine and MSVS:
   //if you substitute the following Scalars with floats you get a 20% worse processing time, if with 2 PointT 55% worse
@@ -922,7 +922,7 @@ computeCentroidAndOBB (const pcl::PointCloud<PointT> &cloud,
   obb_dimensions(1) = obb_max_pointy - obb_min_pointy;
   obb_dimensions(2) = obb_max_pointz - obb_min_pointz;
 
-  obb_center = centroid + obb_rotational_matrix * shift;//position of the OBB center in the same reference Oxyz of the point cloud
+  obb_center.noalias() = centroid + obb_rotational_matrix * shift;//position of the OBB center in the same reference Oxyz of the point cloud
 
   return (point_count);
 }

--- a/common/include/pcl/common/impl/eigen.hpp
+++ b/common/include/pcl/common/impl/eigen.hpp
@@ -912,8 +912,8 @@ transformBetween2CoordinateSystems (const Eigen::Matrix<Scalar, Eigen::Dynamic, 
   // Identity matrix = transform to CS2 to CS3
   // Note: if CS1 == CS2 --> transformation = T3
   transformation = Eigen::Transform<Scalar, 3, Eigen::Affine>::Identity ();
-  transformation.linear () = T3.linear () * T2.linear ().inverse ();
-  transformation.translation () = to0 - (transformation.linear () * fr0);
+  transformation.linear ().noalias () = T3.linear () * T2.linear ().inverse ();
+  transformation.translation ().noalias () = to0 - (transformation.linear () * fr0);
   return (true);
 }
 

--- a/common/include/pcl/common/impl/pca.hpp
+++ b/common/include/pcl/common/impl/pca.hpp
@@ -86,7 +86,7 @@ PCA<PointT>::initCompute ()
   eigenvectors_.col(2) = eigenvectors_.col(0).cross(eigenvectors_.col(1));
   // If not basis only then compute the coefficients
   if (!basis_only_)
-    coefficients_ = eigenvectors_.transpose() * cloud_demean.topRows<3> ();
+    coefficients_.noalias() = eigenvectors_.transpose() * cloud_demean.topRows<3> ();
   compute_done_ = true;
   return (true);
 }
@@ -171,7 +171,7 @@ PCA<PointT>::project (const PointT& input, PointT& projection)
     PCL_THROW_EXCEPTION (InitFailedException, "[pcl::PCA::project] PCA initCompute failed");
 
   Eigen::Vector3f demean_input = input.getVector3fMap () - mean_.head<3> ();
-  projection.getVector3fMap () = eigenvectors_.transpose() * demean_input;
+  projection.getVector3fMap ().noalias () = eigenvectors_.transpose() * demean_input;
 }
 
 

--- a/common/include/pcl/common/impl/polynomial_calculations.hpp
+++ b/common/include/pcl/common/impl/polynomial_calculations.hpp
@@ -482,7 +482,7 @@ PolynomialCalculationsT<real>::bivariatePolynomialApproximation (
   //std::cout << "Cholesky took "<< (choleskyStartTime+get_time ())*1000<<"ms.\n";
 
   //double invStartTime=-get_time ();
-  parameters = A.inverse () * b;
+  parameters.noalias() = A.inverse () * b;
   //std::cout << "Inverse took "<< (invStartTime+get_time ())*1000<<"ms.\n";
 
   //std::cout << PVARC (A)<<PVARC (b)<<PVARN (parameters);

--- a/features/include/pcl/features/impl/intensity_gradient.hpp
+++ b/features/include/pcl/features/impl/intensity_gradient.hpp
@@ -136,7 +136,7 @@ pcl::IntensityGradientEstimation <PointInT, PointNT, PointOutT, IntensitySelecto
 //  std::cout << A << "\n*\n" << bb << "\n=\n" << x << "\nvs.\n" << x2 << "\n\n";
 //  std::cout << A * x << "\nvs.\n" << A * x2 << "\n\n------\n";
   // Project the gradient vector, x, onto the tangent plane
-  gradient = (Eigen::Matrix3f::Identity () - normal*normal.transpose ()) * x;
+  gradient.noalias() = (Eigen::Matrix3f::Identity () - normal*normal.transpose ()) * x;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////

--- a/features/include/pcl/features/impl/moment_of_inertia_estimation.hpp
+++ b/features/include/pcl/features/impl/moment_of_inertia_estimation.hpp
@@ -266,7 +266,7 @@ pcl::MomentOfInertiaEstimation<PointT>::computeOBB ()
   obb_max_point_.y -= shift (1);
   obb_max_point_.z -= shift (2);
 
-  obb_position_ = mean_value_ + obb_rotational_matrix_ * shift;
+  obb_position_.noalias() = mean_value_ + obb_rotational_matrix_ * shift;
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -366,7 +366,7 @@ pcl::MomentOfInertiaEstimation<PointT>::computeCovarianceMatrix (Eigen::Matrix <
     current_point (1) = (*input_)[(*indices_)[i_point]].y - mean_value_ (1);
     current_point (2) = (*input_)[(*indices_)[i_point]].z - mean_value_ (2);
 
-    covariance_matrix += current_point * current_point.transpose ();
+    covariance_matrix.noalias() += current_point * current_point.transpose ();
   }
 
   covariance_matrix *= factor;
@@ -387,7 +387,7 @@ pcl::MomentOfInertiaEstimation<PointT>::computeCovarianceMatrix (PointCloudConst
     current_point (1) = (*cloud)[i_point].y - mean_value_ (1);
     current_point (2) = (*cloud)[i_point].z - mean_value_ (2);
 
-    covariance_matrix += current_point * current_point.transpose ();
+    covariance_matrix.noalias() += current_point * current_point.transpose ();
   }
 
   covariance_matrix *= factor;

--- a/features/include/pcl/features/impl/principal_curvatures.hpp
+++ b/features/include/pcl/features/impl/principal_curvatures.hpp
@@ -78,7 +78,7 @@ pcl::PrincipalCurvaturesEstimation<PointInT, PointNT, PointOutT>::computePointPr
   for (std::size_t idx = 0; idx < indices.size(); ++idx)
   {
     const auto normal = normals[indices[idx]].getNormalVector3fMap();
-    projected_normals[idx] = M * normal;
+    projected_normals[idx].noalias() = M * normal;
     xyz_centroid += projected_normals[idx];
   }
 

--- a/features/include/pcl/features/impl/rops_estimation.hpp
+++ b/features/include/pcl/features/impl/rops_estimation.hpp
@@ -275,9 +275,9 @@ pcl::ROPSEstimation <PointInT, PointOutT>::computeLRF (const PointInT& point, co
     for (const auto &i_pt : pt)
     {
       Eigen::Vector3f vec = i_pt - feature_point;
-      curr_scatter_matrix += vec * (vec.transpose ());
+      curr_scatter_matrix.noalias() += vec * (vec.transpose ());
       for (const auto &j_pt : pt)
-        curr_scatter_matrix += vec * ((j_pt - feature_point).transpose ());
+        curr_scatter_matrix.noalias() += vec * ((j_pt - feature_point).transpose ());
     }
     scatter_matrices.emplace_back (coeff * curr_scatter_matrix);
   }

--- a/features/include/pcl/features/impl/shot_lrf.hpp
+++ b/features/include/pcl/features/impl/shot_lrf.hpp
@@ -77,7 +77,7 @@ pcl::SHOTLocalReferenceFrameEstimation<PointInT, PointOutT>::getLocalRF (const i
     distance = search_parameter_ - sqrt (n_sqr_distances[i_idx]);
 
     // Multiply vij * vij'
-    cov_m += distance * (vij.row (valid_nn_points).head<3> ().transpose () * vij.row (valid_nn_points).head<3> ());
+    cov_m.noalias() += distance * (vij.row (valid_nn_points).head<3> ().transpose () * vij.row (valid_nn_points).head<3> ());
 
     sum += distance;
     valid_nn_points++;

--- a/features/include/pcl/features/our_cvfh.h
+++ b/features/include/pcl/features/our_cvfh.h
@@ -114,7 +114,7 @@ namespace pcl
         homMatrix = transformPC.matrix ();
 
         Eigen::Matrix4f trans_copy = trans.inverse ();
-        trans = trans_copy * center_mat * homMatrix;
+        trans.noalias() = trans_copy * center_mat * homMatrix;
         return trans;
       }
 

--- a/filters/include/pcl/filters/conditional_removal.h
+++ b/filters/include/pcl/filters/conditional_removal.h
@@ -401,8 +401,8 @@ namespace pcl
       inline void
       transformComparison (const Eigen::Matrix4f &transform)
       {
-        tf_comp_matr_ = transform.transpose () * comp_matr_ * transform;
-        tf_comp_vect_ = comp_vect_.transpose () * transform;
+        tf_comp_matr_.noalias() = transform.transpose () * comp_matr_ * transform;
+        tf_comp_vect_.noalias() = comp_vect_.transpose () * transform;
       }
 
       /** \brief transform the coordinate system of the comparison. If you think of

--- a/filters/include/pcl/filters/impl/covariance_sampling.hpp
+++ b/filters/include/pcl/filters/impl/covariance_sampling.hpp
@@ -122,7 +122,7 @@ pcl::CovarianceSampling<PointT, PointNT>::computeCovarianceMatrix (Eigen::Matrix
   }
 
   // Compute the covariance matrix C and its 6 eigenvectors (initially complex, move them to a double matrix)
-  covariance_matrix = f_mat * f_mat.transpose ();
+  covariance_matrix.noalias() = f_mat * f_mat.transpose ();
   return true;
 }
 

--- a/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
+++ b/filters/include/pcl/filters/impl/voxel_grid_covariance.hpp
@@ -175,7 +175,7 @@ pcl::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
       // Accumulate point sum for centroid calculation
       leaf.mean_ += pt3d;
       // Accumulate x*xT for single pass covariance calculation
-      leaf.cov_ += pt3d * pt3d.transpose ();
+      leaf.cov_.noalias() += pt3d * pt3d.transpose ();
 
       // Do we need to process all the fields?
       if (!downsample_all_data_)
@@ -231,7 +231,7 @@ pcl::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
       // Accumulate point sum for centroid calculation
       leaf.mean_ += pt3d;
       // Accumulate x*xT for single pass covariance calculation
-      leaf.cov_ += pt3d * pt3d.transpose ();
+      leaf.cov_.noalias() += pt3d * pt3d.transpose ();
 
       // Do we need to process all the fields?
       if (!downsample_all_data_)
@@ -349,7 +349,7 @@ pcl::VoxelGridCovariance<PointT>::applyFilter (PointCloud &output)
           eigen_val (1, 1) = min_covar_eigvalue;
         }
 
-        leaf.cov_ = leaf.evecs_ * eigen_val * leaf.evecs_.inverse ();
+        leaf.cov_.noalias() = leaf.evecs_ * eigen_val * leaf.evecs_.inverse ();
       }
       leaf.evals_ = eigen_val.diagonal ();
 
@@ -475,7 +475,7 @@ pcl::VoxelGridCovariance<PointT>::getDisplayCloud (pcl::PointCloud<PointXYZ>& ce
       for (int i = 0; i < pnt_per_cell; i++)
       {
         rand_point = Eigen::Vector3d (var_nor (), var_nor (), var_nor ());
-        dist_point = cell_mean + cholesky_decomp * rand_point;
+        dist_point.noalias() = cell_mean + cholesky_decomp * rand_point;
         cell_cloud.push_back (PointXYZ (static_cast<float> (dist_point (0)), static_cast<float> (dist_point (1)), static_cast<float> (dist_point (2))));
       }
     }

--- a/people/include/pcl/people/impl/ground_based_people_detection_app.hpp
+++ b/people/include/pcl/people/impl/ground_based_people_detection_app.hpp
@@ -274,7 +274,7 @@ pcl::people::GroundBasedPeopleDetectionApp<PointT>::applyTransformationGround ()
   {
     Eigen::Transform<float, 3, Eigen::Affine> transform;
     transform = transformation_;
-    ground_coeffs_transformed_ = transform.matrix() * ground_coeffs_;
+    ground_coeffs_transformed_.noalias() = transform.matrix() * ground_coeffs_;
   }
   else
   {
@@ -287,7 +287,7 @@ pcl::people::GroundBasedPeopleDetectionApp<PointT>::applyTransformationIntrinsic
 {
   if (transformation_set_ && intrinsics_matrix_set_)
   {
-    intrinsics_matrix_transformed_ = intrinsics_matrix_ * transformation_.transpose();
+    intrinsics_matrix_transformed_.noalias() = intrinsics_matrix_ * transformation_.transpose();
   }
   else
   {

--- a/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
+++ b/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
@@ -1185,7 +1185,7 @@ pcl::ism::ImplicitShapeModelEstimation<FeatureSize, PointT, NormalT>::alignYCoor
                           B,      A,   0.0f,
                        0.0f,   0.0f,   1.0f;
 
-  result = rotation_matrix_X * rotation_matrix_Z;
+  result.noalias() = rotation_matrix_X * rotation_matrix_Z;
 
   return (result);
 }

--- a/registration/include/pcl/registration/impl/gicp.hpp
+++ b/registration/include/pcl/registration/impl/gicp.hpp
@@ -144,7 +144,7 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget, Scalar>::computeCovar
       double v = 1.; // biggest 2 singular values replaced by 1
       if (k == 2)    // smallest singular value replaced by gicp_epsilon
         v = gicp_epsilon_;
-      cov += v * col * col.transpose();
+      cov.noalias() += v * col * col.transpose();
     }
     cloud_covariances[i] = cov;
   }
@@ -429,8 +429,8 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget, Scalar>::
       else
         inverted_eigenvalues(i, i) = 1.0 / ev;
     }
-    delta = eigensolver.eigenvectors() * inverted_eigenvalues *
-            eigensolver.eigenvectors().transpose() * gradient;
+    delta.noalias() = eigensolver.eigenvectors() * inverted_eigenvalues *
+                      eigensolver.eigenvectors().transpose() * gradient;
 
     // simple line search to guarantee a decrease in the function value
     double alpha = 1.0;
@@ -542,9 +542,9 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget, Scalar>::
     // closes)
     g.head<3>() += Md;
     // Increment rotation gradient
-    p_trans_src = gicp_->base_transformation_.template cast<float>() * p_src;
+    p_trans_src.noalias() = gicp_->base_transformation_.template cast<float>() * p_src;
     Eigen::Vector3d p_base_src(p_trans_src[0], p_trans_src[1], p_trans_src[2]);
-    dCost_dR_T += p_base_src * Md.transpose();
+    dCost_dR_T.noalias() += p_base_src * Md.transpose();
   }
   g.head<3>() *= 2.0 / m;
   dCost_dR_T *= 2.0 / m;
@@ -584,10 +584,10 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget, Scalar>::
     // g.head<3> ()+= 2*M*d/num_matches (we postpone 2/num_matches after the loop
     // closes)
     g.head<3>() += Md;
-    p_trans_src = gicp_->base_transformation_.template cast<float>() * p_src;
+    p_trans_src.noalias() = gicp_->base_transformation_.template cast<float>() * p_src;
     Eigen::Vector3d p_base_src(p_trans_src[0], p_trans_src[1], p_trans_src[2]);
     // Increment rotation gradient
-    dCost_dR_T += p_base_src * Md.transpose();
+    dCost_dR_T.noalias() += p_base_src * Md.transpose();
   }
   f /= static_cast<double>(m);
   g.head<3>() *= (2.0 / m);
@@ -661,7 +661,7 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget, Scalar>::
     const Eigen::Vector3d Md(M * d);    // Md = M*d
     gradient.head<3>() += Md;           // translation gradient
     hessian.topLeftCorner<3, 3>() += M; // translation-translation hessian
-    p_trans_src = base_transformation_float * p_src;
+    p_trans_src.noalias() = base_transformation_float * p_src;
     const Eigen::Vector3d p_base_src(p_trans_src[0], p_trans_src[1], p_trans_src[2]);
     dCost_dR_T.noalias() += p_base_src * Md.transpose();
     dCost_dR_T1b += p_base_src[0] * M;
@@ -895,7 +895,7 @@ GeneralizedIterativeClosestPoint<PointSource, PointTarget, Scalar>::
       PCL_DEBUG("[pcl::%s::computeTransformation] Convergence failed\n",
                 getClassName().c_str());
   }
-  final_transformation_ = previous_transformation_ * guess;
+  final_transformation_.noalias() = previous_transformation_ * guess;
 
   PCL_DEBUG("Transformation "
             "is:\n\t%5f\t%5f\t%5f\t%5f\n\t%5f\t%5f\t%5f\t%5f\n\t%5f\t%5f\t%5f\t%5f\n\t%"

--- a/registration/include/pcl/registration/impl/icp.hpp
+++ b/registration/include/pcl/registration/impl/icp.hpp
@@ -70,7 +70,7 @@ IterativeClosestPoint<PointSource, PointTarget, Scalar>::transformCloud(
       if (!std::isfinite(pt[0]) || !std::isfinite(pt[1]) || !std::isfinite(pt[2]))
         continue;
 
-      pt_t = tr * pt;
+      pt_t.noalias() = tr * pt;
 
       memcpy(data_out + x_idx_offset_, &pt_t[0], sizeof(float));
       memcpy(data_out + y_idx_offset_, &pt_t[1], sizeof(float));
@@ -83,7 +83,7 @@ IterativeClosestPoint<PointSource, PointTarget, Scalar>::transformCloud(
       if (!std::isfinite(nt[0]) || !std::isfinite(nt[1]) || !std::isfinite(nt[2]))
         continue;
 
-      nt_t = rot * nt;
+      nt_t.noalias() = rot * nt;
 
       memcpy(data_out + nx_idx_offset_, &nt_t[0], sizeof(float));
       memcpy(data_out + ny_idx_offset_, &nt_t[1], sizeof(float));
@@ -101,7 +101,7 @@ IterativeClosestPoint<PointSource, PointTarget, Scalar>::transformCloud(
       if (!std::isfinite(pt[0]) || !std::isfinite(pt[1]) || !std::isfinite(pt[2]))
         continue;
 
-      pt_t = tr * pt;
+      pt_t.noalias() = tr * pt;
 
       memcpy(data_out + x_idx_offset_, &pt_t[0], sizeof(float));
       memcpy(data_out + y_idx_offset_, &pt_t[1], sizeof(float));

--- a/registration/include/pcl/registration/impl/ndt_2d.hpp
+++ b/registration/include/pcl/registration/impl/ndt_2d.hpp
@@ -124,7 +124,7 @@ public:
     for (const auto& pt_index : pt_indices_) {
       Eigen::Vector2d p(cloud[pt_index].x, cloud[pt_index].y);
       sx += p;
-      sxx += p * p.transpose();
+      sxx.noalias() += p * p.transpose();
     }
 
     n_ = pt_indices_.size();
@@ -145,7 +145,7 @@ public:
         Eigen::Matrix2d q = solver.eigenvectors();
         // set minimum smallest eigenvalue:
         l(0, 0) = l(1, 1) * min_covar_eigvalue_mult;
-        covar = q * l * q.transpose();
+        covar.noalias() = q * l * q.transpose();
       }
       covar_inv_ = covar.inverse();
     }

--- a/registration/include/pcl/registration/impl/transformation_estimation_3point.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_3point.hpp
@@ -187,7 +187,7 @@ pcl::registration::TransformationEstimation3Point<PointSource, PointTarget, Scal
   transformation_matrix.template topLeftCorner<3, 3>() = R;
   // transformation_matrix.block<3, 1>(0, 3) = source_mean.head<3>() - R *
   // target_mean.head<3>();
-  transformation_matrix.template block<3, 1>(0, 3) =
+  transformation_matrix.template block<3, 1>(0, 3).noalias() =
       target_mean.template head<3>() - R * source_mean.template head<3>();
 }
 

--- a/registration/src/gicp6d.cpp
+++ b/registration/src/gicp6d.cpp
@@ -225,7 +225,7 @@ GeneralizedIterativeClosestPoint6D::computeTransformation(PointCloudSource& outp
       PCL_DEBUG("[pcl::%s::computeTransformation] Convergence failed\n",
                 getClassName().c_str());
   }
-  final_transformation_.topLeftCorner<3, 3>() =
+  final_transformation_.topLeftCorner<3, 3>().noalias() =
       previous_transformation_.topLeftCorner<3, 3>() * guess.topLeftCorner<3, 3>();
   final_transformation_(0, 3) = previous_transformation_(0, 3) + guess(0, 3);
   final_transformation_(1, 3) = previous_transformation_(1, 3) + guess(1, 3);

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_ellipse3d.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_ellipse3d.hpp
@@ -199,12 +199,12 @@ pcl::SampleConsensusModelEllipse3D<PointT>::computeModelCoefficients (const Indi
   Eigen::Vector3f p_ctr;
   float aux_par(0.0);
   if (par_a > par_b) {
-    p_ctr = p0 + Rot * Eigen::Vector3f(par_h, par_k, 0.0);
+    p_ctr.noalias() = p0 + Rot * Eigen::Vector3f(par_h, par_k, 0.0);
   } else {
     aux_par = par_a;
     par_a = par_b;
     par_b = aux_par;
-    p_ctr = p0 + Rot * Eigen::Vector3f(par_k, par_h, 0.0);
+    p_ctr.noalias() = p0 + Rot * Eigen::Vector3f(par_k, par_h, 0.0);
   }
 
   // Center (x, y, z)

--- a/search/include/pcl/search/impl/organized.hpp
+++ b/search/include/pcl/search/impl/organized.hpp
@@ -371,7 +371,7 @@ pcl::search::OrganizedNeighbor<PointT>::estimateProjectionMatrix ()
   KR_ = projection_matrix_.topLeftCorner <3, 3> ();
 
   // precalculate KR * KR^T needed by calculations during nn-search
-  KR_KRT_ = KR_ * KR_.transpose ();
+  KR_KRT_.noalias() = KR_ * KR_.transpose ();
   return true;
 }
 

--- a/surface/include/pcl/surface/impl/mls.hpp
+++ b/surface/include/pcl/surface/impl/mls.hpp
@@ -796,8 +796,8 @@ pcl::MLSResult::computeMLSSurface (const pcl::PointCloud<PointT> &cloud,
 
       // Computing coefficients
       const Eigen::MatrixXd P_weight = P * weight_vec.asDiagonal(); // size will be (nr_coeff_, nn_indices.size ());
-      P_weight_Pt = P_weight * P.transpose ();
-      c_vec = P_weight * f_vec;
+      P_weight_Pt.noalias() = P_weight * P.transpose ();
+      c_vec.noalias() = P_weight * f_vec;
       P_weight_Pt.llt ().solveInPlace (c_vec);
     }
   }

--- a/visualization/src/common/common.cpp
+++ b/visualization/src/common/common.cpp
@@ -533,7 +533,7 @@ pcl::visualization::Camera::computeViewMatrix (Eigen::Matrix4d &view_mat) const
 	view_mat.block <1, 3> (2, 0) = -zAxis;
 	view_mat.row (3) << 0, 0, 0, 1;
 
-	view_mat.block <3, 1> (0, 3) = view_mat.topLeftCorner<3, 3> () * (-posv);
+	view_mat.block <3, 1> (0, 3).noalias() = view_mat.topLeftCorner<3, 3> () * (-posv);
 }
 
 ///////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This leads to more efficient matrix-matrix or matrix-vector multiplication, see
- https://eigen.tuxfamily.org/dox/TopicLazyEvaluation.html
- https://eigen.tuxfamily.org/dox/group__TopicAliasing.html
- https://eigen.tuxfamily.org/dox/TopicWritingEfficientProductExpression.html