### PR TITLE
Fix CUDA 12.9 transform_reduce ambiguity

### DIFF
--- a/gpu/features/src/centroid.cu
+++ b/gpu/features/src/centroid.cu
@@ -89,7 +89,7 @@ void pcl::device::compute3DCentroid(const DeviceArray<PointT>& cloud, float3& ce
     thrust::device_ptr<PointT> src_beg((PointT*)cloud.ptr());
     thrust::device_ptr<PointT> src_end = src_beg + cloud.size();
 
-    centroid = transform_reduce(src_beg, src_beg, PointT2float3<PointT>(), make_float3(0.f, 0.f, 0.f), PlusFloat3());
+    centroid = thrust::transform_reduce(src_beg, src_beg, PointT2float3<PointT>(), make_float3(0.f, 0.f, 0.f), PlusFloat3());
     centroid *= 1.f/cloud.size();
 }
 
@@ -105,7 +105,7 @@ void pcl::device::compute3DCentroid(const DeviceArray<PointT>& cloud, const Indi
         thrust::device_ptr<int> map_end = map_beg + indices.size();
 
 
-        centroid = transform_reduce(make_permutation_iterator(src_beg, map_beg),
+        centroid = thrust::transform_reduce(make_permutation_iterator(src_beg, map_beg),
             make_permutation_iterator(src_beg, map_end),
             PointT2float3<PointT>(), make_float3(0.f, 0.f, 0.f), PlusFloat3());
 
@@ -126,7 +126,7 @@ float3 pcl::device::getMaxDistance(const DeviceArray<PointT>& cloud, const float
     thrust::maximum<thrust::tuple<float, int>> op;
 
     thrust::tuple<float, int> res =
-        transform_reduce(
+        thrust::transform_reduce(
         make_zip_iterator(make_tuple( src_beg, cf )),
         make_zip_iterator(make_tuple( src_beg, ce )),
         TupleDistCvt(pivot), init, op);
@@ -153,7 +153,7 @@ float3 pcl::device::getMaxDistance(const DeviceArray<PointT>& cloud, const Indic
     thrust::tuple<float, int> init(0.f, 0);
     thrust::maximum<thrust::tuple<float, int>> op;
 
-    thrust::tuple<float, int> res = transform_reduce(
+    thrust::tuple<float, int> res = thrust::transform_reduce(
         make_zip_iterator(make_tuple( make_permutation_iterator(src_beg, map_beg), cf )),
         make_zip_iterator(make_tuple( make_permutation_iterator(src_beg, map_end), ce )),
         TupleDistCvt(pivot), init, op);


### PR DESCRIPTION
On CUDA 12.9, it threw errors described in #6296 where `transform_reduce` was ambiguous. This fixes #6296 by updating `transform_reduce` to specify to use `thrust::transform_reduce`. 

This was tested with the CUDA 12.9 docker container and resulted in a successful build. 

There are no functional changes to the code.