### PR TITLE
Fix duplicate symbol errors when using `KdTreeNanoflann`

### DIFF
--- a/search/include/pcl/search/kdtree_nanoflann.h
+++ b/search/include/pcl/search/kdtree_nanoflann.h
@@ -87,7 +87,7 @@ square_if_l2(float radius)
   return radius;
 };
 template <>
-float
+inline float
 square_if_l2<nanoflann::L2_Adaptor<float,
                                    pcl::search::internal::PointCloudAdaptor<float>,
                                    float,
@@ -96,7 +96,7 @@ square_if_l2<nanoflann::L2_Adaptor<float,
   return radius * radius;
 };
 template <>
-float
+inline float
 square_if_l2<
     nanoflann::L2_Simple_Adaptor<float,
                                  pcl::search::internal::PointCloudAdaptor<float>,


### PR DESCRIPTION
**Summary**
This PR eliminates duplicate symbol (multiple definition) link errors that occur when multiple translation units include `kdtree_nanoflann.h`.

**Root cause**
`kdtree_nanoflann.h` defines an explicit template specialization in a header. In C++, explicit specializations are not implicitly inline. When such a definition appears in more than one translation unit, it violates the One Definition Rule (ODR) and produces duplicate symbols at link time.
https://stackoverflow.com/a/51987559

**Change**
Mark the explicit specialization as inline so that identical definitions across translation units are permitted.