### PR TITLE
Fix deprecated vsprintf warning in SVM implementation

### DIFF
--- a/ml/src/svm.cpp
+++ b/ml/src/svm.cpp
@@ -124,7 +124,7 @@ info(const char* fmt, ...)
   char buf[BUFSIZ];
   va_list ap;
   va_start(ap, fmt);
-  vsprintf(buf, fmt, ap);
+  vsnprintf(buf, BUFSIZ, fmt, ap);
   va_end(ap);
   (*svm_print_string)(buf);
 }


### PR DESCRIPTION
During compilation on macOS (15.5, on M4), the build process generated a deprecation warning for vsprintf in ml/src/svm.cpp. 

```
open/pcl/ml/src/svm.cpp:127:3: warning: 'vsprintf' is deprecated: This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use vsnprintf(3) instead. [-Wdeprecated-declarations]
  127 |   vsprintf(buf, fmt, ap);
      |   ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/_stdio.h:298:1: note: 'vsprintf' has been explicitly marked deprecated here
  298 | __deprecated_msg("This function is provided for compatibility reasons only.  Due to security concerns inherent in the design of sprintf(3), it is highly recommended that you use vsnprintf(3) instead.")
      | ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/sys/cdefs.h:218:48: note: expanded from macro '__deprecated_msg'
  218 |         #define __deprecated_msg(_msg) __attribute__((__deprecated__(_msg)))
      |                                                       ^
1 warning generated.
```

The warning indicated that vsprintf is deprecated due to security concerns and recommended using vsnprintf instead, and this PR fixed it.