### PR TITLE
Make copyPoint work with point types having a field of the same name …

### DIFF
--- a/common/include/pcl/common/concatenate.h
+++ b/common/include/pcl/common/concatenate.h
@@ -62,13 +62,8 @@ namespace pcl
       //boost::fusion::at_key<Key> (p2_) = boost::fusion::at_key<Key> (p1_);
       using InT = typename pcl::traits::datatype<PointInT, Key>::type;
       using OutT = typename pcl::traits::datatype<PointOutT, Key>::type;
-      // Note: don't currently support different types for the same field (e.g. converting double to float)
-      BOOST_MPL_ASSERT_MSG ((std::is_same<InT, OutT>::value),
-                            POINT_IN_AND_POINT_OUT_HAVE_DIFFERENT_TYPES_FOR_FIELD,
-                            (Key, PointInT&, InT, PointOutT&, OutT));
-      memcpy (reinterpret_cast<std::uint8_t*>(&p2_) + pcl::traits::offset<PointOutT, Key>::value,
-              reinterpret_cast<const std::uint8_t*>(&p1_) + pcl::traits::offset<PointInT, Key>::value,
-              sizeof (InT));
+      *reinterpret_cast<OutT*>(reinterpret_cast<std::uint8_t*>(&p2_) + pcl::traits::offset<PointOutT, Key>::value) =
+        *reinterpret_cast<const InT*>(reinterpret_cast<const std::uint8_t*>(&p1_) + pcl::traits::offset<PointInT, Key>::value);
     }
 
     private:

--- a/test/common/test_copy_point.cpp
+++ b/test/common/test_copy_point.cpp
@@ -170,6 +170,55 @@ TEST (CopyPointTest, DifferentTypesWithSameColor)
   }
 }
 
+namespace custom {
+  struct MyPoint {
+    float x, y, z, w;
+    double intensity;
+  };
+  struct MyPoint2 {
+    double x, y, z, w;
+  };
+}
+
+POINT_CLOUD_REGISTER_POINT_STRUCT (custom::MyPoint,
+    (float, x, x)
+    (float, y, y)
+    (float, z, z)
+    (double, intensity, intensity)
+)
+POINT_CLOUD_REGISTER_POINT_STRUCT (custom::MyPoint2,
+    (double, x, x)
+    (double, y, y)
+    (double, z, z)
+)
+
+TEST(CopyPointTest, SameFieldNameDifferentDatatype)
+{
+  // in p1 the intensity field is double, while in p2 it is float
+  custom::MyPoint p1;
+  pcl::PointXYZI p2;
+  p1.x = 1.0;
+  p1.y = 2.0;
+  p1.z = 3.0;
+  p1.intensity = 5.0;
+  pcl::copyPoint(p1, p2);
+  EXPECT_EQ(p1.x, p2.x);
+  EXPECT_EQ(p1.y, p2.y);
+  EXPECT_EQ(p1.z, p2.z);
+  EXPECT_EQ(p1.intensity, p2.intensity);
+
+  // in p3 xyz are float, while in p4 they are double
+  pcl::PointXYZ p3;
+  custom::MyPoint2 p4;
+  p3.x = 10.0;
+  p3.y = 11.0;
+  p3.z = 12.0;
+  pcl::copyPoint(p3, p4);
+  EXPECT_EQ(p3.x, p4.x);
+  EXPECT_EQ(p3.y, p4.y);
+  EXPECT_EQ(p3.z, p4.z);
+}
+
 int
 main (int argc, char **argv)
 {


### PR DESCRIPTION
…but different datatype

Following a recent question on Discord.

I also did a quick time measurement and found that `copyPoint` is as fast as before.