### PR TITLE
Optimization for Octree radiusSearch

### DIFF
--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -398,13 +398,9 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
       else {
         // we reached leaf node level
         const auto* child_leaf = static_cast<const LeafNode*>(child_node);
-        Indices decoded_point_vector;
 
-        // decode leaf node into decoded_point_vector
-        (*child_leaf)->getPointIndices(decoded_point_vector);
-
-        // Linearly iterate over all decoded (unsorted) points
-        for (const auto& index : decoded_point_vector) {
+        // Linearly iterate over all points in the leaf
+        for (const auto& index : (*child_leaf)->getPointIndicesVector()) {
           const PointT& candidate_point = this->getPointByIndex(index);
 
           // calculate point distance to search point

--- a/octree/include/pcl/octree/octree_container.h
+++ b/octree/include/pcl/octree/octree_container.h
@@ -324,6 +324,16 @@ public:
     return leafDataTVector_;
   }
 
+  /** \brief Retrieve const reference to point indices vector. This container stores a
+   * vector of point indices.
+   * \return const reference to vector of point indices to be stored within data vector
+   */
+  const pcl::Indices&
+  getPointIndicesVector() const
+  {
+    return leafDataTVector_;
+  }
+
   /** \brief Get size of container (number of indices)
    * \return number of point indices in container.
    */


### PR DESCRIPTION
Avoid copying point indices, achieves a speed advantage, especially if search radius is large