### PR TITLE
Remove unnecessary calculations from NDT constructor

### DIFF
--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -50,15 +50,6 @@ NormalDistributionsTransform<PointSource, PointTarget, Scalar>::
 {
   reg_name_ = "NormalDistributionsTransform";
 
-  // Initializes the gaussian fitting parameters (eq. 6.8) [Magnusson 2009]
-  const double gauss_c1 = 10.0 * (1 - outlier_ratio_);
-  const double gauss_c2 = outlier_ratio_ / pow(resolution_, 3);
-  const double gauss_d3 = -std::log(gauss_c2);
-  gauss_d1_ = -std::log(gauss_c1 + gauss_c2) - gauss_d3;
-  gauss_d2_ =
-      -2 * std::log((-std::log(gauss_c1 * std::exp(-0.5) + gauss_c2) - gauss_d3) /
-                    gauss_d1_);
-
   transformation_epsilon_ = 0.1;
   max_iterations_ = 35;
 }


### PR DESCRIPTION
Gaussian fitting parameters are recalculated each time in https://github.com/PointCloudLibrary/pcl/blob/master/registration/include/pcl/registration/impl/ndt.hpp#L79-L86 because they can change via `setOulierRatio` and `setResolution` methods.
Therefore, there is no point in calculating them in constructor