### PR TITLE
Remove an unused cufft.h include

### DIFF
--- a/cuda/common/include/pcl/cuda/cutil.h
+++ b/cuda/common/include/pcl/cuda/cutil.h
@@ -786,14 +786,6 @@ extern "C" {
                 __FILE__, __LINE__, cudaGetErrorString( err) );              \
     } }
 
-#  define CUFFT_SAFE_CALL( call) {                                           \
-    cufftResult err = call;                                                  \
-    if( CUFFT_SUCCESS != err) {                                              \
-        fprintf(stderr, "CUFFT error in file '%s' in line %i.\n",            \
-                __FILE__, __LINE__);                                         \
-        exit(EXIT_FAILURE);                                                  \
-    } }
-
 #  define CUT_SAFE_CALL( call)                                               \
     if( CUTTrue != call) {                                                   \
         fprintf(stderr, "Cut error in file '%s' in line %i.\n",              \

--- a/cuda/common/include/pcl/cuda/cutil_inline_runtime.h
+++ b/cuda/common/include/pcl/cuda/cutil_inline_runtime.h
@@ -25,14 +25,11 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include <cufft.h>
-
 // We define these calls here, so the user doesn't need to include __FILE__ and __LINE__
 // The advantage is the developers gets to use the inline function so they can debug
 #define cutilSafeCallNoSync(err)     __cudaSafeCallNoSync(err, __FILE__, __LINE__)
 #define cutilSafeCall(err)           __cudaSafeCall      (err, __FILE__, __LINE__)
 #define cutilSafeThreadSync()        __cudaSafeThreadSync(__FILE__, __LINE__)
-#define cufftSafeCall(err)           __cufftSafeCall     (err, __FILE__, __LINE__)
 #define cutilCheckError(err)         __cutilCheckError   (err, __FILE__, __LINE__)
 #define cutilCheckMsg(msg)           __cutilGetLastError (msg, __FILE__, __LINE__)
 #define cutilCheckMsgAndSync(msg)    __cutilGetLastErrorAndSync (msg, __FILE__, __LINE__)
@@ -270,15 +267,6 @@ inline void __cudaSafeThreadSync( const char *file, const int line )
     if ( cudaSuccess != err) {
         FPRINTF((stderr, "%s(%i) : cudaDeviceSynchronize() Runtime API error : %s.\n",
                 file, line, cudaGetErrorString( err) ));
-        exit(-1);
-    }
-}
-
-inline void __cufftSafeCall( cufftResult err, const char *file, const int line )
-{
-    if( CUFFT_SUCCESS != err) {
-        FPRINTF((stderr, "%s(%i) : cufftSafeCall() CUFFT error.\n",
-                file, line));
         exit(-1);
     }
 }


### PR DESCRIPTION
`cutil.h` and `cutil_inline_runtime.h` add an include for cufft.h and introduce cuFFT-specific utility macros, but neither is actually used anywhere in the code.

While cuFFT usually comes installed with the rest of the CUDA Toolkit, I'm in the process of setting up modularized CUDA Toolkit packaging on top of Conan, where cuFFT would be downloaded as an individual package, weighing around 350 MB. It would be great if that unnecessary dependency could be avoided without having to patch the source code. :slightly_smiling_face: 