### PR TITLE
Fixing #6239

### DIFF
--- a/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
@@ -110,8 +110,7 @@ CorrespondenceRejectorSampleConsensus<PointT>::getRemainingCorrespondences(
       return;
     }
 
-    pcl::Indices inliers;
-    sac.getInliers(inliers);
+    const auto inliers = sac.getInliers();
 
     if (inliers.size() < 3) {
       remaining_correspondences = original_correspondences;
@@ -133,9 +132,8 @@ CorrespondenceRejectorSampleConsensus<PointT>::getRemainingCorrespondences(
         inlier_indices_.push_back(index_to_correspondence[inlier]);
     }
 
-    // get best transformation
-    Eigen::VectorXf model_coefficients;
-    sac.getModelCoefficients(model_coefficients);
+    // get the best transformation
+    Eigen::VectorXf model_coefficients = sac.getModelCoefficients();
     best_transformation_.row(0) = model_coefficients.segment<4>(0);
     best_transformation_.row(1) = model_coefficients.segment<4>(4);
     best_transformation_.row(2) = model_coefficients.segment<4>(8);

--- a/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus.hpp
@@ -110,7 +110,7 @@ CorrespondenceRejectorSampleConsensus<PointT>::getRemainingCorrespondences(
       return;
     }
 
-    const auto inliers = sac.getInliers();
+    const auto& inliers = sac.getInliers();
 
     if (inliers.size() < 3) {
       remaining_correspondences = original_correspondences;
@@ -133,7 +133,7 @@ CorrespondenceRejectorSampleConsensus<PointT>::getRemainingCorrespondences(
     }
 
     // get the best transformation
-    Eigen::VectorXf model_coefficients = sac.getModelCoefficients();
+    const Eigen::VectorXf& model_coefficients = sac.getModelCoefficients();
     best_transformation_.row(0) = model_coefficients.segment<4>(0);
     best_transformation_.row(1) = model_coefficients.segment<4>(4);
     best_transformation_.row(2) = model_coefficients.segment<4>(8);

--- a/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus_2d.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus_2d.hpp
@@ -110,8 +110,7 @@ CorrespondenceRejectorSampleConsensus2D<PointT>::getRemainingCorrespondences(
         "[pcl::registration::%s::getRemainingCorrespondences] Error refining model!\n",
         getClassName().c_str());
 
-  pcl::Indices inliers;
-  sac.getInliers(inliers);
+  const auto inliers = sac.getInliers();
 
   if (inliers.size() < 3) {
     PCL_ERROR("[pcl::registration::%s::getRemainingCorrespondences] Less than 3 "
@@ -131,9 +130,8 @@ CorrespondenceRejectorSampleConsensus2D<PointT>::getRemainingCorrespondences(
     remaining_correspondences[i] =
         original_correspondences[index_to_correspondence[inliers[i]]];
 
-  // get best transformation
-  Eigen::VectorXf model_coefficients;
-  sac.getModelCoefficients(model_coefficients);
+  // get the best transformation
+  Eigen::VectorXf model_coefficients = sac.getModelCoefficients();
   best_transformation_.row(0) = model_coefficients.segment<4>(0);
   best_transformation_.row(1) = model_coefficients.segment<4>(4);
   best_transformation_.row(2) = model_coefficients.segment<4>(8);

--- a/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus_2d.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_rejection_sample_consensus_2d.hpp
@@ -110,7 +110,7 @@ CorrespondenceRejectorSampleConsensus2D<PointT>::getRemainingCorrespondences(
         "[pcl::registration::%s::getRemainingCorrespondences] Error refining model!\n",
         getClassName().c_str());
 
-  const auto inliers = sac.getInliers();
+  const auto& inliers = sac.getInliers();
 
   if (inliers.size() < 3) {
     PCL_ERROR("[pcl::registration::%s::getRemainingCorrespondences] Less than 3 "
@@ -131,7 +131,7 @@ CorrespondenceRejectorSampleConsensus2D<PointT>::getRemainingCorrespondences(
         original_correspondences[index_to_correspondence[inliers[i]]];
 
   // get the best transformation
-  Eigen::VectorXf model_coefficients = sac.getModelCoefficients();
+  const Eigen::VectorXf& model_coefficients = sac.getModelCoefficients();
   best_transformation_.row(0) = model_coefficients.segment<4>(0);
   best_transformation_.row(1) = model_coefficients.segment<4>(4);
   best_transformation_.row(2) = model_coefficients.segment<4>(8);

--- a/sample_consensus/include/pcl/sample_consensus/sac.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac.h
@@ -310,15 +310,13 @@ namespace pcl
       inline const Indices&
       getModel() const {return model_;  }
 
-      /** \brief Return the model coefficients of the best model found so far.
+      /** \brief Return the best set of inliers found so far for this model.
         * \param[out] inliers the resultant set of inliers
         */
       inline void 
       getInliers (Indices &inliers) const { inliers = inliers_; }
 
-      /**
-       *
-       * \brief Return the model coefficients of the best model found so far.
+      /** \brief Return the best set of inliers found so far for this model.
        * \return the resultant set of inliers
        */
       inline const Indices&

--- a/sample_consensus/include/pcl/sample_consensus/sac.h
+++ b/sample_consensus/include/pcl/sample_consensus/sac.h
@@ -303,17 +303,39 @@ namespace pcl
       inline void 
       getModel (Indices &model) const { model = model_; }
 
-      /** \brief Return the best set of inliers found so far for this model. 
+      /**
+       * \brief Return the best model found so far.
+       * \return the resultant model
+       */
+      inline const Indices&
+      getModel() const {return model_;  }
+
+      /** \brief Return the model coefficients of the best model found so far.
         * \param[out] inliers the resultant set of inliers
         */
       inline void 
       getInliers (Indices &inliers) const { inliers = inliers_; }
+
+      /**
+       *
+       * \brief Return the model coefficients of the best model found so far.
+       * \return the resultant set of inliers
+       */
+      inline const Indices&
+      getInliers() const {return inliers_;  }
 
       /** \brief Return the model coefficients of the best model found so far. 
         * \param[out] model_coefficients the resultant model coefficients, as documented in \ref sample_consensus
         */
       inline void 
       getModelCoefficients (Eigen::VectorXf &model_coefficients) const { model_coefficients = model_coefficients_; }
+
+      /**
+       * \brief Return the model coefficients of the best model found so far.
+       * \return the resultant model coefficients
+       */
+      inline const Eigen::VectorXf&
+      getModelCoefficients() const {return model_coefficients_;  }
 
     protected:
       /** \brief The underlying data model used (i.e. what is it that we attempt to search for). */

--- a/segmentation/include/pcl/segmentation/impl/cpc_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/cpc_segmentation.hpp
@@ -159,12 +159,11 @@ pcl::CPCSegmentation<PointT>::applyCuttingPlane (std::uint32_t depth_levels_left
       continue;
     }
 
-    Eigen::VectorXf model_coefficients;
-    weight_sac.getModelCoefficients (model_coefficients);
+    Eigen::VectorXf model_coefficients = weight_sac.getModelCoefficients ();
 
     model_coefficients[3] += std::numeric_limits<float>::epsilon ();    
 
-    weight_sac.getInliers (*support_indices);
+    *support_indices = weight_sac.getInliers ();
 
     // the support_indices which are actually cut (if not locally constrain:  cut_support_indices = support_indices
     pcl::Indices cut_support_indices;

--- a/segmentation/include/pcl/segmentation/impl/sac_segmentation.hpp
+++ b/segmentation/include/pcl/segmentation/impl/sac_segmentation.hpp
@@ -108,11 +108,10 @@ pcl::SACSegmentation<PointT>::segment (PointIndices &inliers, ModelCoefficients 
   }
 
   // Get the model inliers
-  sac_->getInliers (inliers.indices);
+  inliers.indices = sac_->getInliers ();
 
   // Get the model coefficients
-  Eigen::VectorXf coeff (model_->getModelSize ());
-  sac_->getModelCoefficients (coeff);
+  Eigen::VectorXf coeff = sac_->getModelCoefficients ();
 
   // If the user needs optimized coefficients
   if (optimize_coefficients_)

--- a/tools/sac_segmentation_plane.cpp
+++ b/tools/sac_segmentation_plane.cpp
@@ -109,11 +109,9 @@ compute (const pcl::PCLPointCloud2::ConstPtr &input, pcl::PCLPointCloud2 &output
   RandomSampleConsensus<PointXYZ> sac (model, threshold);
   sac.setMaxIterations (max_iterations);
   bool res = sac.computeModel ();
-  
-  pcl::Indices inliers;
-  sac.getInliers (inliers);
-  Eigen::VectorXf coefficients;
-  sac.getModelCoefficients (coefficients);
+
+  auto inliers = sac.getInliers ();
+  Eigen::VectorXf coefficients = sac.getModelCoefficients ();
 
   if (!res || inliers.empty ())
   {
@@ -121,8 +119,8 @@ compute (const pcl::PCLPointCloud2::ConstPtr &input, pcl::PCLPointCloud2 &output
     return;
   }
   sac.refineModel (2, 50);
-  sac.getInliers (inliers);
-  sac.getModelCoefficients (coefficients);
+  inliers = sac.getInliers ();
+  coefficients = sac.getModelCoefficients ();
 
   print_info ("[done, "); print_value ("%g", tt.toc ()); print_info (" ms, plane has : "); print_value ("%lu", inliers.size ()); print_info (" points]\n");
 

--- a/tools/sac_segmentation_plane.cpp
+++ b/tools/sac_segmentation_plane.cpp
@@ -110,8 +110,8 @@ compute (const pcl::PCLPointCloud2::ConstPtr &input, pcl::PCLPointCloud2 &output
   sac.setMaxIterations (max_iterations);
   bool res = sac.computeModel ();
 
-  auto inliers = sac.getInliers ();
-  Eigen::VectorXf coefficients = sac.getModelCoefficients ();
+  const auto& inliers = sac.getInliers ();
+  const auto& coefficients = sac.getModelCoefficients ();
 
   if (!res || inliers.empty ())
   {

--- a/tools/sac_segmentation_plane.cpp
+++ b/tools/sac_segmentation_plane.cpp
@@ -110,8 +110,8 @@ compute (const pcl::PCLPointCloud2::ConstPtr &input, pcl::PCLPointCloud2 &output
   sac.setMaxIterations (max_iterations);
   bool res = sac.computeModel ();
 
-  const auto& inliers = sac.getInliers ();
-  const auto& coefficients = sac.getModelCoefficients ();
+  auto inliers = sac.getInliers ();
+  Eigen::VectorXf coefficients = sac.getModelCoefficients ();
 
   if (!res || inliers.empty ())
   {


### PR DESCRIPTION
Adding new methods to `SampleConsensus` so `getInliers`, `getModel` and `getModelCoefficients` return a const reference. 
Usages within PCL has been replaced.