### PR TITLE
Fix uninitialized build warnings

### DIFF
--- a/io/include/pcl/io/impl/vtk_lib_io.hpp
+++ b/io/include/pcl/io/impl/vtk_lib_io.hpp
@@ -122,7 +122,7 @@ pcl::io::vtkPolyDataToPointCloud (vtkPolyData* const polydata, pcl::PointCloud<P
   {
     for (std::size_t i = 0; i < cloud.size (); ++i)
     {
-      float normal[3];
+      float normal[3] = {0.0f, 0.0f, 0.0f};
       normals->GetTupleValue (i, normal);
       pcl::setFieldValue<PointT, float> (cloud[i], normal_x_idx, normal[0]);
       pcl::setFieldValue<PointT, float> (cloud[i], normal_y_idx, normal[1]);

--- a/recognition/src/ransac_based/obj_rec_ransac.cpp
+++ b/recognition/src/ransac_based/obj_rec_ransac.cpp
@@ -296,7 +296,8 @@ pcl::recognition::ObjRecRANSAC::groupHypotheses(std::list<HypothesisBase>& hypot
 #endif
 
   // Compute the bounds for the positional discretization
-  float b[6]; scene_octree_.getBounds (b);
+  float b[6] = {0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f};
+  scene_octree_.getBounds (b);
   float enlr = scene_bounds_enlargement_factor_*std::max (std::max (b[1]-b[0], b[3]-b[2]), b[5]-b[4]);
   b[0] -= enlr; b[1] += enlr;
   b[2] -= enlr; b[3] += enlr;

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -121,17 +121,15 @@ NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeTransform
     // 2009]
     Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6>> sv(
         hessian, Eigen::ComputeFullU | Eigen::ComputeFullV);
-    #if EIGEN_VERSION_AT_LEAST(3, 4, 0)
+#if EIGEN_VERSION_AT_LEAST(3, 4, 0)
     if (sv.info() != Eigen::ComputationInfo::Success) {
-	trans_likelihood_ = score / static_cast<double>(input_->size());
-	converged_ = 0;
-	return;
+      trans_likelihood_ = score / static_cast<double>(input_->size());
+      converged_ = 0;
+      return;
     }
-    #endif
+#endif
     // Negative for maximization as opposed to minimization
     Eigen::Matrix<double, 6, 1> delta = sv.solve(-score_gradient);
-
-
 
     // Calculate step length with guaranteed sufficient decrease [More, Thuente 1994]
     double delta_norm = delta.norm();

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -121,8 +121,17 @@ NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeTransform
     // 2009]
     Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6>> sv(
         hessian, Eigen::ComputeFullU | Eigen::ComputeFullV);
+    #if EIGEN_VERSION_AT_LEAST(3, 4, 0)
+    if (sv.info() != Eigen::ComputationInfo::Success) {
+	trans_likelihood_ = score / static_cast<double>(input_->size());
+	converged_ = 0;
+	return;
+    }
+    #endif
     // Negative for maximization as opposed to minimization
     Eigen::Matrix<double, 6, 1> delta = sv.solve(-score_gradient);
+
+
 
     // Calculate step length with guaranteed sufficient decrease [More, Thuente 1994]
     double delta_norm = delta.norm();

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -125,6 +125,8 @@ NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeTransform
     if (sv.info() != Eigen::ComputationInfo::Success) {
       trans_likelihood_ = score / static_cast<double>(input_->size());
       converged_ = 0;
+      PCL_ERROR("[%s::computeTransformation] JacobiSVD on hessian failed!\n",
+                getClassName().c_str());
       return;
     }
 #endif


### PR DESCRIPTION
This fixes a few uninitialized build warnings. 

This was tested on Ubuntu 24.04, c++ version 13.3.0.

Some of the warnings that this attempts to fix:
```
pcl/recognition/src/ransac_based/obj_rec_ransac.cpp: In member function ‘int pcl::recognition::ObjRecRANSAC::groupHypotheses(std::__cxx11::list<pcl::recognition::HypothesisBase>&, int, pcl::recognition::RigidTransformSpace&, HypothesisOctree&) const’:
pcl/recognition/src/ransac_based/obj_rec_ransac.cpp:300:77: warning: ‘b’ may be used uninitialized [-Wmaybe-uninitialized]
  300 |   float enlr = scene_bounds_enlargement_factor_*std::max (std::max (b[1]-b[0], b[3]-b[2]), b[5]-b[4]);
      |                                                                          ~~~^
pcl/recognition/src/ransac_based/obj_rec_ransac.cpp:299:9: note: ‘b’ declared here
  299 |   float b[6]; scene_octree_.getBounds (b);
```

```
In file included from /usr/include/eigen3/Eigen/SVD:36,
                 from /usr/include/eigen3/Eigen/Geometry:13,
                 from pcl/common/include/pcl/point_cloud.h:46,
                 from pcl/io/include/pcl/io/pcd_io.h:44,
                 from pcl/tools/ndt3d.cpp:37:
In member function ‘Eigen::SVDBase<MatrixType>::Index Eigen::SVDBase<MatrixType>::rank() const [with Derived = Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> >]’,
    inlined from ‘void Eigen::SVDBase<MatrixType>::_solve_impl(const RhsType&, DstType&) const [with RhsType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_opposite_op<double>, const Eigen::Matrix<double, 6, 1> >; DstType = Eigen::Matrix<double, 6, 1>; Derived = Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> >]’ at /usr/include/eigen3/Eigen/src/SVD/SVDBase.h:314:22,
    inlined from ‘static void Eigen::internal::Assignment<DstXprType, Eigen::Solve<DecType, RhsType>, Eigen::internal::assign_op<Scalar, Scalar>, Eigen::internal::Dense2Dense>::run(DstXprType&, const SrcXprType&, const Eigen::internal::assign_op<Scalar, Scalar>&) [with DstXprType = Eigen::Matrix<double, 6, 1>; DecType = Eigen::SVDBase<Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> > >; RhsType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_opposite_op<double>, const Eigen::Matrix<double, 6, 1> >; Scalar = double]’ at /usr/include/eigen3/Eigen/src/Core/Solve.h:147:26,
    inlined from ‘void Eigen::internal::call_assignment_no_alias(Dst&, const Src&, const Func&) [with Dst = Eigen::Matrix<double, 6, 1>; Src = Eigen::Solve<Eigen::SVDBase<Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> > >, Eigen::CwiseUnaryOp<scalar_opposite_op<double>, const Eigen::Matrix<double, 6, 1> > >; Func = assign_op<double, double>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:890:49,
    inlined from ‘Derived& Eigen::PlainObjectBase<Derived>::_set_noalias(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Solve<Eigen::SVDBase<Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> > >, Eigen::CwiseUnaryOp<Eigen::internal::scalar_opposite_op<double>, const Eigen::Matrix<double, 6, 1> > >; Derived = Eigen::Matrix<double, 6, 1>]’ at /usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h:797:41,
    inlined from ‘Eigen::PlainObjectBase<Derived>::PlainObjectBase(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Solve<Eigen::SVDBase<Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> > >, Eigen::CwiseUnaryOp<Eigen::internal::scalar_opposite_op<double>, const Eigen::Matrix<double, 6, 1> > >; Derived = Eigen::Matrix<double, 6, 1>]’ at /usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h:594:19,
    inlined from ‘Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>::Matrix(const Eigen::EigenBase<OtherDerived>&) [with OtherDerived = Eigen::Solve<Eigen::SVDBase<Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> > >, Eigen::CwiseUnaryOp<Eigen::internal::scalar_opposite_op<double>, const Eigen::Matrix<double, 6, 1> > >; _Scalar = double; int _Rows = 6; int _Cols = 1; int _Options = 0; int _MaxRows = 6; int _MaxCols = 1]’ at /usr/include/eigen3/Eigen/src/Core/Matrix.h:423:29,
    inlined from ‘void pcl::NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeTransformation(PointCloudSource&, const Matrix4&) [with PointSource = pcl::PointXYZ; PointTarget = pcl::PointXYZ; Scalar = float]’ at pcl/registration/include/pcl/registration/impl/ndt.hpp:125:33:
/usr/include/eigen3/Eigen/src/SVD/SVDBase.h:154:15: warning: ‘sv.Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6, 0, 6, 6>, 2>::<unnamed>.Eigen::SVDBase<Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> > >::m_nonzeroSingularValues’ may be used uninitialized [-Wmaybe-uninitialized]
  154 |     Index i = m_nonzeroSingularValues-1;
      |               ^~~~~~~~~~~~~~~~~~~~~~~
In file included from pcl/registration/include/pcl/registration/ndt.h:638,
                 from pcl/tools/ndt3d.cpp:39:
pcl/registration/include/pcl/registration/impl/ndt.hpp: In member function ‘void pcl::NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeTransformation(PointCloudSource&, const Matrix4&) [with PointSource = pcl::PointXYZ; PointTarget = pcl::PointXYZ; Scalar = float]’:
pcl/registration/include/pcl/registration/impl/ndt.hpp:122:51: note: ‘sv’ declared here
  122 |     Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6>> sv(
      |                                                   ^~
In member function ‘Eigen::SVDBase<MatrixType>::Index Eigen::SVDBase<MatrixType>::rank() const [with Derived = Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> >]’,
    inlined from ‘void Eigen::SVDBase<MatrixType>::_solve_impl(const RhsType&, DstType&) const [with RhsType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_opposite_op<double>, const Eigen::Matrix<double, 6, 1> >; DstType = Eigen::Matrix<double, 6, 1>; Derived = Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> >]’ at /usr/include/eigen3/Eigen/src/SVD/SVDBase.h:314:22,
    inlined from ‘static void Eigen::internal::Assignment<DstXprType, Eigen::Solve<DecType, RhsType>, Eigen::internal::assign_op<Scalar, Scalar>, Eigen::internal::Dense2Dense>::run(DstXprType&, const SrcXprType&, const Eigen::internal::assign_op<Scalar, Scalar>&) [with DstXprType = Eigen::Matrix<double, 6, 1>; DecType = Eigen::SVDBase<Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> > >; RhsType = Eigen::CwiseUnaryOp<Eigen::internal::scalar_opposite_op<double>, const Eigen::Matrix<double, 6, 1> >; Scalar = double]’ at /usr/include/eigen3/Eigen/src/Core/Solve.h:147:26,
    inlined from ‘void Eigen::internal::call_assignment_no_alias(Dst&, const Src&, const Func&) [with Dst = Eigen::Matrix<double, 6, 1>; Src = Eigen::Solve<Eigen::SVDBase<Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> > >, Eigen::CwiseUnaryOp<scalar_opposite_op<double>, const Eigen::Matrix<double, 6, 1> > >; Func = assign_op<double, double>]’ at /usr/include/eigen3/Eigen/src/Core/AssignEvaluator.h:890:49,
    inlined from ‘Derived& Eigen::PlainObjectBase<Derived>::_set_noalias(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Solve<Eigen::SVDBase<Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> > >, Eigen::CwiseUnaryOp<Eigen::internal::scalar_opposite_op<double>, const Eigen::Matrix<double, 6, 1> > >; Derived = Eigen::Matrix<double, 6, 1>]’ at /usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h:797:41,
    inlined from ‘Eigen::PlainObjectBase<Derived>::PlainObjectBase(const Eigen::DenseBase<OtherDerived>&) [with OtherDerived = Eigen::Solve<Eigen::SVDBase<Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> > >, Eigen::CwiseUnaryOp<Eigen::internal::scalar_opposite_op<double>, const Eigen::Matrix<double, 6, 1> > >; Derived = Eigen::Matrix<double, 6, 1>]’ at /usr/include/eigen3/Eigen/src/Core/PlainObjectBase.h:594:19,
    inlined from ‘Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols>::Matrix(const Eigen::EigenBase<OtherDerived>&) [with OtherDerived = Eigen::Solve<Eigen::SVDBase<Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6> > >, Eigen::CwiseUnaryOp<Eigen::internal::scalar_opposite_op<double>, const Eigen::Matrix<double, 6, 1> > >; _Scalar = double; int _Rows = 6; int _Cols = 1; int _Options = 0; int _MaxRows = 6; int _MaxCols = 1]’ at /usr/include/eigen3/Eigen/src/Core/Matrix.h:423:29,
    inlined from ‘void pcl::NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeTransformation(PointCloudSource&, const Matrix4&) [with PointSource = pcl::PointXYZ; PointTarget = pcl::PointXYZ; Scalar = float]’ at pcl/registration/include/pcl/registration/impl/ndt.hpp:125:33:
/usr/include/eigen3/Eigen/src/SVD/SVDBase.h:153:93: warning: ‘*(const Eigen::PlainObjectBase<Eigen::Matrix<double, 6, 1, 0, 6, 1> >::Scalar*)((char*)&sv + offsetof(Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6, 0, 6, 6>, 2>,Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6, 0, 6, 6>, 2>::<unnamed>.Eigen::SVDBase<Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6, 0, 6, 6>, 2> >::m_singularValues.Eigen::Matrix<double, 6, 1, 0, 6, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<double, 6, 1, 0, 6, 1> >::<unnamed>.Eigen::MatrixBase<Eigen::Matrix<double, 6, 1, 0, 6, 1> >::<unnamed>.Eigen::DenseBase<Eigen::Matrix<double, 6, 1, 0, 6, 1> >::<unnamed>.Eigen::DenseCoeffsBase<Eigen::Matrix<double, 6, 1, 0, 6, 1>, 3>::<unnamed>.Eigen::DenseCoeffsBase<Eigen::Matrix<double, 6, 1, 0, 6, 1>, 1>::<unnamed>.Eigen::DenseCoeffsBase<Eigen::Matrix<double, 6, 1, 0, 6, 1>, 0>::<unnamed>))’ may be used uninitialized [-Wmaybe-uninitialized]
  153 |     RealScalar premultiplied_threshold = numext::maxi<RealScalar>(m_singularValues.coeff(0) * threshold(), (std::numeric_limits<RealScalar>::min)());
      |                                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~
pcl/registration/include/pcl/registration/impl/ndt.hpp: In member function ‘void pcl::NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeTransformation(PointCloudSource&, const Matrix4&) [with PointSource = pcl::PointXYZ; PointTarget = pcl::PointXYZ; Scalar = float]’:
pcl/registration/include/pcl/registration/impl/ndt.hpp:122:51: note: ‘sv’ declared here
  122 |     Eigen::JacobiSVD<Eigen::Matrix<double, 6, 6>> sv(
      |                                                   ^~

```

```
In file included from pcl/common/include/pcl/memory.h:46,
                 from pcl/io/include/pcl/io/pcd_io.h:42,
                 from pcl/tools/obj2pcd.cpp:40:
In function ‘void pcl::setFieldValue(PointT&, std::size_t, const ValT&) [with PointT = PointNormal; ValT = float]’,
    inlined from ‘void pcl::io::vtkPolyDataToPointCloud(vtkPolyData*, pcl::PointCloud<PointT>&) [with PointT = pcl::PointNormal]’ at pcl/io/include/pcl/io/impl/vtk_lib_io.hpp:127:41:
pcl/common/include/pcl/type_traits.h:240:40: warning: ‘normal’ may be used uninitialized [-Wmaybe-uninitialized]
  240 |     *reinterpret_cast<ValT*>(data_ptr) = value;
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
In file included from pcl/io/include/pcl/io/vtk_lib_io.h:260,
                 from pcl/tools/obj2pcd.cpp:41:
pcl/io/include/pcl/io/impl/vtk_lib_io.hpp: In function ‘void pcl::io::vtkPolyDataToPointCloud(vtkPolyData*, pcl::PointCloud<PointT>&) [with PointT = pcl::PointNormal]’:
pcl/io/include/pcl/io/impl/vtk_lib_io.hpp:125:13: note: ‘normal’ declared here
  125 |       float normal[3];
      |             ^~~~~~
In function ‘void pcl::setFieldValue(PointT&, std::size_t, const ValT&) [with PointT = PointXYZ; ValT = float]’,
    inlined from ‘void pcl::io::vtkPolyDataToPointCloud(vtkPolyData*, pcl::PointCloud<PointT>&) [with PointT = pcl::PointXYZ]’ at pcl/io/include/pcl/io/impl/vtk_lib_io.hpp:127:41:
pcl/common/include/pcl/type_traits.h:240:40: warning: ‘normal’ may be used uninitialized [-Wmaybe-uninitialized]
  240 |     *reinterpret_cast<ValT*>(data_ptr) = value;
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
pcl/io/include/pcl/io/impl/vtk_lib_io.hpp: In function ‘void pcl::io::vtkPolyDataToPointCloud(vtkPolyData*, pcl::PointCloud<PointT>&) [with PointT = pcl::PointXYZ]’:
pcl/io/include/pcl/io/impl/vtk_lib_io.hpp:125:13: note: ‘normal’ declared here
  125 |       float normal[3];
      |             ^~~~~~
[ 38%] Linking CXX executable ../bin/pcl_obj2pcd
[ 38%] Built target pcl_obj2pcd
[ 38%] Building CXX object tools/CMakeFiles/pcl_compute_hausdorff.dir/compute_hausdorff.cpp.o
In file included from pcl/common/include/pcl/memory.h:46,
                 from pcl/io/include/pcl/io/pcd_io.h:42,
                 from pcl/tools/vtk2pcd.cpp:40:
In function ‘void pcl::setFieldValue(PointT&, std::size_t, const ValT&) [with PointT = PointNormal; ValT = float]’,
    inlined from ‘void pcl::io::vtkPolyDataToPointCloud(vtkPolyData*, pcl::PointCloud<PointT>&) [with PointT = pcl::PointNormal]’ at pcl/io/include/pcl/io/impl/vtk_lib_io.hpp:127:41:
pcl/common/include/pcl/type_traits.h:240:40: warning: ‘normal’ may be used uninitialized [-Wmaybe-uninitialized]
  240 |     *reinterpret_cast<ValT*>(data_ptr) = value;
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
In file included from pcl/io/include/pcl/io/vtk_lib_io.h:260,
                 from pcl/tools/vtk2pcd.cpp:41:
pcl/io/include/pcl/io/impl/vtk_lib_io.hpp: In function ‘void pcl::io::vtkPolyDataToPointCloud(vtkPolyData*, pcl::PointCloud<PointT>&) [with PointT = pcl::PointNormal]’:
pcl/io/include/pcl/io/impl/vtk_lib_io.hpp:125:13: note: ‘normal’ declared here
  125 |       float normal[3];
      |             ^~~~~~
In function ‘void pcl::setFieldValue(PointT&, std::size_t, const ValT&) [with PointT = PointXYZ; ValT = float]’,
    inlined from ‘void pcl::io::vtkPolyDataToPointCloud(vtkPolyData*, pcl::PointCloud<PointT>&) [with PointT = pcl::PointXYZ]’ at pcl/io/include/pcl/io/impl/vtk_lib_io.hpp:127:41:
pcl/common/include/pcl/type_traits.h:240:40: warning: ‘normal’ may be used uninitialized [-Wmaybe-uninitialized]
  240 |     *reinterpret_cast<ValT*>(data_ptr) = value;
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~
pcl/io/include/pcl/io/impl/vtk_lib_io.hpp: In function ‘void pcl::io::vtkPolyDataToPointCloud(vtkPolyData*, pcl::PointCloud<PointT>&) [with PointT = pcl::PointXYZ]’:
pcl/io/include/pcl/io/impl/vtk_lib_io.hpp:125:13: note: ‘normal’ declared here
  125 |       float normal[3];
      |             ^~~~~~
```