### PR TITLE
Update CMake commands in tutorials

### DIFF
--- a/doc/tutorials/content/dinast_grabber.rst
+++ b/doc/tutorials/content/dinast_grabber.rst
@@ -161,10 +161,6 @@ We will test the grabber with the previous example. Write down the whole code to
 
   find_package(PCL 1.7 REQUIRED)
 
-  include_directories(${PCL_INCLUDE_DIRS})
-  link_directories(${PCL_LIBRARY_DIRS})
-  add_definitions(${PCL_DEFINITIONS})
-
   add_executable (dinast_grabber dinast_grabber.cpp)
   target_link_libraries (dinast_grabber ${PCL_LIBRARIES})
 

--- a/doc/tutorials/content/hdl_grabber.rst
+++ b/doc/tutorials/content/hdl_grabber.rst
@@ -213,10 +213,6 @@ Add the following lines to your CMakeLists.txt file:
 
    find_package(PCL 1.2 REQUIRED)
 
-   include_directories(${PCL_INCLUDE_DIRS})
-   link_directories(${PCL_LIBRARY_DIRS})
-   add_definitions(${PCL_DEFINITIONS})
-
    add_executable(pcl_hdl_viewer_simple hdl_viewer_simple.cpp)
    target_link_libraries(pcl_hdl_viewer_simple ${PCL_LIBRARIES})
 

--- a/doc/tutorials/content/sources/alignment_prerejective/CMakeLists.txt
+++ b/doc/tutorials/content/sources/alignment_prerejective/CMakeLists.txt
@@ -4,9 +4,5 @@ project(alignment_prerejective)
 
 find_package(PCL 1.7 REQUIRED COMPONENTS io registration segmentation visualization)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (alignment_prerejective alignment_prerejective.cpp)
 target_link_libraries (alignment_prerejective ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/bare_earth/CMakeLists.txt
+++ b/doc/tutorials/content/sources/bare_earth/CMakeLists.txt
@@ -4,9 +4,5 @@ project(bare_earth)
 
 find_package(PCL 1.7.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (bare_earth bare_earth.cpp)
 target_link_libraries (bare_earth ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/bspline_fitting/CMakeLists.txt
+++ b/doc/tutorials/content/sources/bspline_fitting/CMakeLists.txt
@@ -4,9 +4,5 @@ project(bspline_fitting)
 
 find_package(PCL 1.7 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (bspline_fitting bspline_fitting.cpp)
 target_link_libraries (bspline_fitting ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/cloud_viewer/CMakeLists.txt
+++ b/doc/tutorials/content/sources/cloud_viewer/CMakeLists.txt
@@ -4,9 +4,5 @@ project(cloud_viewer)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (cloud_viewer cloud_viewer.cpp)
 target_link_libraries (cloud_viewer ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/cluster_extraction/CMakeLists.txt
+++ b/doc/tutorials/content/sources/cluster_extraction/CMakeLists.txt
@@ -4,9 +4,5 @@ project(cluster_extraction)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (cluster_extraction cluster_extraction.cpp)
 target_link_libraries (cluster_extraction ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/concatenate_clouds/CMakeLists.txt
+++ b/doc/tutorials/content/sources/concatenate_clouds/CMakeLists.txt
@@ -4,9 +4,5 @@ project(concatenate_clouds)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (concatenate_clouds concatenate_clouds.cpp)
 target_link_libraries (concatenate_clouds ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/concatenate_fields/CMakeLists.txt
+++ b/doc/tutorials/content/sources/concatenate_fields/CMakeLists.txt
@@ -4,9 +4,5 @@ project(concatenate_fields)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (concatenate_fields concatenate_fields.cpp)
 target_link_libraries (concatenate_fields ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/concatenate_points/CMakeLists.txt
+++ b/doc/tutorials/content/sources/concatenate_points/CMakeLists.txt
@@ -4,9 +4,5 @@ project(concatenate_points)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (concatenate_points concatenate_points.cpp)
 target_link_libraries (concatenate_points ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/concave_hull_2d/CMakeLists.txt
+++ b/doc/tutorials/content/sources/concave_hull_2d/CMakeLists.txt
@@ -4,9 +4,5 @@ project(concave_hull_2d)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (concave_hull_2d concave_hull_2d.cpp)
 target_link_libraries (concave_hull_2d ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/conditional_euclidean_clustering/CMakeLists.txt
+++ b/doc/tutorials/content/sources/conditional_euclidean_clustering/CMakeLists.txt
@@ -4,9 +4,5 @@ project(conditional_euclidean_clustering)
 
 find_package(PCL 1.7 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (conditional_euclidean_clustering conditional_euclidean_clustering.cpp)
 target_link_libraries (conditional_euclidean_clustering ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/conditional_removal/CMakeLists.txt
+++ b/doc/tutorials/content/sources/conditional_removal/CMakeLists.txt
@@ -4,9 +4,5 @@ project(conditional_removal)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (conditional_removal conditional_removal.cpp)
 target_link_libraries (conditional_removal ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/convex_hull_2d/CMakeLists.txt
+++ b/doc/tutorials/content/sources/convex_hull_2d/CMakeLists.txt
@@ -4,9 +4,5 @@ project(convex_hull_2d)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (convex_hull_2d convex_hull_2d.cpp)
 target_link_libraries (convex_hull_2d ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/correspondence_grouping/CMakeLists.txt
+++ b/doc/tutorials/content/sources/correspondence_grouping/CMakeLists.txt
@@ -4,9 +4,5 @@ project(correspondence_grouping)
 
 find_package(PCL 1.5 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (correspondence_grouping correspondence_grouping.cpp)
 target_link_libraries (correspondence_grouping ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/cylinder_segmentation/CMakeLists.txt
+++ b/doc/tutorials/content/sources/cylinder_segmentation/CMakeLists.txt
@@ -4,9 +4,5 @@ project(cylinder_segmentation)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (cylinder_segmentation cylinder_segmentation.cpp)
 target_link_libraries (cylinder_segmentation ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/davidsdk/CMakeLists.txt
+++ b/doc/tutorials/content/sources/davidsdk/CMakeLists.txt
@@ -5,9 +5,6 @@ project(pcl-davidSDK_images_viewer)
 find_package(PCL 1.8.0 REQUIRED)
 find_package(OpenCV REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
 
 add_executable(davidsdk_images_viewer davidsdk_images_viewer.cpp)
 target_link_libraries(davidsdk_images_viewer ${PCL_LIBRARIES} ${OpenCV_LIBS})

--- a/doc/tutorials/content/sources/don_segmentation/CMakeLists.txt
+++ b/doc/tutorials/content/sources/don_segmentation/CMakeLists.txt
@@ -4,9 +4,5 @@ project(don_segmentation)
 
 find_package(PCL 1.7 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (don_segmentation don_segmentation.cpp)
 target_link_libraries (don_segmentation ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/ensenso_cameras/CMakeLists.txt
+++ b/doc/tutorials/content/sources/ensenso_cameras/CMakeLists.txt
@@ -5,9 +5,5 @@ project(pcl-ensenso_cloud_images_viewer)
 find_package(PCL 1.8.0 REQUIRED)
 find_package(OpenCV REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable(ensenso_cloud_images_viewer ensenso_cloud_images_viewer.cpp)
 target_link_libraries(ensenso_cloud_images_viewer ${PCL_LIBRARIES} ${OpenCV_LIBS})

--- a/doc/tutorials/content/sources/extract_indices/CMakeLists.txt
+++ b/doc/tutorials/content/sources/extract_indices/CMakeLists.txt
@@ -4,9 +4,5 @@ project(extract_indices)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (extract_indices extract_indices.cpp)
 target_link_libraries (extract_indices ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/function_filter/CMakeLists.txt
+++ b/doc/tutorials/content/sources/function_filter/CMakeLists.txt
@@ -6,4 +6,3 @@ find_package(PCL 1.11.1.99 REQUIRED)
 
 add_executable (sphere_removal sphere_removal.cpp)
 target_link_libraries (sphere_removal ${PCL_LIBRARIES})
-add_definitions(${PCL_DEFINITIONS})

--- a/doc/tutorials/content/sources/global_hypothesis_verification/CMakeLists.txt
+++ b/doc/tutorials/content/sources/global_hypothesis_verification/CMakeLists.txt
@@ -5,9 +5,5 @@ project(global_hypothesis_verification)
 #Pcl
 find_package(PCL 1.7 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (global_hypothesis_verification global_hypothesis_verification.cpp)
 target_link_libraries (global_hypothesis_verification ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/gpu/people_detect/CMakeLists.txt
+++ b/doc/tutorials/content/sources/gpu/people_detect/CMakeLists.txt
@@ -4,10 +4,6 @@ project(people_detect)
 
 find_package(PCL 1.7 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 #Searching CUDA
 find_package(CUDA)
 

--- a/doc/tutorials/content/sources/greedy_projection/CMakeLists.txt
+++ b/doc/tutorials/content/sources/greedy_projection/CMakeLists.txt
@@ -4,9 +4,5 @@ project(greedy_projection)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (greedy_projection greedy_projection.cpp)
 target_link_libraries (greedy_projection ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/ground_based_rgbd_people_detection/CMakeLists.txt
+++ b/doc/tutorials/content/sources/ground_based_rgbd_people_detection/CMakeLists.txt
@@ -2,9 +2,5 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(ground_based_rgbd_people_detector)
 find_package(PCL 1.7 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (ground_based_rgbd_people_detector MACOSX_BUNDLE src/main_ground_based_people_detection.cpp)
 target_link_libraries (ground_based_rgbd_people_detector ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/iccv2011/CMakeLists.txt
+++ b/doc/tutorials/content/sources/iccv2011/CMakeLists.txt
@@ -4,9 +4,7 @@ project(iccv11)
 
 find_package(PCL 1.5 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS} include)
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
+include_directories(include)
 
 add_executable (iccv2011_capture_tool src/capture_tool.cpp src/openni_capture.cpp)
 target_link_libraries (iccv2011_capture_tool ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/implicit_shape_model/CMakeLists.txt
+++ b/doc/tutorials/content/sources/implicit_shape_model/CMakeLists.txt
@@ -5,9 +5,6 @@ project(implicit_shape_model)
 find_package(PCL 1.5 REQUIRED)
 
 set(CMAKE_BUILD_TYPE Release)
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
 
 add_executable (implicit_shape_model implicit_shape_model.cpp)
 target_link_libraries (implicit_shape_model ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/interactive_icp/CMakeLists.txt
+++ b/doc/tutorials/content/sources/interactive_icp/CMakeLists.txt
@@ -4,9 +4,6 @@ project(pcl-interactive_icp)
 
 find_package(PCL 1.5 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
 
 add_executable (interactive_icp interactive_icp.cpp)
 target_link_libraries (interactive_icp ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/iros2011/CMakeLists.txt
+++ b/doc/tutorials/content/sources/iros2011/CMakeLists.txt
@@ -4,9 +4,7 @@ project(iros11)
 
 find_package(PCL 1.5 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS} include)
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
+include_directories(include)
 
 add_executable (iros2011_capture_tool src/capture_tool.cpp src/openni_capture.cpp)
 target_link_libraries (iros2011_capture_tool ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/iterative_closest_point/CMakeLists.txt
+++ b/doc/tutorials/content/sources/iterative_closest_point/CMakeLists.txt
@@ -4,10 +4,6 @@ project(iterative_closest_point)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (iterative_closest_point iterative_closest_point.cpp)
 target_link_libraries (iterative_closest_point ${PCL_LIBRARIES})
 

--- a/doc/tutorials/content/sources/kdtree_search/CMakeLists.txt
+++ b/doc/tutorials/content/sources/kdtree_search/CMakeLists.txt
@@ -4,9 +4,5 @@ project(kdtree_search)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (kdtree_search kdtree_search.cpp)
 target_link_libraries (kdtree_search ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/matrix_transform/CMakeLists.txt
+++ b/doc/tutorials/content/sources/matrix_transform/CMakeLists.txt
@@ -4,9 +4,5 @@ project(pcl-matrix_transform)
 
 find_package(PCL 1.7 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (matrix_transform matrix_transform.cpp)
 target_link_libraries (matrix_transform ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/min_cut_segmentation/CMakeLists.txt
+++ b/doc/tutorials/content/sources/min_cut_segmentation/CMakeLists.txt
@@ -4,9 +4,5 @@ project(min_cut_segmentation)
 
 find_package(PCL 1.5 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (min_cut_segmentation min_cut_segmentation.cpp)
 target_link_libraries (min_cut_segmentation ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/model_outlier_removal/CMakeLists.txt
+++ b/doc/tutorials/content/sources/model_outlier_removal/CMakeLists.txt
@@ -4,9 +4,5 @@ project(model_outlier_removal)
 
 find_package(PCL 1.7 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (model_outlier_removal model_outlier_removal.cpp)
 target_link_libraries (model_outlier_removal ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/moment_of_inertia/CMakeLists.txt
+++ b/doc/tutorials/content/sources/moment_of_inertia/CMakeLists.txt
@@ -4,10 +4,6 @@ project(moment_of_inertia)
 
 find_package(PCL 1.8 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (moment_of_inertia moment_of_inertia.cpp)
 target_link_libraries (moment_of_inertia ${PCL_LIBRARIES})
 

--- a/doc/tutorials/content/sources/narf_descriptor_visualization/CMakeLists.txt
+++ b/doc/tutorials/content/sources/narf_descriptor_visualization/CMakeLists.txt
@@ -4,9 +4,5 @@ project(narf_descriptor_visualization)
 
 find_package(PCL 1.3 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (narf_descriptor_visualization narf_descriptor_visualization.cpp)
 target_link_libraries (narf_descriptor_visualization ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/narf_feature_extraction/CMakeLists.txt
+++ b/doc/tutorials/content/sources/narf_feature_extraction/CMakeLists.txt
@@ -4,9 +4,5 @@ project(narf_feature_extraction)
 
 find_package(PCL 1.3 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (narf_feature_extraction narf_feature_extraction.cpp)
 target_link_libraries (narf_feature_extraction ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/narf_keypoint_extraction/CMakeLists.txt
+++ b/doc/tutorials/content/sources/narf_keypoint_extraction/CMakeLists.txt
@@ -4,9 +4,5 @@ project(narf_keypoint_extraction)
 
 find_package(PCL 1.3 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (narf_keypoint_extraction narf_keypoint_extraction.cpp)
 target_link_libraries (narf_keypoint_extraction ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/normal_distributions_transform/CMakeLists.txt
+++ b/doc/tutorials/content/sources/normal_distributions_transform/CMakeLists.txt
@@ -4,10 +4,6 @@ project(normal_distributions_transform)
 
 find_package(PCL 1.5 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 
 add_executable(normal_distributions_transform normal_distributions_transform.cpp)
 target_link_libraries (normal_distributions_transform ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/normal_estimation_using_integral_images/CMakeLists.txt
+++ b/doc/tutorials/content/sources/normal_estimation_using_integral_images/CMakeLists.txt
@@ -4,10 +4,6 @@ project(normal_estimation_using_integral_images)
 
 find_package(PCL 1.3 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (normal_estimation_using_integral_images normal_estimation_using_integral_images.cpp)
 target_link_libraries (normal_estimation_using_integral_images ${PCL_LIBRARIES})
 

--- a/doc/tutorials/content/sources/octree_change_detection/CMakeLists.txt
+++ b/doc/tutorials/content/sources/octree_change_detection/CMakeLists.txt
@@ -4,9 +4,5 @@ project(octree_change_detection)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (octree_change_detection octree_change_detection.cpp)
 target_link_libraries (octree_change_detection ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/octree_search/CMakeLists.txt
+++ b/doc/tutorials/content/sources/octree_search/CMakeLists.txt
@@ -4,9 +4,5 @@ project(octree_search)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (octree_search octree_search.cpp)
 target_link_libraries (octree_search ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/openni_grabber/CMakeLists.txt
+++ b/doc/tutorials/content/sources/openni_grabber/CMakeLists.txt
@@ -4,9 +4,5 @@ project(openni_grabber)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (openni_grabber openni_grabber.cpp)
 target_link_libraries (openni_grabber ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/openni_narf_keypoint_extraction/CMakeLists.txt
+++ b/doc/tutorials/content/sources/openni_narf_keypoint_extraction/CMakeLists.txt
@@ -4,10 +4,6 @@ project(openni_narf_keypoint_extraction)
 
 find_package(PCL 1.3 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (openni_narf_keypoint_extraction openni_narf_keypoint_extraction.cpp)
 target_link_libraries (openni_narf_keypoint_extraction ${PCL_LIBRARIES})
 

--- a/doc/tutorials/content/sources/openni_range_image_visualization/CMakeLists.txt
+++ b/doc/tutorials/content/sources/openni_range_image_visualization/CMakeLists.txt
@@ -4,9 +4,5 @@ project(openni_range_image_visualization)
 
 find_package(PCL 1.3 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (openni_range_image_visualization openni_range_image_visualization.cpp)
 target_link_libraries (openni_range_image_visualization ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/pairwise_incremental_registration/CMakeLists.txt
+++ b/doc/tutorials/content/sources/pairwise_incremental_registration/CMakeLists.txt
@@ -4,9 +4,5 @@ project(tuto-pairwise)
 
 find_package(PCL 1.4 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (pairwise_incremental_registration pairwise_incremental_registration.cpp)
 target_link_libraries (pairwise_incremental_registration ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/passthrough/CMakeLists.txt
+++ b/doc/tutorials/content/sources/passthrough/CMakeLists.txt
@@ -4,9 +4,5 @@ project(passthrough)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (passthrough passthrough.cpp)
 target_link_libraries (passthrough ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/pcd_read/CMakeLists.txt
+++ b/doc/tutorials/content/sources/pcd_read/CMakeLists.txt
@@ -4,9 +4,5 @@ project(pcd_read)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (pcd_read pcd_read.cpp)
 target_link_libraries (pcd_read ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/pcd_write/CMakeLists.txt
+++ b/doc/tutorials/content/sources/pcd_write/CMakeLists.txt
@@ -4,9 +4,5 @@ project(pcd_write)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (pcd_write pcd_write.cpp)
 target_link_libraries (pcd_write ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/pcl_painter2D/CMakeLists.txt
+++ b/doc/tutorials/content/sources/pcl_painter2D/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(pcl_painter2D_demo)
 find_package(PCL 1.7)
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
 add_executable(pcl_painter2D_demo pcl_painter2D_demo.cpp)
 target_link_libraries(pcl_painter2D_demo ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/pcl_plotter/CMakeLists.txt
+++ b/doc/tutorials/content/sources/pcl_plotter/CMakeLists.txt
@@ -1,8 +1,5 @@
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(pcl_plotter)
 find_package(PCL 1.7 REQUIRED COMPONENTS common visualization)
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
 add_executable(pcl_plotter pcl_plotter_demo.cpp)
 target_link_libraries(pcl_plotter ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/pcl_visualizer/CMakeLists.txt
+++ b/doc/tutorials/content/sources/pcl_visualizer/CMakeLists.txt
@@ -4,9 +4,5 @@ project(pcl_visualizer_viewports)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (pcl_visualizer_demo pcl_visualizer_demo.cpp)
 target_link_libraries (pcl_visualizer_demo ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/planar_segmentation/CMakeLists.txt
+++ b/doc/tutorials/content/sources/planar_segmentation/CMakeLists.txt
@@ -4,9 +4,5 @@ project(planar_segmentation)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (planar_segmentation planar_segmentation.cpp)
 target_link_libraries (planar_segmentation ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/point_cloud_compression/CMakeLists.txt
+++ b/doc/tutorials/content/sources/point_cloud_compression/CMakeLists.txt
@@ -4,9 +4,5 @@ project(point_cloud_compression)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (point_cloud_compression point_cloud_compression.cpp)
 target_link_libraries (point_cloud_compression ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/project_inliers/CMakeLists.txt
+++ b/doc/tutorials/content/sources/project_inliers/CMakeLists.txt
@@ -4,9 +4,5 @@ project(project_inliers)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (project_inliers project_inliers.cpp)
 target_link_libraries (project_inliers ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_colorize_cloud/CMakeLists.txt
@@ -25,9 +25,6 @@ find_package(PCL 1.7.1 REQUIRED)
 # Fix a compilation bug under ubuntu 16.04 (Xenial)
 list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")
 
-include_directories(${PCL_INCLUDE_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 set(project_SOURCES main.cpp pclviewer.cpp)
 
 add_executable(${PROJECT_NAME} ${project_SOURCES})

--- a/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
+++ b/doc/tutorials/content/sources/qt_visualizer/CMakeLists.txt
@@ -25,9 +25,6 @@ find_package(PCL 1.7.1 REQUIRED)
 # Fix a compilation bug under ubuntu 16.04 (Xenial)
 list(REMOVE_ITEM PCL_LIBRARIES "vtkproj4")
 
-include_directories(${PCL_INCLUDE_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 set(project_SOURCES main.cpp pclviewer.cpp)
 
 add_executable(${PROJECT_NAME} ${project_SOURCES})

--- a/doc/tutorials/content/sources/radius_outlier_removal/CMakeLists.txt
+++ b/doc/tutorials/content/sources/radius_outlier_removal/CMakeLists.txt
@@ -4,9 +4,5 @@ project(radius_outlier_removal)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (radius_outlier_removal radius_outlier_removal.cpp)
 target_link_libraries (radius_outlier_removal ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/random_sample_consensus/CMakeLists.txt
+++ b/doc/tutorials/content/sources/random_sample_consensus/CMakeLists.txt
@@ -4,9 +4,5 @@ project(random_sample_consensus)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (random_sample_consensus random_sample_consensus.cpp)
 target_link_libraries (random_sample_consensus ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/range_image_border_extraction/CMakeLists.txt
+++ b/doc/tutorials/content/sources/range_image_border_extraction/CMakeLists.txt
@@ -4,10 +4,6 @@ project(range_image_border_extraction)
 
 find_package(PCL 1.3 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (range_image_border_extraction range_image_border_extraction.cpp)
 target_link_libraries (range_image_border_extraction ${PCL_LIBRARIES})
 

--- a/doc/tutorials/content/sources/range_image_creation/CMakeLists.txt
+++ b/doc/tutorials/content/sources/range_image_creation/CMakeLists.txt
@@ -4,9 +4,5 @@ project(range_image_creation)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (range_image_creation range_image_creation.cpp)
 target_link_libraries (range_image_creation ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/range_image_visualization/CMakeLists.txt
+++ b/doc/tutorials/content/sources/range_image_visualization/CMakeLists.txt
@@ -4,10 +4,6 @@ project(range_image_visualization)
 
 find_package(PCL 1.3 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (range_image_visualization range_image_visualization.cpp)
 target_link_libraries (range_image_visualization ${PCL_LIBRARIES})
 

--- a/doc/tutorials/content/sources/region_growing_rgb_segmentation/CMakeLists.txt
+++ b/doc/tutorials/content/sources/region_growing_rgb_segmentation/CMakeLists.txt
@@ -4,10 +4,6 @@ project(region_growing_rgb_segmentation)
 
 find_package(PCL 1.5 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (region_growing_rgb_segmentation region_growing_rgb_segmentation.cpp)
 target_link_libraries (region_growing_rgb_segmentation ${PCL_LIBRARIES})
 

--- a/doc/tutorials/content/sources/region_growing_segmentation/CMakeLists.txt
+++ b/doc/tutorials/content/sources/region_growing_segmentation/CMakeLists.txt
@@ -4,10 +4,6 @@ project(region_growing_segmentation)
 
 find_package(PCL 1.5 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (region_growing_segmentation region_growing_segmentation.cpp)
 target_link_libraries (region_growing_segmentation ${PCL_LIBRARIES})
 

--- a/doc/tutorials/content/sources/registration_api/CMakeLists.txt
+++ b/doc/tutorials/content/sources/registration_api/CMakeLists.txt
@@ -4,10 +4,6 @@ project(registration_api)
 
 find_package(PCL 1.3 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 #add_executable (example1 example1.cpp)
 #target_link_libraries (example1 ${PCL_LIBRARIES})
 

--- a/doc/tutorials/content/sources/remove_outliers/CMakeLists.txt
+++ b/doc/tutorials/content/sources/remove_outliers/CMakeLists.txt
@@ -4,9 +4,5 @@ project(remove_outliers)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (remove_outliers remove_outliers.cpp)
 target_link_libraries (remove_outliers ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/resampling/CMakeLists.txt
+++ b/doc/tutorials/content/sources/resampling/CMakeLists.txt
@@ -4,9 +4,5 @@ project(resampling)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (resampling resampling.cpp)
 target_link_libraries (resampling ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/rops_feature/CMakeLists.txt
+++ b/doc/tutorials/content/sources/rops_feature/CMakeLists.txt
@@ -4,10 +4,6 @@ project(rops_feature)
 
 find_package(PCL 1.8 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (rops_feature rops_feature.cpp)
 target_link_libraries (rops_feature ${PCL_LIBRARIES})
 

--- a/doc/tutorials/content/sources/statistical_removal/CMakeLists.txt
+++ b/doc/tutorials/content/sources/statistical_removal/CMakeLists.txt
@@ -4,9 +4,5 @@ project(statistical_removal)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (statistical_removal statistical_removal.cpp)
 target_link_libraries (statistical_removal ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/stick_segmentation/CMakeLists.txt
+++ b/doc/tutorials/content/sources/stick_segmentation/CMakeLists.txt
@@ -4,9 +4,5 @@ project(stick_segmentation)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (stick_segmentation stick_segmentation.cpp)
 target_link_libraries (stick_segmentation ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/supervoxel_clustering/CMakeLists.txt
+++ b/doc/tutorials/content/sources/supervoxel_clustering/CMakeLists.txt
@@ -4,9 +4,5 @@ project(supervoxel_clustering)
 
 find_package(PCL 1.8 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (supervoxel_clustering supervoxel_clustering.cpp)
 target_link_libraries (supervoxel_clustering ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/template_alignment/CMakeLists.txt
+++ b/doc/tutorials/content/sources/template_alignment/CMakeLists.txt
@@ -4,9 +4,5 @@ project(template_alignment)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (template_alignment template_alignment.cpp)
 target_link_libraries (template_alignment ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/tracking/CMakeLists.txt
+++ b/doc/tutorials/content/sources/tracking/CMakeLists.txt
@@ -4,9 +4,5 @@ project(openni_tracking)
 
 find_package(PCL 1.7 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (tracking_sample tracking_sample.cpp)
 target_link_libraries (tracking_sample ${PCL_LIBRARIES})

--- a/doc/tutorials/content/sources/vfh_recognition/CMakeLists.txt
+++ b/doc/tutorials/content/sources/vfh_recognition/CMakeLists.txt
@@ -3,9 +3,6 @@ cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(vfh_cluster_classifier)
 
 find_package(PCL 1.2 REQUIRED)
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
 
 find_package(HDF5 REQUIRED)
 find_package(FLANN REQUIRED)

--- a/doc/tutorials/content/sources/voxel_grid/CMakeLists.txt
+++ b/doc/tutorials/content/sources/voxel_grid/CMakeLists.txt
@@ -4,9 +4,5 @@ project(voxel_grid)
 
 find_package(PCL 1.2 REQUIRED)
 
-include_directories(${PCL_INCLUDE_DIRS})
-link_directories(${PCL_LIBRARY_DIRS})
-add_definitions(${PCL_DEFINITIONS})
-
 add_executable (voxel_grid voxel_grid.cpp)
 target_link_libraries (voxel_grid ${PCL_LIBRARIES})

--- a/doc/tutorials/content/using_pcl_pcl_config.rst
+++ b/doc/tutorials/content/using_pcl_pcl_config.rst
@@ -21,12 +21,9 @@ CMakeLists.txt that contains:
 
 .. code-block:: cmake
    
-   cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
+   cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
    project(MY_GRAND_PROJECT)
    find_package(PCL 1.3 REQUIRED)
-   include_directories(${PCL_INCLUDE_DIRS})
-   link_directories(${PCL_LIBRARY_DIRS})
-   add_definitions(${PCL_DEFINITIONS})
    add_executable(pcd_write_test pcd_write.cpp)
    target_link_libraries(pcd_write_test ${PCL_LIBRARIES})
 
@@ -37,7 +34,7 @@ Now, let's see what we did.
 
 .. code-block:: cmake
    
-   cmake_minimum_required(VERSION 2.6 FATAL_ERROR)
+   cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
    
 This is mandatory for cmake, and since we are making a very basic
 project we don't need features from cmake 2.8 or higher.
@@ -65,29 +62,6 @@ gracefully if it can't be found. As PCL is modular one can request:
 
 .. code-block:: cmake
 
-   include_directories(${PCL_INCLUDE_DIRS})
-   link_directories(${PCL_LIBRARY_DIRS})
-   add_definitions(${PCL_DEFINITIONS})
-   
-When PCL is found, several related variables are set:
-
-* `PCL_FOUND`: set to 1 if PCL is found, otherwise unset
-* `PCL_INCLUDE_DIRS`: set to the paths to PCL installed headers and
-  the dependency headers
-* `PCL_LIBRARIES`: set to the file names of the built and installed PCL libraries
-* `PCL_LIBRARY_DIRS`: set to the paths to where PCL libraries and 3rd
-  party dependencies reside
-* `PCL_VERSION`: the version of the found PCL 
-* `PCL_COMPONENTS`: lists all available components
-* `PCL_DEFINITIONS`: lists the needed preprocessor definitions and compiler flags
-
-To let cmake know about external headers you include in your project,
-one needs to use ``include_directories()`` macro. In our case
-``PCL_INCLUDE_DIRS``, contains exactly what we need, thus we ask cmake
-to search the paths it contains for a header potentially included.
-
-.. code-block:: cmake
-
    add_executable(pcd_write_test pcd_write.cpp)
 
 Here, we tell cmake that we are trying to make an executable file
@@ -110,6 +84,23 @@ PCLConfig.cmake uses a CMake special feature named `EXPORT` which
 allows for using others' projects targets as if you built them
 yourself. When you are using such targets they are called `imported
 targets` and act just like any other target.
+
+CMake variables defined after finding PCL
+=========================================
+
+When PCL is found, several related variables are set:
+
+* `PCL_FOUND`: set to 1 if PCL is found, otherwise unset
+* `PCL_INCLUDE_DIRS`: set to the paths to PCL installed headers and
+  the dependency headers
+* `PCL_LIBRARIES`: set to the file names of the built and installed PCL libraries
+* `PCL_LIBRARY_DIRS`: set to the paths to where PCL libraries and 3rd
+  party dependencies reside
+* `PCL_VERSION`: the version of the found PCL 
+* `PCL_COMPONENTS`: lists all available components
+* `PCL_DEFINITIONS`: lists the needed preprocessor definitions and compiler flags
+
+In older PCL versions, it was necessary to explicitly tell CMake about `PCL_INCLUDE_DIRS`, `PCL_LIBRARY_DIRS`, and `PCL_DEFINITIONS`, but in newer PCL versions, the `target_link_libraries` call handles that automatically.
 
 Compiling and running the project
 ---------------------------------


### PR DESCRIPTION
PCL_INCLUDE_DIRS, PCL_LIBRARY_DIRS, and PCL_DEFINITIONS do not have to be used explicitly any more, using target_link_libraries is sufficient.

See also discussion about tutorials in https://github.com/PointCloudLibrary/pcl/issues/5806