### PR TITLE
Reduce dependency on FLANN, move towards nanoflann as default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,10 +352,11 @@ if(NOT EIGEN3_FOUND AND Eigen3_FOUND)
 endif()
 
 # FLANN
-find_package(FLANN 1.9.1)
+find_package(FLANN 1.9.1)#TODO comment out?
 if(NOT FLANN_FOUND)
   message(WARNING "Flann was not found, so many PCL modules will not be built!")
 else()
+  set(PCL_HAS_FLANN 1)
   if(NOT (${FLANN_LIBRARY_TYPE} MATCHES ${PCL_FLANN_REQUIRED_TYPE}) AND NOT (${PCL_FLANN_REQUIRED_TYPE} MATCHES "DONTCARE"))
     message(FATAL_ERROR "Flann was selected with ${PCL_FLANN_REQUIRED_TYPE} but found as ${FLANN_LIBRARY_TYPE}")
   endif()

--- a/apps/include/pcl/apps/vfh_nn_classifier.h
+++ b/apps/include/pcl/apps/vfh_nn_classifier.h
@@ -43,6 +43,7 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/PCLPointCloud2.h>
 #include <pcl/point_types.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 #include <fstream>
 

--- a/apps/src/pyramid_surface_matching.cpp
+++ b/apps/src/pyramid_surface_matching.cpp
@@ -3,6 +3,7 @@
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/registration/pyramid_feature_matching.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 

--- a/examples/features/example_difference_of_normals.cpp
+++ b/examples/features/example_difference_of_normals.cpp
@@ -13,6 +13,7 @@
 #include <pcl/filters/conditional_removal.h>
 #include <pcl/segmentation/extract_clusters.h>
 #include <pcl/filters/voxel_grid.h>
+#include <pcl/search/organized.h> // for OrganizedNeighbor
 
 #include <pcl/features/don.h>
 

--- a/examples/features/example_fast_point_feature_histograms.cpp
+++ b/examples/features/example_fast_point_feature_histograms.cpp
@@ -42,6 +42,7 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/features/fpfh.h>
 #include <pcl/features/normal_3d.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 int
 main (int argc, char** argv)

--- a/examples/features/example_normal_estimation.cpp
+++ b/examples/features/example_normal_estimation.cpp
@@ -62,10 +62,7 @@ main (int, char** argv)
   pcl::NormalEstimation<pcl::PointXYZ, pcl::Normal> normal_estimation;
   normal_estimation.setInputCloud (cloud);
 
-  // Create an empty kdtree representation, and pass it to the normal estimation object.
-  // Its content will be filled inside the object, based on the given input dataset (as no other search surface is given).
-  pcl::search::KdTree<pcl::PointXYZ>::Ptr tree (new pcl::search::KdTree<pcl::PointXYZ>);
-  normal_estimation.setSearchMethod (tree);
+  // We could call normal_estimation.setSearchMethod (...); with a manually created search object here, but instead we let the NormalEstimation class decide
 
   // Output datasets
   pcl::PointCloud<pcl::Normal>::Ptr cloud_normals (new pcl::PointCloud<pcl::Normal>);

--- a/examples/features/example_point_feature_histograms.cpp
+++ b/examples/features/example_point_feature_histograms.cpp
@@ -42,6 +42,7 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/features/pfh.h>
 #include <pcl/features/normal_3d.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 int
 main (int, char** argv)

--- a/examples/features/example_principal_curvatures_estimation.cpp
+++ b/examples/features/example_principal_curvatures_estimation.cpp
@@ -42,6 +42,7 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/features/principal_curvatures.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 int
 main (int, char** argv)

--- a/examples/features/example_rift_estimation.cpp
+++ b/examples/features/example_rift_estimation.cpp
@@ -44,6 +44,7 @@
 #include <pcl/features/normal_3d.h>
 #include <pcl/features/rift.h>
 #include <pcl/features/intensity_gradient.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 int
 main (int, char** argv)

--- a/examples/features/example_shape_contexts.cpp
+++ b/examples/features/example_shape_contexts.cpp
@@ -42,6 +42,7 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/features/3dsc.h>
 #include <pcl/features/normal_3d.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 int
 main (int, char** argv)

--- a/examples/features/example_spin_images.cpp
+++ b/examples/features/example_spin_images.cpp
@@ -42,6 +42,7 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/features/spin_image.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 int
 main (int, char** argv)

--- a/examples/segmentation/example_region_growing.cpp
+++ b/examples/segmentation/example_region_growing.cpp
@@ -45,6 +45,7 @@
 #include <pcl/segmentation/region_growing.h>
 #include <pcl/common/time.h>
 #include <pcl/console/parse.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 int
 main (int argc, char** av)

--- a/features/include/pcl/features/impl/feature.hpp
+++ b/features/include/pcl/features/impl/feature.hpp
@@ -41,8 +41,8 @@
 #ifndef PCL_FEATURES_IMPL_FEATURE_H_
 #define PCL_FEATURES_IMPL_FEATURE_H_
 
-#include <pcl/search/kdtree.h> // for KdTree
-#include <pcl/search/organized.h> // for OrganizedNeighbor
+#include <pcl/common/eigen.h> // for eigen33
+#include <pcl/search/auto.h> // for autoSelectMethod
 
 
 namespace pcl
@@ -119,14 +119,15 @@ Feature<PointInT, PointOutT>::initCompute ()
   // Check if a space search locator was given
   if (!tree_)
   {
-    if (surface_->isOrganized () && input_->isOrganized ()) {
-      tree_.reset (new pcl::search::OrganizedNeighbor<PointInT> ());
-      if(!tree_->setInputCloud (surface_)) { // may return false if OrganizedNeighbor cannot work with the cloud, then use KdTree instead
-        tree_.reset (new pcl::search::KdTree<PointInT> (false));
-      }
-    } else {
-      tree_.reset (new pcl::search::KdTree<PointInT> (false));
-    }
+    //if (surface_->isOrganized () && input_->isOrganized ()) {
+    //  tree_.reset (new pcl::search::OrganizedNeighbor<PointInT> ());
+    //  if(!tree_->setInputCloud (surface_)) { // may return false if OrganizedNeighbor cannot work with the cloud, then use KdTree instead
+    //    tree_.reset (new pcl::search::KdTree<PointInT> (false));
+    //  }
+    //} else {
+    //  tree_.reset (new pcl::search::KdTree<PointInT> (false));
+    //}
+    tree_.reset (pcl::search::autoSelectMethod<PointInT>(surface_, false));
   }
 
   if (tree_->getInputCloud () != surface_) { // Make sure the tree searches the surface

--- a/filters/include/pcl/filters/impl/bilateral.hpp
+++ b/filters/include/pcl/filters/impl/bilateral.hpp
@@ -41,8 +41,7 @@
 #define PCL_FILTERS_BILATERAL_IMPL_H_
 
 #include <pcl/filters/bilateral.h>
-#include <pcl/search/organized.h> // for OrganizedNeighbor
-#include <pcl/search/kdtree.h> // for KdTree
+#include <pcl/search/auto.h> // for autoSelectMethod
 #include <pcl/common/point_tests.h> // for isXYZFinite
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -84,14 +83,12 @@ pcl::BilateralFilter<PointT>::applyFilter (PointCloud &output)
   // In case a search method has not been given, initialize it using some defaults
   if (!tree_)
   {
-    // For organized datasets, use an OrganizedNeighbor
-    if (input_->isOrganized ())
-      tree_.reset (new pcl::search::OrganizedNeighbor<PointT> ());
-    // For unorganized data, use a FLANN kdtree
-    else
-      tree_.reset (new pcl::search::KdTree<PointT> (false));
+    tree_.reset (pcl::search::autoSelectMethod<PointT>(input_, false, pcl::search::Purpose::radius_search));
   }
-  tree_->setInputCloud (input_);
+  else
+  {
+    tree_->setInputCloud (input_);
+  }
 
   Indices k_indices;
   std::vector<float> k_distances;

--- a/filters/include/pcl/filters/impl/convolution_3d.hpp
+++ b/filters/include/pcl/filters/impl/convolution_3d.hpp
@@ -41,8 +41,7 @@
 #define PCL_FILTERS_CONVOLUTION_3D_IMPL_HPP
 
 #include <pcl/common/point_tests.h> // for isFinite
-#include <pcl/search/organized.h>
-#include <pcl/search/kdtree.h>
+#include <pcl/search/auto.h> // for autoSelectMethod
 #include <pcl/pcl_config.h>
 #include <pcl/point_types.h>
 #include <pcl/common/point_tests.h>
@@ -195,10 +194,7 @@ pcl::filters::Convolution3D<PointInT, PointOutT, KernelT>::initCompute ()
   // Initialize the spatial locator
   if (!tree_)
   {
-    if (input_->isOrganized ())
-      tree_.reset (new pcl::search::OrganizedNeighbor<PointInT> ());
-    else
-      tree_.reset (new pcl::search::KdTree<PointInT> (false));
+    tree_.reset (pcl::search::autoSelectMethod<PointT>(input_, false, pcl::search::Purpose::radius_search)); // TODO input_ or surface_?
   }
   // If no search surface has been defined, use the input dataset as the search surface itself
   if (!surface_)

--- a/filters/include/pcl/filters/impl/local_maximum.hpp
+++ b/filters/include/pcl/filters/impl/local_maximum.hpp
@@ -46,8 +46,7 @@
 #include <pcl/filters/local_maximum.h>
 #include <pcl/filters/project_inliers.h>
 #include <pcl/ModelCoefficients.h>
-#include <pcl/search/organized.h> // for OrganizedNeighbor
-#include <pcl/search/kdtree.h> // for KdTree
+#include <pcl/search/auto.h> // for autoSelectMethod
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
@@ -92,12 +91,9 @@ pcl::LocalMaximum<PointT>::applyFilterIndices (Indices &indices)
   // Initialize the search class
   if (!searcher_)
   {
-    if (input_->isOrganized ())
-      searcher_.reset (new pcl::search::OrganizedNeighbor<PointT> ());
-    else
-      searcher_.reset (new pcl::search::KdTree<PointT> (false));
+    searcher_.reset (pcl::search::autoSelectMethod<PointT>(cloud_projected, false, pcl::search::Purpose::radius_search));
   }
-  if (!searcher_->setInputCloud (cloud_projected))
+  else if (!searcher_->setInputCloud (cloud_projected))
   {
     PCL_ERROR ("[pcl::%s::applyFilter] Error when initializing search method!\n", getClassName ().c_str ());
     indices.clear ();

--- a/filters/include/pcl/filters/impl/radius_outlier_removal.hpp
+++ b/filters/include/pcl/filters/impl/radius_outlier_removal.hpp
@@ -40,9 +40,9 @@
 #ifndef PCL_FILTERS_IMPL_RADIUS_OUTLIER_REMOVAL_H_
 #define PCL_FILTERS_IMPL_RADIUS_OUTLIER_REMOVAL_H_
 
+#include <pcl/common/point_tests.h> // for isXYZFinite
 #include <pcl/filters/radius_outlier_removal.h>
-#include <pcl/search/organized.h> // for OrganizedNeighbor
-#include <pcl/search/kdtree.h> // for KdTree
+#include <pcl/search/auto.h> // for autoSelectMethod
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
@@ -59,12 +59,9 @@ pcl::RadiusOutlierRemoval<PointT>::applyFilterIndices (Indices &indices)
   // Initialize the search class
   if (!searcher_)
   {
-    if (input_->isOrganized ())
-      searcher_.reset (new pcl::search::OrganizedNeighbor<PointT> ());
-    else
-      searcher_.reset (new pcl::search::KdTree<PointT> (false));
+    searcher_.reset (pcl::search::autoSelectMethod<PointT>(input_, false, input_->is_dense ? pcl::search::Purpose::many_knn_search : pcl::search::Purpose::radius_search));
   }
-  if (!searcher_->setInputCloud (input_))
+  else if (!searcher_->setInputCloud (input_))
   {
     PCL_ERROR ("[pcl::%s::applyFilter] Error when initializing search method!\n", getClassName ().c_str ());
     indices.clear ();

--- a/filters/include/pcl/filters/impl/statistical_outlier_removal.hpp
+++ b/filters/include/pcl/filters/impl/statistical_outlier_removal.hpp
@@ -41,8 +41,7 @@
 #define PCL_FILTERS_IMPL_STATISTICAL_OUTLIER_REMOVAL_H_
 
 #include <pcl/filters/statistical_outlier_removal.h>
-#include <pcl/search/organized.h> // for OrganizedNeighbor
-#include <pcl/search/kdtree.h> // for KdTree
+#include <pcl/search/auto.h> // for autoSelectMethod
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT> void
@@ -51,12 +50,9 @@ pcl::StatisticalOutlierRemoval<PointT>::applyFilterIndices (Indices &indices)
   // Initialize the search class
   if (!searcher_)
   {
-    if (input_->isOrganized ())
-      searcher_.reset (new pcl::search::OrganizedNeighbor<PointT> ());
-    else
-      searcher_.reset (new pcl::search::KdTree<PointT> (false));
+    searcher_.reset (pcl::search::autoSelectMethod<PointT>(input_, false, pcl::search::Purpose::many_knn_search));
   }
-  if (!searcher_->setInputCloud (input_))
+  else if (!searcher_->setInputCloud (input_))
   {
     PCL_ERROR ("[pcl::%s::applyFilter] Error when initializing search method!\n", getClassName ().c_str ());
     indices.clear ();

--- a/filters/include/pcl/filters/voxel_grid_covariance.h
+++ b/filters/include/pcl/filters/voxel_grid_covariance.h
@@ -40,7 +40,8 @@
 #include <pcl/filters/voxel_grid.h>
 #include <map>
 #include <pcl/point_types.h>
-#include <pcl/kdtree/kdtree_flann.h>
+#include <pcl/search/search.h>
+#include <pcl/search/auto.h> // for autoSelectMethod
 
 namespace pcl
 {
@@ -196,8 +197,7 @@ namespace pcl
        */
       VoxelGridCovariance () :
         leaves_ (),
-        voxel_centroids_ (),
-        kdtree_ ()
+        voxel_centroids_ ()
       {
         downsample_all_data_ = false;
         save_leaf_layout_ = false;
@@ -270,7 +270,7 @@ namespace pcl
             searchable_ = false;
           } else {
             // Initiates kdtree of the centroids of voxels containing a sufficient number of points
-            kdtree_.setInputCloud (voxel_centroids_);
+            kdtree_.reset (pcl::search::autoSelectMethod<PointT>(voxel_centroids_, false)); // TODO sorted or not?
           }
         }
       }
@@ -292,7 +292,7 @@ namespace pcl
             searchable_ = false;
           } else {
             // Initiates kdtree of the centroids of voxels containing a sufficient number of points
-            kdtree_.setInputCloud (voxel_centroids_);
+            kdtree_.reset (pcl::search::autoSelectMethod<PointT>(voxel_centroids_, false)); // TODO sorted or not?
           }
         }
       }
@@ -462,7 +462,7 @@ namespace pcl
 
         // Find k-nearest neighbors in the occupied voxel centroid cloud
         Indices k_indices (k);
-        k = kdtree_.nearestKSearch (point, k, k_indices, k_sqr_distances);
+        k = kdtree_->nearestKSearch (point, k, k_indices, k_sqr_distances);
 
         // Find leaves corresponding to neighbors
         k_leaves.reserve (k);
@@ -521,7 +521,7 @@ namespace pcl
 
         // Find neighbors within radius in the occupied voxel centroid cloud
         Indices k_indices;
-        const int k = kdtree_.radiusSearch (point, radius, k_indices, k_sqr_distances, max_nn);
+        const int k = kdtree_->radiusSearch (point, radius, k_indices, k_sqr_distances, max_nn);
 
         // Find leaves corresponding to neighbors
         k_leaves.reserve (k);
@@ -583,7 +583,8 @@ namespace pcl
       std::vector<int> voxel_centroids_leaf_indices_;
 
       /** \brief KdTree generated using \ref voxel_centroids_ (used for searching). */
-      KdTreeFLANN<PointT> kdtree_;
+      //KdTreeFLANN<PointT> kdtree_;
+      typename pcl::search::Search<PointT>::Ptr kdtree_;
   };
 }
 

--- a/filters/src/radius_outlier_removal.cpp
+++ b/filters/src/radius_outlier_removal.cpp
@@ -39,6 +39,7 @@
  */
 
 #include <pcl/filters/impl/radius_outlier_removal.hpp>
+#include <pcl/search/auto.h> // for autoSelectMethod
 #include <pcl/conversions.h>
 #include <pcl/memory.h>
 
@@ -72,13 +73,14 @@ pcl::RadiusOutlierRemoval<pcl::PCLPointCloud2>::applyFilter (PCLPointCloud2 &out
     if (cloud->isOrganized ())
     {
       PCL_DEBUG ("[pcl::%s::applyFilter] Cloud is organized, so using OrganizedNeighbor.\n", getClassName ().c_str ());
-      searcher_.reset (new pcl::search::OrganizedNeighbor<pcl::PointXYZ> ());
+      //searcher_.reset (new pcl::search::OrganizedNeighbor<pcl::PointXYZ> ());
     }
     else
     {
       PCL_DEBUG ("[pcl::%s::applyFilter] Cloud is not organized, so using KdTree.\n", getClassName ().c_str ());
-      searcher_.reset (new pcl::search::KdTree<pcl::PointXYZ> (false));
+      //searcher_.reset (new pcl::search::KdTree<pcl::PointXYZ> (false));
     }
+    searcher_.reset (pcl::search::autoSelectMethod<pcl::PointXYZ>(cloud, false));
   }
   searcher_->setInputCloud (cloud);
 
@@ -170,12 +172,12 @@ pcl::RadiusOutlierRemoval<pcl::PCLPointCloud2>::applyFilter (Indices &indices)
   // Initialize the search class
   if (!searcher_)
   {
-    if (cloud->isOrganized ())
-      searcher_.reset (new pcl::search::OrganizedNeighbor<pcl::PointXYZ> ());
-    else
-      searcher_.reset (new pcl::search::KdTree<pcl::PointXYZ> (false));
+    searcher_.reset (pcl::search::autoSelectMethod<pcl::PointXYZ>(cloud, false));
   }
-  searcher_->setInputCloud (cloud);
+  else
+  {
+    searcher_->setInputCloud (cloud);
+  }
 
   // The arrays to be used
   Indices nn_indices (indices_->size ());

--- a/filters/src/statistical_outlier_removal.cpp
+++ b/filters/src/statistical_outlier_removal.cpp
@@ -194,14 +194,9 @@ pcl::StatisticalOutlierRemoval<pcl::PCLPointCloud2>::generateStatistics (double&
 
   // Initialize the spatial locator
   if (!tree_)
-  {
-    if (cloud->isOrganized ())
-      tree_.reset (new pcl::search::OrganizedNeighbor<pcl::PointXYZ> ());
-    else
-      tree_.reset (new pcl::search::KdTree<pcl::PointXYZ> (false));
-  }
-
-  tree_->setInputCloud (cloud);
+    tree_.reset (pcl::search::autoSelectMethod<pcl::PointXYZ>(cloud, false, pcl::search::Purpose::many_knn_search));
+  else
+    tree_->setInputCloud (cloud);
 
   // Allocate enough space to hold the results
   Indices nn_indices (mean_k_);

--- a/kdtree/CMakeLists.txt
+++ b/kdtree/CMakeLists.txt
@@ -3,7 +3,7 @@ set(SUBSYS_DESC "Point cloud kd-tree library")
 set(SUBSYS_DEPS common)
 
 PCL_SUBSYS_OPTION(build "${SUBSYS_NAME}" "${SUBSYS_DESC}" ON)
-PCL_SUBSYS_DEPEND(build NAME ${SUBSYS_NAME} DEPS ${SUBSYS_DEPS} EXT_DEPS flann)
+PCL_SUBSYS_DEPEND(build NAME ${SUBSYS_NAME} DEPS ${SUBSYS_DEPS} OPT_DEPS flann)# EXT_DEPS flann)
 
 PCL_ADD_DOC("${SUBSYS_NAME}")
 
@@ -11,9 +11,11 @@ if(NOT build)
   return()
 endif()
 
-set(srcs
-  src/kdtree_flann.cpp
-)
+if(FLANN_FOUND)
+  set(srcs
+    src/kdtree_flann.cpp
+  )
+endif()
 
 set(incs
   "include/pcl/${SUBSYS_NAME}/kdtree.h"
@@ -27,9 +29,15 @@ set(impl_incs
 )
 
 set(LIB_NAME "pcl_${SUBSYS_NAME}")
-PCL_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs} ${impl_incs})
-target_link_libraries("${LIB_NAME}" pcl_common FLANN::FLANN)
-set(EXT_DEPS flann)
+if(FLANN_FOUND)
+  PCL_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs} ${impl_incs})
+  target_link_libraries("${LIB_NAME}" pcl_common)
+  target_link_libraries("${LIB_NAME}" FLANN::FLANN)
+  set(EXT_DEPS flann)
+else()
+  PCL_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} INCLUDES ${incs} ${impl_incs})
+  target_link_libraries("${LIB_NAME}" INTERFACE pcl_common)
+endif()
 PCL_MAKE_PKGCONFIG(${LIB_NAME} COMPONENT ${SUBSYS_NAME} DESC ${SUBSYS_DESC} PCL_DEPS ${SUBSYS_DEPS} EXT_DEPS ${EXT_DEPS})
 
 # Install include files

--- a/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
+++ b/kdtree/include/pcl/kdtree/impl/kdtree_flann.hpp
@@ -49,9 +49,8 @@ template <typename PointT, typename Dist>
 pcl::KdTreeFLANN<PointT, Dist>::KdTreeFLANN (bool sorted)
   : pcl::KdTree<PointT> (sorted)
   , flann_index_ ()
-  , 
-   param_k_ (::flann::SearchParams (-1 , epsilon_))
-  , param_radius_ (::flann::SearchParams (-1, epsilon_, sorted))
+  //, param_k_ (::flann::SearchParams (-1 , epsilon_))
+  //, param_radius_ (::flann::SearchParams (-1, epsilon_, sorted))
 {
   if (!std::is_same<std::size_t, pcl::index_t>::value) {
     const auto message = "FLANN is not optimized for current index type. Will incur "
@@ -70,9 +69,8 @@ template <typename PointT, typename Dist>
 pcl::KdTreeFLANN<PointT, Dist>::KdTreeFLANN (const KdTreeFLANN<PointT, Dist> &k)
   : pcl::KdTree<PointT> (false)
   , flann_index_ ()
-  , 
-   param_k_ (::flann::SearchParams (-1 , epsilon_))
-  , param_radius_ (::flann::SearchParams (-1, epsilon_, false))
+  //, param_k_ (::flann::SearchParams (-1 , epsilon_))
+  //, param_radius_ (::flann::SearchParams (-1, epsilon_, false))
 {
   *this = k;
 }
@@ -82,8 +80,8 @@ template <typename PointT, typename Dist> void
 pcl::KdTreeFLANN<PointT, Dist>::setEpsilon (float eps)
 {
   epsilon_ = eps;
-  param_k_ =  ::flann::SearchParams (-1 , epsilon_);
-  param_radius_ = ::flann::SearchParams (-1 , epsilon_, sorted_);
+  //param_k_ =  ::flann::SearchParams (-1 , epsilon_);
+  //param_radius_ = ::flann::SearchParams (-1 , epsilon_, sorted_);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -91,8 +89,8 @@ template <typename PointT, typename Dist> void
 pcl::KdTreeFLANN<PointT, Dist>::setSortedResults (bool sorted)
 {
   sorted_ = sorted;
-  param_k_ = ::flann::SearchParams (-1, epsilon_);
-  param_radius_ = ::flann::SearchParams (-1, epsilon_, sorted_);
+  //param_k_ = ::flann::SearchParams (-1, epsilon_);
+  //param_radius_ = ::flann::SearchParams (-1, epsilon_, sorted_);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////
@@ -253,12 +251,13 @@ pcl::KdTreeFLANN<PointT, Dist>::nearestKSearch (const PointT &point, unsigned in
   // Wrap the k_distances vector (no data copy)
   ::flann::Matrix<float> k_distances_mat (k_distances.data(), 1, k);
 
+  ::flann::SearchParams param_k (-1 , epsilon_);
   knn_search(*flann_index_,
              ::flann::Matrix<float>(query.data(), 1, dim_),
              k_indices,
              k_distances_mat,
              k,
-             param_k_);
+             param_k);
 
   // Do mapping to original point cloud
   if (!identity_mapping_)
@@ -384,7 +383,7 @@ pcl::KdTreeFLANN<PointT, Dist>::radiusSearch (const PointT &point, double radius
 
   std::vector<std::vector<float> > dists(1);
 
-  ::flann::SearchParams params (param_radius_);
+  ::flann::SearchParams params (-1, epsilon_, sorted_);//(param_radius_);
   if (max_nn == total_nr_points_)
     params.max_neighbors = -1;  // return all neighbors in radius
   else

--- a/kdtree/include/pcl/kdtree/kdtree_flann.h
+++ b/kdtree/include/pcl/kdtree/kdtree_flann.h
@@ -41,7 +41,7 @@
 #pragma once
 
 #include <pcl/kdtree/kdtree.h>
-#include <flann/util/params.h>
+//#include <flann/util/params.h> // TODO remove?
 
 #include <memory>
 
@@ -50,6 +50,36 @@ namespace flann
 {
   template <typename T> struct L2_Simple;
   template <typename T> class Index;
+  struct SearchParams;
+#if 0
+struct SearchParams
+{
+    SearchParams(int checks_ = 32, float eps_ = 0.0, bool sorted_ = true ) :
+    	checks(checks_), eps(eps_), sorted(sorted_)
+    {
+    	max_neighbors = -1;
+    	use_heap = FLANN_Undefined;
+    	cores = 1;
+    	matrices_in_gpu_ram = false;
+    }
+
+    // how many leafs to visit when searching for neighbours (-1 for unlimited)
+    int checks;
+    // search for eps-approximate neighbours (default: 0)
+    float eps;
+    // only for radius search, require neighbours sorted by distance (default: true)
+    bool sorted;
+    // maximum number of neighbors radius search should return (-1 for unlimited)
+    int max_neighbors;
+    // use a heap to manage the result set (default: FLANN_Undefined)
+    tri_type use_heap;
+    // how many cores to assign to the search (used only if compiled with OpenMP capable compiler) (0 for auto)
+    int cores;
+    // for GPU search indicates if matrices are already in GPU ram
+    bool matrices_in_gpu_ram;
+};
+
+#endif
 }
 
 namespace pcl
@@ -177,8 +207,8 @@ public:
     identity_mapping_ = k.identity_mapping_;
     dim_ = k.dim_;
     total_nr_points_ = k.total_nr_points_;
-    param_k_ = k.param_k_;
-    param_radius_ = k.param_radius_;
+    //param_k_ = k.param_k_;
+    //param_radius_ = k.param_radius_;
     return (*this);
   }
 
@@ -306,10 +336,10 @@ private:
   uindex_t total_nr_points_{0};
 
   /** \brief The KdTree search parameters for K-nearest neighbors. */
-  ::flann::SearchParams param_k_;
+  //std::shared_ptr<::flann::SearchParams> param_k_;
 
   /** \brief The KdTree search parameters for radius search. */
-  ::flann::SearchParams param_radius_;
+  //std::shared_ptr<::flann::SearchParams> param_radius_;
   };
 }
 

--- a/pcl_config.h.in
+++ b/pcl_config.h.in
@@ -53,6 +53,10 @@
 #cmakedefine PCL_HAS_NANOFLANN 1
 #endif
 
+#ifndef PCL_HAS_FLANN
+#cmakedefine PCL_HAS_FLANN 1
+#endif
+
 // SSE macros
 #cmakedefine HAVE_POSIX_MEMALIGN
 #cmakedefine HAVE_MM_MALLOC

--- a/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
+++ b/recognition/include/pcl/recognition/impl/implicit_shape_model.hpp
@@ -44,6 +44,7 @@
 #include "../implicit_shape_model.h"
 #include <pcl/filters/voxel_grid.h> // for VoxelGrid
 #include <pcl/filters/extract_indices.h> // for ExtractIndices
+#include <pcl/search/kdtree.h> // for KdTree
 
 #include <pcl/memory.h>  // for dynamic_pointer_cast
 

--- a/search/CMakeLists.txt
+++ b/search/CMakeLists.txt
@@ -3,7 +3,7 @@ set(SUBSYS_DESC "Point cloud generic search library")
 set(SUBSYS_DEPS common kdtree octree)
 
 PCL_SUBSYS_OPTION(build "${SUBSYS_NAME}" "${SUBSYS_DESC}" ON)
-PCL_SUBSYS_DEPEND(build NAME ${SUBSYS_NAME} DEPS ${SUBSYS_DEPS} EXT_DEPS flann)
+PCL_SUBSYS_DEPEND(build NAME ${SUBSYS_NAME} DEPS ${SUBSYS_DEPS} OPT_DEPS flann)# EXT_DEPS flann)
 
 PCL_ADD_DOC("${SUBSYS_NAME}")
 
@@ -12,14 +12,21 @@ if(NOT build)
 endif()
 
 set(srcs
+  src/auto.cpp
   src/search.cpp
-  src/kdtree.cpp
   src/brute_force.cpp
   src/organized.cpp
   src/octree.cpp
 )
 
+if(FLANN_FOUND)
+  list(APPEND srcs
+    src/kdtree.cpp
+  )
+endif()
+
 set(incs
+  "include/pcl/${SUBSYS_NAME}/auto.h"
   "include/pcl/${SUBSYS_NAME}/search.h"
   "include/pcl/${SUBSYS_NAME}/kdtree.h"
   "include/pcl/${SUBSYS_NAME}/kdtree_nanoflann.h"
@@ -40,8 +47,11 @@ set(impl_incs
 
 set(LIB_NAME "pcl_${SUBSYS_NAME}")
 PCL_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs} ${impl_incs})
-target_link_libraries("${LIB_NAME}" pcl_common FLANN::FLANN pcl_octree pcl_kdtree)
-list(APPEND EXT_DEPS flann)
+target_link_libraries("${LIB_NAME}" pcl_common pcl_octree pcl_kdtree)
+if(FLANN_FOUND)
+  target_link_libraries("${LIB_NAME}" FLANN::FLANN)
+  list(APPEND EXT_DEPS flann)
+endif()
 PCL_MAKE_PKGCONFIG(${LIB_NAME} COMPONENT ${SUBSYS_NAME} DESC ${SUBSYS_DESC} PCL_DEPS ${SUBSYS_DEPS})
 
 PCL_ADD_INCLUDES("${SUBSYS_NAME}" "${SUBSYS_NAME}" ${incs})

--- a/search/include/pcl/search/auto.h
+++ b/search/include/pcl/search/auto.h
@@ -1,0 +1,61 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2010-2011, Willow Garage, Inc.
+ *  Copyright (c) 2012-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#pragma once
+
+#include <pcl/point_cloud.h>
+#include <pcl/search/search.h>
+
+namespace pcl {
+  namespace search {
+    enum class Purpose : std::uint32_t {
+      undefined = 0, ///< Default value, for general-purpose search method
+      radius_search = 1, ///< The search method will mainly be used for radiusSearch
+      one_knn_search = 2, ///< The search method will mainly be used for nearestKSearch where k is 1
+      many_knn_search = 4 ///< The search method will mainly be used for nearestKSearch where k is larger than 1
+    };
+
+    /**
+      * Automatically select the fastest search method for the given point cloud. Make sure to delete the returned object after use! Distance function (euclidean?)
+      * \param[in] sorted_results Whether the search method should always return results sorted by distance (may be slower than unsorted)
+      * \param[in] purpose Optional, can be used to give more information about what this search method will be used for, to achieve optimal performance
+      */
+    template<typename PointT>
+    pcl::search::Search<PointT> * autoSelectMethod(const typename pcl::PointCloud<PointT>::ConstPtr& cloud, bool sorted_results, Purpose purpose = Purpose::undefined);
+  } // namespace search
+} // namespace pcl

--- a/search/src/auto.cpp
+++ b/search/src/auto.cpp
@@ -1,0 +1,74 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2012-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PCL_NO_PRECOMPILE
+#include <pcl/impl/instantiate.hpp>
+#include <pcl/point_types.h>
+
+#include <pcl/search/auto.h>
+#include <pcl/search/organized.h>
+#include <pcl/search/kdtree.h>
+#include <pcl/search/kdtree_nanoflann.h>
+
+template<typename PointT>
+pcl::search::Search<PointT> * pcl::search::autoSelectMethod(const typename pcl::PointCloud<PointT>::ConstPtr& cloud, bool sorted_results, pcl::search::Purpose purpose) { // TODO knn/radius/1knn search?
+  pcl::search::Search<PointT> * searcher = nullptr;
+  if (cloud->isOrganized ()) {
+    searcher = new pcl::search::OrganizedNeighbor<PointT> (sorted_results);
+    if(searcher->setInputCloud (cloud)) { // may return false if OrganizedNeighbor cannot work with the cloud, then use KdTree instead
+      return searcher;
+    }
+  }
+#if PCL_HAS_NANOFLANN
+  searcher = new pcl::search::KdTreeNanoflann<PointT> (sorted_results, (purpose == pcl::search::Purpose::one_knn_search ? 10 : 20));
+  if(searcher->setInputCloud (cloud)) {
+    return searcher;
+  }
+#endif
+#if PCL_HAS_FLANN
+  searcher = new pcl::search::KdTree<PointT> (sorted_results);
+  if(searcher->setInputCloud (cloud)) {
+    return searcher;
+  }
+#endif
+  return searcher; // TODO should this guarantee to call setInputCloud on searcher?
+}
+
+#define PCL_INSTANTIATE_AutoSelectMethod(T) template pcl::search::Search<T> * pcl::search::autoSelectMethod<T>(const typename pcl::PointCloud<T>::ConstPtr& cloud, bool sorted_results, pcl::search::Purpose purpose);
+PCL_INSTANTIATE(AutoSelectMethod, PCL_XYZ_POINT_TYPES)
+#endif    // PCL_NO_PRECOMPILE
+

--- a/segmentation/CMakeLists.txt
+++ b/segmentation/CMakeLists.txt
@@ -24,7 +24,6 @@ set(srcs
   src/organized_multi_plane_segmentation.cpp
   src/planar_polygon_fusion.cpp
   src/crf_segmentation.cpp
-  src/unary_classifier.cpp
   src/conditional_euclidean_clustering.cpp
   src/supervoxel_clustering.cpp
   src/grabcut_segmentation.cpp
@@ -60,7 +59,6 @@ set(incs
   "include/pcl/${SUBSYS_NAME}/planar_polygon_fusion.h"
   "include/pcl/${SUBSYS_NAME}/crf_segmentation.h"
   "include/pcl/${SUBSYS_NAME}/crf_normal_segmentation.h"
-  "include/pcl/${SUBSYS_NAME}/unary_classifier.h"
   "include/pcl/${SUBSYS_NAME}/conditional_euclidean_clustering.h"
   "include/pcl/${SUBSYS_NAME}/supervoxel_clustering.h"
   "include/pcl/${SUBSYS_NAME}/grabcut_segmentation.h"
@@ -85,7 +83,6 @@ set(impl_incs
   "include/pcl/${SUBSYS_NAME}/impl/organized_multi_plane_segmentation.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/planar_polygon_fusion.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/crf_segmentation.hpp"
-  "include/pcl/${SUBSYS_NAME}/impl/unary_classifier.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/crf_normal_segmentation.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/conditional_euclidean_clustering.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/supervoxel_clustering.hpp"
@@ -95,6 +92,12 @@ set(impl_incs
   "include/pcl/${SUBSYS_NAME}/impl/lccp_segmentation.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/cpc_segmentation.hpp"
 )
+
+if(FLANN_FOUND)
+  set(srcs src/unary_classifier.cpp)
+  set(incs "include/pcl/${SUBSYS_NAME}/unary_classifier.h")
+  set(impl_incs "include/pcl/${SUBSYS_NAME}/impl/unary_classifier.hpp")
+endif()
 
 set(LIB_NAME "pcl_${SUBSYS_NAME}")
 PCL_ADD_LIBRARY(${LIB_NAME} COMPONENT ${SUBSYS_NAME} SOURCES ${srcs} ${incs} ${impl_incs})

--- a/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
+++ b/segmentation/include/pcl/segmentation/impl/supervoxel_clustering.hpp
@@ -381,7 +381,7 @@ pcl::SupervoxelClustering<PointT>::selectInitialSupervoxelSeeds (Indices &seed_i
   distance.resize(1,0);
   if (!voxel_kdtree_)
   {
-    voxel_kdtree_.reset (new pcl::search::KdTree<PointT>);
+    voxel_kdtree_.reset (pcl::search::autoSelectMethod<PointT>(voxel_centroid_cloud_, false)); // TODO sorted or not?
     voxel_kdtree_ ->setInputCloud (voxel_centroid_cloud_);
   }
   

--- a/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
+++ b/segmentation/include/pcl/segmentation/impl/unary_classifier.hpp
@@ -49,6 +49,7 @@
 #include <pcl/features/normal_3d.h> // for NormalEstimation
 #include <pcl/segmentation/unary_classifier.h>
 #include <pcl/common/io.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 template <typename PointT>

--- a/segmentation/include/pcl/segmentation/supervoxel_clustering.h
+++ b/segmentation/include/pcl/segmentation/supervoxel_clustering.h
@@ -196,7 +196,6 @@ namespace pcl
       using NormalCloudT = pcl::PointCloud<Normal>;
       using OctreeAdjacencyT = pcl::octree::OctreePointCloudAdjacency<PointT, LeafContainerT>;
       using OctreeSearchT = pcl::octree::OctreePointCloudSearch<PointT>;
-      using KdTreeT = pcl::search::KdTree<PointT>;
       using IndicesPtr = pcl::IndicesPtr;
 
       using PCLBase <PointT>::initCompute;
@@ -381,7 +380,7 @@ namespace pcl
       transformFunction (PointT &p);
 
       /** \brief Contains a KDtree for the voxelized cloud */
-      typename pcl::search::KdTree<PointT>::Ptr voxel_kdtree_;
+      typename pcl::search::Search<PointT>::Ptr voxel_kdtree_;
 
       /** \brief Octree Adjacency structure with leaves at voxel resolution */
       typename OctreeAdjacencyT::Ptr adjacency_octree_;

--- a/test/features/CMakeLists.txt
+++ b/test/features/CMakeLists.txt
@@ -89,7 +89,7 @@ if(BUILD_io)
                ARGUMENTS "${PCL_SOURCE_DIR}/test/bun0.pcd")
   PCL_ADD_TEST(features_narf test_narf
                FILES test_narf.cpp
-               LINK_WITH pcl_gtest pcl_features FLANN::FLANN)
+               LINK_WITH pcl_gtest pcl_features)
   PCL_ADD_TEST(a_ii_normals_test test_ii_normals
                FILES test_ii_normals.cpp
                LINK_WITH pcl_gtest pcl_io pcl_features

--- a/test/features/test_base_feature.cpp
+++ b/test/features/test_base_feature.cpp
@@ -42,6 +42,7 @@
 #include <pcl/features/feature.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/common/centroid.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/features/test_board_estimation.cpp
+++ b/test/features/test_board_estimation.cpp
@@ -43,6 +43,7 @@
 #include <pcl/features/normal_3d_omp.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/features/board.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::test;

--- a/test/features/test_boundary_estimation.cpp
+++ b/test/features/test_boundary_estimation.cpp
@@ -42,6 +42,7 @@
 #include <pcl/features/normal_3d.h>
 #include <pcl/features/boundary.h>
 #include <pcl/io/pcd_io.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/features/test_curvatures_estimation.cpp
+++ b/test/features/test_curvatures_estimation.cpp
@@ -42,6 +42,7 @@
 #include <pcl/features/normal_3d.h>
 #include <pcl/features/principal_curvatures.h>
 #include <pcl/io/pcd_io.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/features/test_cvfh_estimation.cpp
+++ b/test/features/test_cvfh_estimation.cpp
@@ -43,6 +43,7 @@
 #include <pcl/features/cvfh.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/filters/voxel_grid.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/features/test_flare_estimation.cpp
+++ b/test/features/test_flare_estimation.cpp
@@ -43,6 +43,7 @@
 #include <pcl/features/normal_3d.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/features/flare.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using KdTreePtr = pcl::search::KdTree<pcl::PointXYZ>::Ptr;
 using PointCloudPtr = pcl::PointCloud<pcl::PointXYZ>::Ptr;

--- a/test/features/test_gradient_estimation.cpp
+++ b/test/features/test_gradient_estimation.cpp
@@ -41,6 +41,7 @@
 #include <pcl/point_cloud.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/features/intensity_gradient.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 

--- a/test/features/test_grsd_estimation.cpp
+++ b/test/features/test_grsd_estimation.cpp
@@ -43,6 +43,7 @@
 #include <pcl/features/grsd.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/io/pcd_io.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/features/test_ii_normals.cpp
+++ b/test/features/test_ii_normals.cpp
@@ -40,6 +40,7 @@
 #include <pcl/point_types.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/features/integral_image_normal.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 #include <iostream>
 

--- a/test/features/test_invariants_estimation.cpp
+++ b/test/features/test_invariants_estimation.cpp
@@ -41,6 +41,7 @@
 #include <pcl/point_cloud.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/features/moment_invariants.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/features/test_normal_estimation.cpp
+++ b/test/features/test_normal_estimation.cpp
@@ -44,6 +44,7 @@
 #include <pcl/features/normal_3d_omp.h>
 #include <pcl/features/integral_image_normal.h>
 #include <pcl/io/pcd_io.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/features/test_pfh_estimation.cpp
+++ b/test/features/test_pfh_estimation.cpp
@@ -50,6 +50,7 @@
 #include <pcl/features/vfh.h>
 #include <pcl/features/gfpfh.h>
 #include <pcl/io/pcd_io.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using PointT = pcl::PointNormal;
 using KdTreePtr = pcl::search::KdTree<PointT>::Ptr;

--- a/test/features/test_ppf_estimation.cpp
+++ b/test/features/test_ppf_estimation.cpp
@@ -42,6 +42,7 @@
 #include <pcl/features/normal_3d.h>
 #include <pcl/features/ppf.h>
 #include <pcl/io/pcd_io.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/features/test_rift_estimation.cpp
+++ b/test/features/test_rift_estimation.cpp
@@ -40,6 +40,7 @@
 #include <pcl/test/gtest.h>
 #include <pcl/point_cloud.h>
 #include <pcl/features/rift.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 

--- a/test/features/test_rops_estimation.cpp
+++ b/test/features/test_rops_estimation.cpp
@@ -41,6 +41,7 @@
 #include <pcl/point_cloud.h>
 #include <pcl/features/rops_estimation.h>
 #include <pcl/io/pcd_io.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 pcl::PointCloud <pcl::PointXYZ>::Ptr cloud;
 pcl::PointIndicesPtr indices;

--- a/test/features/test_rsd_estimation.cpp
+++ b/test/features/test_rsd_estimation.cpp
@@ -43,6 +43,7 @@
 #include <pcl/features/rsd.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/io/pcd_io.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/features/test_shot_estimation.cpp
+++ b/test/features/test_shot_estimation.cpp
@@ -46,6 +46,7 @@
 #include "pcl/features/shot_lrf.h"
 #include <pcl/features/3dsc.h>
 #include <pcl/features/usc.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/features/test_shot_lrf_estimation.cpp
+++ b/test/features/test_shot_lrf_estimation.cpp
@@ -42,6 +42,7 @@
 #include <pcl/pcl_tests.h>
 #include <pcl/io/pcd_io.h>
 #include <pcl/features/shot_lrf.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::test;

--- a/test/features/test_spin_estimation.cpp
+++ b/test/features/test_spin_estimation.cpp
@@ -43,6 +43,7 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/features/spin_image.h>
 #include <pcl/features/intensity_spin.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -57,6 +57,7 @@
 #include <pcl/filters/conditional_removal.h>
 #include <pcl/filters/median_filter.h>
 #include <pcl/filters/normal_refinement.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 #include <pcl/common/transforms.h>
 #include <pcl/common/eigen.h>

--- a/test/recognition/test_recognition_cg.cpp
+++ b/test/recognition/test_recognition_cg.cpp
@@ -48,6 +48,7 @@
 #include <pcl/recognition/cg/hough_3d.h>
 #include <pcl/recognition/cg/geometric_consistency.h>
 #include <pcl/common/eigen.h>
+#include <pcl/kdtree/kdtree_flann.h> // for KdTreeFLANN
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/segmentation/test_segmentation.cpp
+++ b/test/segmentation/test_segmentation.cpp
@@ -55,7 +55,6 @@ using namespace pcl::io;
 
 PointCloud<PointXYZ>::Ptr cloud_;
 PointCloud<PointXYZ>::Ptr cloud_t_;
-KdTree<PointXYZ>::Ptr tree_;
 
 pcl::PointCloud<pcl::PointXYZRGB>::Ptr colored_cloud;
 pcl::PointCloud<pcl::PointXYZ>::Ptr another_cloud_;

--- a/test/surface/test_ear_clipping.cpp
+++ b/test/surface/test_ear_clipping.cpp
@@ -45,6 +45,7 @@
 #include <pcl/features/normal_3d.h>
 #include <pcl/surface/ear_clipping.h>
 #include <pcl/common/common.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/surface/test_moving_least_squares.cpp
+++ b/test/surface/test_moving_least_squares.cpp
@@ -45,6 +45,7 @@
 #include <pcl/features/normal_3d.h>
 #include <pcl/surface/mls.h>
 #include <pcl/common/common.h> // getMinMax3D
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::io;

--- a/test/visualization/test_visualization.cpp
+++ b/test/visualization/test_visualization.cpp
@@ -44,6 +44,7 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/features/normal_3d.h>
 #include <pcl/visualization/pcl_visualizer.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::io;

--- a/tools/crf_segmentation.cpp
+++ b/tools/crf_segmentation.cpp
@@ -122,8 +122,6 @@ compute (const CloudT::Ptr &cloud,
 
   // estimate surface normals
   pcl::NormalEstimation<PointT, pcl::PointNormal> ne;
-  pcl::search::KdTree<PointT>::Ptr tree (new pcl::search::KdTree<PointT> ());
-  ne.setSearchMethod (tree);
   ne.setInputCloud (cloud);
   ne.setRadiusSearch (normal_radius_search);
   ne.compute (*cloud_normals);

--- a/tools/extract_feature.cpp
+++ b/tools/extract_feature.cpp
@@ -117,7 +117,6 @@ computeFeatureViaNormals (const pcl::PCLPointCloud2::ConstPtr &input, pcl::PCLPo
 
   NormalEstimation<PointIn, NormalT> ne;
   ne.setInputCloud (xyz);
-  ne.setSearchMethod (typename pcl::search::KdTree<PointIn>::Ptr (new pcl::search::KdTree<PointIn>));
   ne.setKSearch (n_k);
   ne.setRadiusSearch (n_radius);
 
@@ -127,8 +126,6 @@ computeFeatureViaNormals (const pcl::PCLPointCloud2::ConstPtr &input, pcl::PCLPo
   FeatureAlgorithm feature_est;
   feature_est.setInputCloud (xyz);
   feature_est.setInputNormals (normals);
-
-  feature_est.setSearchMethod (typename pcl::search::KdTree<PointIn>::Ptr (new pcl::search::KdTree<PointIn>));
 
   PointCloud<PointOut> output_features;
 

--- a/tools/fpfh_estimation.cpp
+++ b/tools/fpfh_estimation.cpp
@@ -43,6 +43,7 @@
 #include <pcl/console/print.h>
 #include <pcl/console/parse.h>
 #include <pcl/console/time.h>
+#include <pcl/search/kdtree.h> // for KdTree
 
 using namespace pcl;
 using namespace pcl::io;

--- a/tools/normal_estimation.cpp
+++ b/tools/normal_estimation.cpp
@@ -108,7 +108,6 @@ compute (const pcl::PCLPointCloud2::ConstPtr &input, pcl::PCLPointCloud2 &output
   {
     NormalEstimation<PointXYZ, Normal> ne;
     ne.setInputCloud (xyz);
-    ne.setSearchMethod (search::KdTree<PointXYZ>::Ptr (new search::KdTree<PointXYZ>));
     ne.setKSearch (k);
     ne.setRadiusSearch (radius);
     ne.compute (normals);

--- a/tools/spin_estimation.cpp
+++ b/tools/spin_estimation.cpp
@@ -167,7 +167,6 @@ main (int argc, char** argv)
   //spin_est.setInputWithNormals (xyznormals, xyznormals);
   spin_est.setInputCloud (xyznormals);
   spin_est.setInputNormals (xyznormals);
-  spin_est.setSearchMethod (search::KdTree<PointNormal>::Ptr (new search::KdTree<PointNormal>));
   spin_est.setRadiusSearch (radius);
 
   if (find_argument(argc, argv, "-radial") > 0)

--- a/tools/vfh_estimation.cpp
+++ b/tools/vfh_estimation.cpp
@@ -85,7 +85,6 @@ compute (const PointCloud<PointNormal>::Ptr &input, PointCloud<VFHSignature308> 
   print_highlight (stderr, "Computing ");
 
   VFHEstimation<PointNormal, PointNormal, VFHSignature308> ne;
-  ne.setSearchMethod (search::KdTree<PointNormal>::Ptr (new search::KdTree<PointNormal>));
   ne.setInputCloud (input);
   ne.setInputNormals (input);
   


### PR DESCRIPTION
Current behaviour: FLANN is the default search method for unorganized point clouds. If FLANN is not available, many PCL modules will not be built.
Desired new behaviour (work in progress):
  Both FLANN and nanoflann are installed: use nanoflann as default search method for unorganized clouds (faster than FLANN)
  Only FLANN is installed: use FLANN as default (same as before)
  Only nanoflann is installed: use nanoflann as default (different than before, all PCL modules should be built, all classes should be available)
  Neither FLANN nor nanoflann is installed: to discuss, maybe use PCL's octree as default search method for unorganized clouds?