### PR TITLE
Fix uninitialized build warning

### DIFF
--- a/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
+++ b/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
@@ -188,7 +188,7 @@ pcl::features::ISMVoteList<PointT>::findStrongestPeaks (
       }
     }
 
-    if( peak_counter == 0 )
+    if( best_density == -1.0 || strongest_peak == Eigen::Vector3f::Constant (-1) || best_peak_ind == -1 || peak_counter == 0 )
       break;// no peaks
 
     pcl::ISMPeak peak;

--- a/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
+++ b/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
@@ -188,7 +188,8 @@ pcl::features::ISMVoteList<PointT>::findStrongestPeaks (
       }
     }
 
-    if( best_density == -1.0 || strongest_peak == Eigen::Vector3f::Constant (-1) || best_peak_ind == -1 || peak_counter == 0 )
+    if( best_density == -1.0 || strongest_peak == Eigen::Vector3f::Constant (-1) ||
+        best_peak_ind == -1 || peak_counter == 0 )
       break;// no peaks
 
     pcl::ISMPeak peak;

--- a/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
+++ b/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
@@ -171,7 +171,7 @@ pcl::features::ISMVoteList<PointT>::findStrongestPeaks (
   {
     // find best peak with taking into consideration peak flags
     double best_density = -1.0;
-    Eigen::Vector3f strongest_peak;
+    Eigen::Vector3f strongest_peak = Eigen::Vector3f::Constant (-1);
     int best_peak_ind (-1);
     int peak_counter (0);
     for (int i = 0; i < NUM_INIT_PTS; i++)


### PR DESCRIPTION
```
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
```

```
In file included from /home/mithridat/Downloads/pcl/recognition/src/implicit_shape_model.cpp:43:
/home/mithridat/Downloads/pcl/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp: In member function ‘void pcl::features::ISMVoteList<PointT>::findStrongestPeaks(std::vector<pcl::ISMPeak, Eigen::aligned_allocator<pcl::ISMPeak> >&, int, double, double) [with PointT = pcl::PointXYZ]’:
/home/mithridat/Downloads/pcl/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp:174:21: warning: ‘*(float*)((char*)&strongest_peak + offsetof(Eigen::Vector3f, Eigen::Matrix<float, 3, 1, 0, 3, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<float, 3, 1, 0, 3, 1> >::<unnamed>.Eigen::MatrixBase<Eigen::Matrix<float, 3, 1, 0, 3, 1> >::<unnamed>.Eigen::DenseBase<Eigen::Matrix<float, 3, 1, 0, 3, 1> >::<unnamed>.Eigen::DenseCoeffsBase<Eigen::Matrix<float, 3, 1, 0, 3, 1>, 3>::<unnamed>.Eigen::DenseCoeffsBase<Eigen::Matrix<float, 3, 1, 0, 3, 1>, 1>::<unnamed>.Eigen::DenseCoeffsBase<Eigen::Matrix<float, 3, 1, 0, 3, 1>, 0>::<unnamed>))’ may be used uninitialized [-Wmaybe-uninitialized]
  174 |     Eigen::Vector3f strongest_peak;
      |                     ^~~~~~~~~~~~~~
/home/mithridat/Downloads/pcl/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp:174:21: warning: ‘strongest_peak.Eigen::Matrix<float, 3, 1, 0, 3, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<float, 3, 1, 0, 3, 1> >::m_storage.Eigen::DenseStorage<float, 3, 3, 1, 0>::m_data.Eigen::internal::plain_array<float, 3, 0, 0>::array[1]’ may be used uninitialized [-Wmaybe-uninitialized]
```