### PR TITLE
Better Cylinder Estimation Accuracy

### DIFF
--- a/sample_consensus/src/sac_model_cone.cpp
+++ b/sample_consensus/src/sac_model_cone.cpp
@@ -60,19 +60,16 @@ int pcl::internal::optimizeModelCoefficientsCone (Eigen::VectorXf& coeff, const 
     {
       Eigen::Vector3f axis_dir(x[3], x[4], x[5]);
       axis_dir.normalize();
-      const Eigen::ArrayXf axis_dir_x = Eigen::ArrayXf::Constant(pts_x.size(), axis_dir.x());
-      const Eigen::ArrayXf axis_dir_y = Eigen::ArrayXf::Constant(pts_x.size(), axis_dir.y());
-      const Eigen::ArrayXf axis_dir_z = Eigen::ArrayXf::Constant(pts_x.size(), axis_dir.z());
       const Eigen::ArrayXf bx = Eigen::ArrayXf::Constant(pts_x.size(), x[0]) - pts_x;
       const Eigen::ArrayXf by = Eigen::ArrayXf::Constant(pts_x.size(), x[1]) - pts_y;
       const Eigen::ArrayXf bz = Eigen::ArrayXf::Constant(pts_x.size(), x[2]) - pts_z;
       const Eigen::ArrayXf actual_cone_radius = std::tan(x[6]) *
-          (bx*axis_dir_x+by*axis_dir_y+bz*axis_dir_z);
-      // compute the squared distance of point b to the line (cross product), then subtract the actual cone radius (squared)
-      fvec = ((axis_dir_y * bz - axis_dir_z * by).square()
-             +(axis_dir_z * bx - axis_dir_x * bz).square()
-             +(axis_dir_x * by - axis_dir_y * bx).square())
-             -actual_cone_radius.square();
+          (bx*axis_dir.x()+by*axis_dir.y()+bz*axis_dir.z());
+      // compute the distance of point b to the line (cross product), then subtract the actual cone radius
+      fvec = ((axis_dir.y() * bz - axis_dir.z() * by).square()
+             +(axis_dir.z() * bx - axis_dir.x() * bz).square()
+             +(axis_dir.x() * by - axis_dir.y() * bx).square()).sqrt()
+             -actual_cone_radius.abs();
       return (0);
     }
 

--- a/sample_consensus/src/sac_model_cylinder.cpp
+++ b/sample_consensus/src/sac_model_cylinder.cpp
@@ -66,11 +66,11 @@ int pcl::internal::optimizeModelCoefficientsCylinder (Eigen::VectorXf& coeff, co
       const Eigen::ArrayXf bx = Eigen::ArrayXf::Constant(pts_x.size(), x[0]) - pts_x;
       const Eigen::ArrayXf by = Eigen::ArrayXf::Constant(pts_x.size(), x[1]) - pts_y;
       const Eigen::ArrayXf bz = Eigen::ArrayXf::Constant(pts_x.size(), x[2]) - pts_z;
-      // compute the squared distance of point b to the line (cross product), then subtract the squared model radius
+      // compute the distance of point b to the line (cross product), then subtract the model radius
       fvec = ((line_dir_y * bz - line_dir_z * by).square()
              +(line_dir_z * bx - line_dir_x * bz).square()
-             +(line_dir_x * by - line_dir_y * bx).square())
-             -Eigen::ArrayXf::Constant(pts_x.size(), x[6]*x[6]);
+             +(line_dir_x * by - line_dir_y * bx).square()).sqrt()
+             -Eigen::ArrayXf::Constant(pts_x.size(), std::abs(x[6]));
       return (0);
     }
 

--- a/sample_consensus/src/sac_model_cylinder.cpp
+++ b/sample_consensus/src/sac_model_cylinder.cpp
@@ -60,17 +60,14 @@ int pcl::internal::optimizeModelCoefficientsCylinder (Eigen::VectorXf& coeff, co
     {
       Eigen::Vector3f line_dir(x[3], x[4], x[5]);
       line_dir.normalize();
-      const Eigen::ArrayXf line_dir_x = Eigen::ArrayXf::Constant(pts_x.size(), line_dir.x());
-      const Eigen::ArrayXf line_dir_y = Eigen::ArrayXf::Constant(pts_x.size(), line_dir.y());
-      const Eigen::ArrayXf line_dir_z = Eigen::ArrayXf::Constant(pts_x.size(), line_dir.z());
       const Eigen::ArrayXf bx = Eigen::ArrayXf::Constant(pts_x.size(), x[0]) - pts_x;
       const Eigen::ArrayXf by = Eigen::ArrayXf::Constant(pts_x.size(), x[1]) - pts_y;
       const Eigen::ArrayXf bz = Eigen::ArrayXf::Constant(pts_x.size(), x[2]) - pts_z;
       // compute the distance of point b to the line (cross product), then subtract the model radius
-      fvec = ((line_dir_y * bz - line_dir_z * by).square()
-             +(line_dir_z * bx - line_dir_x * bz).square()
-             +(line_dir_x * by - line_dir_y * bx).square()).sqrt()
-             -Eigen::ArrayXf::Constant(pts_x.size(), std::abs(x[6]));
+      fvec = ((line_dir.y() * bz - line_dir.z() * by).square()
+             +(line_dir.z() * bx - line_dir.x() * bz).square()
+             +(line_dir.x() * by - line_dir.y() * bx).square()).sqrt()
+             - std::abs(x[6]);
       return (0);
     }
 


### PR DESCRIPTION
The cylinder optimization problem is biased. The residuals are defined as $\hat{r}^2 - (r + \epsilon_i)^2$, where $r$ is the radius of the cylinder, $\hat{r}$ is the estimator which we optimize and $\epsilon_i$ are zero mean random noise variables. The correct residual to estimate $r$ is $\hat{r} - (r + \epsilon_i)$.

As a result, the estimated radius is approximately $\sqrt{r^2 + \sigma^2}$, where $\sigma^2$ is the variance of the $\epsilon_i$. Since often $r \gg \sigma$, this bias is not really noticable in these low noise situations. But it is significant in high noise point clouds.

I have added a test which generates random noisy cylinder point clouds to verify that the current radius estimation is inaccurate. The actual radius consistently gets overestimated. For sufficiently many points $n$, our radius estimation error should be approximately $\sigma / \sqrt{n}$. With this PR, the estimation error is consistent with the theory and the radius estimation is not biased anymore.

I have done the same changes to the cone estimation problem for the same reason. The other estimation problems (Circle, Circle3D, Ellipse3D, Sphere) have correct residuals. The Torus one I haven't looked into enough to understand it.