### PR TITLE
Add OpenMP Parallelization to FarthestPointSampling

### DIFF
--- a/filters/include/pcl/filters/farthest_point_sampling.h
+++ b/filters/include/pcl/filters/farthest_point_sampling.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <pcl/filters/filter_indices.h>
+#include <omp.h>
 
 #include <climits>
 #include <random>
@@ -43,6 +44,7 @@ namespace pcl
           seed_ (std::random_device()())
         {
           filter_name_ = "FarthestPointSamping";
+          setNumberOfThreads(0);
         }
 
         /** \brief Set number of points to be sampled.
@@ -79,12 +81,31 @@ namespace pcl
           return (seed_);
         }
 
+        /** \brief Set the number of threads to use when operating in parallel 
+          * \param nr_threads the number of threads to use
+          */
+        inline void
+        setNumberOfThreads (unsigned int nr_threads)
+        {
+          nr_threads_ = nr_threads == 0 ? omp_get_num_procs() : nr_threads;
+        }
+
+        /** \brief Get the value of the internal \a nr_threads_ parameter.
+          */
+        inline unsigned int 
+        getNumberOfThreads () const
+        {
+          return nr_threads_;
+        }
+
       protected:
 
         /** \brief Number of points that will be returned. */
         std::size_t sample_size_;
         /** \brief Random number seed. */
         unsigned int seed_;
+        /** \brief Number of threads */
+        unsigned int nr_threads_;
 
         /** \brief Sample of point indices
           * \param indices indices of the filtered point cloud

--- a/filters/include/pcl/filters/impl/farthest_point_sampling.hpp
+++ b/filters/include/pcl/filters/impl/farthest_point_sampling.hpp
@@ -54,6 +54,8 @@ pcl::FarthestPointSampling<PointT>::applyFilter (Indices &indices)
     const PointT& max_index_point = (*input_)[toCloudIndex(max_index)];
 
     #pragma omp parallel for \
+    default(none) \
+    shared(distances_to_selected_points, max_index, max_index_point, size, toCloudIndex) \
     num_threads(nr_threads_)
     for (std::size_t i = 0; i < size; ++i)
     {

--- a/filters/include/pcl/filters/impl/farthest_point_sampling.hpp
+++ b/filters/include/pcl/filters/impl/farthest_point_sampling.hpp
@@ -42,7 +42,7 @@ pcl::FarthestPointSampling<PointT>::applyFilter (Indices &indices)
   std::uniform_int_distribution<index_t> dis(0, size -1);
 
   //lambda to map filter indices back to pointcloud indices for increased readability
-  auto toCloudIndex = [this](const int idx){return (*indices_)[idx];};
+  auto toCloudIndex = [this](const auto idx){return (*indices_)[idx];};
 
   //pick the first point at random
   index_t max_index = dis(random_gen);

--- a/filters/include/pcl/filters/impl/farthest_point_sampling.hpp
+++ b/filters/include/pcl/filters/impl/farthest_point_sampling.hpp
@@ -42,7 +42,7 @@ pcl::FarthestPointSampling<PointT>::applyFilter (Indices &indices)
   std::uniform_int_distribution<index_t> dis(0, size -1);
 
   //lambda to map filter indices back to pointcloud indices for increased readability
-  auto toCloudIndex = [this](const auto idx){return (*indices_)[idx];};
+  auto toCloudIndex = [this](const int idx){return (*indices_)[idx];};
 
   //pick the first point at random
   index_t max_index = dis(random_gen);


### PR DESCRIPTION
FarthestPointSampling is a relatively recent addition to the filters module and has not yet been upgraded with a parallel implementation. The inner loop which recalculates the maximum minimum distance involves a large number of (mostly) independent operations, making it a good candidate for parallelization. The outer loop is serial due to the nature of the filter and so cannot be parallelized. 

This PR adds OpenMP-based parallelization to that inner loop, and introduces an API to allow the user to select the number of threads, with the default being the maximum CPU thread count. I also had another lock-free version where each thread would independently calculate it's own maximum and then all the results would be reduced at the end, but that performed about the same but had more complicated (i.e. bug-prone) control flow.

The following code was used to benchmark performance:

```cpp
#include <chrono>
#include <iostream>
#include <pcl/conversions.h>
#include <pcl/io/vtk_lib_io.h>
#include <pcl/filters/farthest_point_sampling.h>

int main() {
    pcl::PolygonMesh mesh;
    pcl::io::loadPolygonFile("/home/alex/Downloads/Espeon.stl", mesh);

    auto vertices = pcl::PointCloud<pcl::PointXYZ>{}.makeShared();
    pcl::fromPCLPointCloud2(mesh.cloud, *vertices);
    std::cout << "Loaded pointcloud with " << vertices->size() << " points\n";

    pcl::FarthestPointSampling<pcl::PointXYZ> farthest_point_sampler;
    farthest_point_sampler.setInputCloud(vertices);
    
    for (unsigned int nr_threads : {1, 2, 5, 10, 0}) {
        farthest_point_sampler.setNumberOfThreads(nr_threads);
        std::cout << farthest_point_sampler.getNumberOfThreads() << " thread" << (farthest_point_sampler.getNumberOfThreads() > 1 ? "s" : "") << ":\n";
        for (std::size_t sample_count = 10; sample_count <= 10000; sample_count *= 10) {
            farthest_point_sampler.setSample(sample_count);
            std::size_t total_milliseconds = 0;
            for (std::size_t trial_idx = 0; trial_idx < 10; trial_idx++) {
                pcl::Indices indices;
                farthest_point_sampler.setSeed(0);
                auto start = std::chrono::steady_clock::now();
                farthest_point_sampler.filter(indices);
                auto stop = std::chrono::steady_clock::now();
                total_milliseconds += std::chrono::duration_cast<std::chrono::milliseconds>(stop - start).count();
            }

            std::cout << std::setw(8) << sample_count << ": " << total_milliseconds/100 << " ms\n"; 
        }
    }
}
``` 

which gave this output, where the number on the left is the number of samples drawn at each trial, and the number on the right is the average execution time over 10 trials:

```
Loaded pointcloud with 638087 points
1 thread:
      10: 2 ms
     100: 23 ms
    1000: 246 ms
   10000: 2133 ms
2 threads:
      10: 1 ms
     100: 11 ms
    1000: 111 ms
   10000: 1124 ms
5 threads:
      10: 0 ms
     100: 5 ms
    1000: 58 ms
   10000: 598 ms
10 threads:
      10: 0 ms
     100: 3 ms
    1000: 35 ms
   10000: 353 ms
20 threads:
      10: 0 ms
     100: 2 ms
    1000: 28 ms
   10000: 337 ms
```