### PR TITLE
Cleanup gpu fpfh and remove unnecessary headers

### DIFF
--- a/gpu/features/src/fpfh.cu
+++ b/gpu/features/src/fpfh.cu
@@ -44,6 +44,10 @@
 using namespace pcl::gpu;
 using namespace pcl::device;
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846f
+#endif
+
 namespace pcl
 {
     namespace device

--- a/gpu/features/src/fpfh.cu
+++ b/gpu/features/src/fpfh.cu
@@ -39,18 +39,10 @@
 #include "pcl/gpu/utils/safe_call.hpp"
 #include "pcl/gpu/utils/device/warp.hpp"
 #include "pcl/gpu/utils/device/functional.hpp"
-#include "pcl/gpu/utils/device/funcattrib.hpp"
-#include "pcl/gpu/utils/timers_cuda.hpp"
 #include "pcl/gpu/features/device/pair_features.hpp"
-
-#include <iostream>
 
 using namespace pcl::gpu;
 using namespace pcl::device;
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846f
-#endif
 
 namespace pcl
 {
@@ -124,7 +116,7 @@ namespace pcl
 
                 float hist_incr = 100.f / (float)(size - 1); // or 100/(size - 1) ???
 
-                //now [inds, inds + size) contains indices of neighb points for idx-th point in cloud
+                //now [inds, inds + size) contains indices of neighboring points for idx-th point in cloud
                 //this list also contains idx itseelf.               
 
                 for(int i = lane; i < size; i += Warp::STRIDE)


### PR DESCRIPTION
This cleans up some unnecessary headers.

This was tested on Ubuntu 24.04, successfully building and running.