### PR TITLE
Re-add instantiation of Convolution for MSVC

### DIFF
--- a/filters/src/convolution.cpp
+++ b/filters/src/convolution.cpp
@@ -189,5 +189,20 @@ Convolution<pcl::RGB, pcl::RGB>::convolveOneColDense(int i, int j)
   result.b = static_cast<std::uint8_t>(b);
   return (result);
 }
+
+#ifdef _MSC_VER
+// Seems to be necessary with MSVC, but not necessary with other compilers (even produces warning with PCL_SYMBOL_VISIBILITY_HIDDEN and gcc)
+#ifndef PCL_NO_PRECOMPILE
+#include <pcl/impl/instantiate.hpp>
+#include <pcl/point_types.h>
+
+PCL_INSTANTIATE_PRODUCT(
+    Convolution, ((pcl::RGB))((pcl::RGB)))
+
+PCL_INSTANTIATE_PRODUCT(
+    Convolution, ((pcl::PointXYZRGB))((pcl::PointXYZRGB)))
+#endif // PCL_NO_PRECOMPILE
+#endif // _MSC_VER
+
 } // namespace filters
 } // namespace pcl


### PR DESCRIPTION
Partially reverting https://github.com/PointCloudLibrary/pcl/commit/1092d70e5bd2333d3f63a8ab6b904e8ba6fcc34a 
With MSVC, building the app pcl_convolve fails for static builds without these instantiations. With gcc and clang, these instantiations do not seem to be necessary, and with gcc they even produce a warning when building with default-hidden-visibility. So we only do the explicit instantiations when compiling with MSVC.

See also https://github.com/microsoft/vcpkg/pull/46378/files#diff-5fe93e814fe39547c696f5fbeabd7a655bf6d33e9be3a9a551a6114c8d6aee14
and https://github.com/PointCloudLibrary/pcl/commit/1092d70e5bd2333d3f63a8ab6b904e8ba6fcc34a#r162020986