### PR TITLE
Add const "guards" in correspondence estimation

### DIFF
--- a/registration/include/pcl/registration/correspondence_estimation.h
+++ b/registration/include/pcl/registration/correspondence_estimation.h
@@ -142,7 +142,7 @@ public:
    * automatic)
    */
   void
-  setNumberOfThreads(unsigned int nr_threads)
+  setNumberOfThreads(const unsigned int nr_threads)
   {
 #ifdef _OPENMP
     num_threads_ = nr_threads != 0 ? nr_threads : omp_get_num_procs();
@@ -163,7 +163,7 @@ public:
 
   /** \brief Abstract method for setting the source normals */
   virtual void
-  setSourceNormals(pcl::PCLPointCloud2::ConstPtr /*cloud2*/)
+  setSourceNormals(const pcl::PCLPointCloud2::ConstPtr /*cloud2*/)
   {
     PCL_WARN("[pcl::registration::%s::setSourceNormals] This class does not require "
              "input source normals\n",
@@ -179,7 +179,7 @@ public:
 
   /** \brief Abstract method for setting the target normals */
   virtual void
-  setTargetNormals(pcl::PCLPointCloud2::ConstPtr /*cloud2*/)
+  setTargetNormals(const pcl::PCLPointCloud2::ConstPtr /*cloud2*/)
   {
     PCL_WARN("[pcl::registration::%s::setTargetNormals] This class does not require "
              "input target normals\n",
@@ -228,7 +228,7 @@ public:
    * confident that the tree will be set correctly.
    */
   inline void
-  setSearchMethodTarget(const KdTreePtr& tree, bool force_no_recompute = false)
+  setSearchMethodTarget(const KdTreePtr& tree, const bool force_no_recompute = false)
   {
     tree_ = tree;
     force_no_recompute_ = force_no_recompute;
@@ -253,7 +253,7 @@ public:
    */
   inline void
   setSearchMethodSource(const KdTreeReciprocalPtr& tree,
-                        bool force_no_recompute = false)
+                        const bool force_no_recompute = false)
   {
     tree_reciprocal_ = tree;
     force_no_recompute_reciprocal_ = force_no_recompute;
@@ -277,7 +277,7 @@ public:
   virtual void
   determineCorrespondences(
       pcl::Correspondences& correspondences,
-      double max_distance = std::numeric_limits<double>::max()) = 0;
+      const double max_distance = std::numeric_limits<double>::max()) = 0;
 
   /** \brief Determine the reciprocal correspondences between input and target cloud.
    * A correspondence is considered reciprocal if both Src_i has Tgt_i as a
@@ -290,7 +290,7 @@ public:
   virtual void
   determineReciprocalCorrespondences(
       pcl::Correspondences& correspondences,
-      double max_distance = std::numeric_limits<double>::max()) = 0;
+      const double max_distance = std::numeric_limits<double>::max()) = 0;
 
   /** \brief Provide a boost shared pointer to the PointRepresentation for target cloud
    * to be used when searching for nearest neighbors.
@@ -476,7 +476,7 @@ public:
   void
   determineCorrespondences(
       pcl::Correspondences& correspondences,
-      double max_distance = std::numeric_limits<double>::max()) override;
+      const double max_distance = std::numeric_limits<double>::max()) override;
 
   /** \brief Determine the reciprocal correspondences between input and target cloud.
    * A correspondence is considered reciprocal if both Src_i has Tgt_i as a
@@ -489,7 +489,7 @@ public:
   void
   determineReciprocalCorrespondences(
       pcl::Correspondences& correspondences,
-      double max_distance = std::numeric_limits<double>::max()) override;
+      const double max_distance = std::numeric_limits<double>::max()) override;
 
   /** \brief Clone and cast to CorrespondenceEstimationBase */
   typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::Ptr

--- a/registration/include/pcl/registration/correspondence_estimation_backprojection.h
+++ b/registration/include/pcl/registration/correspondence_estimation_backprojection.h
@@ -150,9 +150,9 @@ public:
 
   /** \brief Blob method for setting the source normals */
   void
-  setSourceNormals(pcl::PCLPointCloud2::ConstPtr cloud2)
+  setSourceNormals(const pcl::PCLPointCloud2::ConstPtr cloud2)
   {
-    NormalsPtr cloud(new PointCloudNormals);
+    const NormalsPtr cloud(new PointCloudNormals);
     fromPCLPointCloud2(*cloud2, *cloud);
     setSourceNormals(cloud);
   }
@@ -166,9 +166,9 @@ public:
 
   /** \brief Method for setting the target normals */
   void
-  setTargetNormals(pcl::PCLPointCloud2::ConstPtr cloud2)
+  setTargetNormals(const pcl::PCLPointCloud2::ConstPtr cloud2)
   {
-    NormalsPtr cloud(new PointCloudNormals);
+    const NormalsPtr cloud(new PointCloudNormals);
     fromPCLPointCloud2(*cloud2, *cloud);
     setTargetNormals(cloud);
   }
@@ -180,8 +180,9 @@ public:
    * cloud
    */
   void
-  determineCorrespondences(pcl::Correspondences& correspondences,
-                           double max_distance = std::numeric_limits<double>::max());
+  determineCorrespondences(
+      pcl::Correspondences& correspondences,
+      const double max_distance = std::numeric_limits<double>::max());
 
   /** \brief Determine the reciprocal correspondences between input and target cloud.
    * A correspondence is considered reciprocal if both Src_i has Tgt_i as a
@@ -194,7 +195,7 @@ public:
   virtual void
   determineReciprocalCorrespondences(
       pcl::Correspondences& correspondences,
-      double max_distance = std::numeric_limits<double>::max());
+      const double max_distance = std::numeric_limits<double>::max());
 
   /** \brief Set the number of nearest neighbours to be considered in the target
    * point cloud. By default, we use k = 10 nearest neighbors.
@@ -202,7 +203,7 @@ public:
    * \param[in] k the number of nearest neighbours to be considered
    */
   inline void
-  setKSearch(unsigned int k)
+  setKSearch(const unsigned int k)
   {
     k_ = k;
   }

--- a/registration/include/pcl/registration/correspondence_estimation_normal_shooting.h
+++ b/registration/include/pcl/registration/correspondence_estimation_normal_shooting.h
@@ -166,9 +166,9 @@ public:
 
   /** \brief Blob method for setting the source normals */
   void
-  setSourceNormals(pcl::PCLPointCloud2::ConstPtr cloud2) override
+  setSourceNormals(const pcl::PCLPointCloud2::ConstPtr cloud2) override
   {
-    NormalsPtr cloud(new PointCloudNormals);
+    const NormalsPtr cloud(new PointCloudNormals);
     fromPCLPointCloud2(*cloud2, *cloud);
     setSourceNormals(cloud);
   }
@@ -182,7 +182,7 @@ public:
   void
   determineCorrespondences(
       pcl::Correspondences& correspondences,
-      double max_distance = std::numeric_limits<double>::max()) override;
+      const double max_distance = std::numeric_limits<double>::max()) override;
 
   /** \brief Determine the reciprocal correspondences between input and target cloud.
    * A correspondence is considered reciprocal if both Src_i has Tgt_i as a
@@ -195,7 +195,7 @@ public:
   void
   determineReciprocalCorrespondences(
       pcl::Correspondences& correspondences,
-      double max_distance = std::numeric_limits<double>::max()) override;
+      const double max_distance = std::numeric_limits<double>::max()) override;
 
   /** \brief Set the number of nearest neighbours to be considered in the target
    * point cloud. By default, we use k = 10 nearest neighbors.
@@ -203,7 +203,7 @@ public:
    * \param[in] k the number of nearest neighbours to be considered
    */
   inline void
-  setKSearch(unsigned int k)
+  setKSearch(const unsigned int k)
   {
     k_ = k;
   }

--- a/registration/include/pcl/registration/correspondence_estimation_organized_projection.h
+++ b/registration/include/pcl/registration/correspondence_estimation_organized_projection.h
@@ -190,7 +190,7 @@ public:
    * will be rejected
    */
   void
-  determineCorrespondences(Correspondences& correspondences, double max_distance);
+  determineCorrespondences(Correspondences& correspondences, const double max_distance);
 
   /** \brief Computes the correspondences, applying a maximum Euclidean distance
    * threshold.
@@ -201,7 +201,7 @@ public:
    */
   void
   determineReciprocalCorrespondences(Correspondences& correspondences,
-                                     double max_distance);
+                                     const double max_distance);
 
   /** \brief Clone and cast to CorrespondenceEstimationBase */
   virtual typename CorrespondenceEstimationBase<PointSource, PointTarget, Scalar>::Ptr

--- a/registration/include/pcl/registration/impl/correspondence_estimation.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_estimation.hpp
@@ -145,7 +145,7 @@ pointCopyOrRef(typename pcl::PointCloud<PointSource>::ConstPtr& input, const Ind
 template <typename PointSource, typename PointTarget, typename Scalar>
 void
 CorrespondenceEstimation<PointSource, PointTarget, Scalar>::determineCorrespondences(
-    pcl::Correspondences& correspondences, double max_distance)
+    pcl::Correspondences& correspondences, const double max_distance)
 {
   if (!initCompute())
     return;
@@ -158,7 +158,7 @@ CorrespondenceEstimation<PointSource, PointTarget, Scalar>::determineCorresponde
   for (auto& corrs : per_thread_correspondences) {
     corrs.reserve(2 * indices_->size() / num_threads_);
   }
-  double max_dist_sqr = max_distance * max_distance;
+  const double max_dist_sqr = max_distance * max_distance;
 
 #pragma omp parallel for default(none)                                                 \
     shared(max_dist_sqr, per_thread_correspondences) firstprivate(index, distance)     \
@@ -221,7 +221,7 @@ template <typename PointSource, typename PointTarget, typename Scalar>
 void
 CorrespondenceEstimation<PointSource, PointTarget, Scalar>::
     determineReciprocalCorrespondences(pcl::Correspondences& correspondences,
-                                       double max_distance)
+                                       const double max_distance)
 {
   if (!initCompute())
     return;
@@ -230,7 +230,6 @@ CorrespondenceEstimation<PointSource, PointTarget, Scalar>::
   // Set the internal point representation of choice
   if (!initComputeReciprocal())
     return;
-  double max_dist_sqr = max_distance * max_distance;
 
   correspondences.resize(indices_->size());
   pcl::Indices index(1);
@@ -241,6 +240,7 @@ CorrespondenceEstimation<PointSource, PointTarget, Scalar>::
   for (auto& corrs : per_thread_correspondences) {
     corrs.reserve(2 * indices_->size() / num_threads_);
   }
+  const double max_dist_sqr = max_distance * max_distance;
 
 #pragma omp parallel for default(none)                                                 \
     shared(max_dist_sqr, per_thread_correspondences)                                   \

--- a/registration/include/pcl/registration/impl/correspondence_estimation_backprojection.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_estimation_backprojection.hpp
@@ -66,7 +66,8 @@ CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar>
 void
 CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar>::
-    determineCorrespondences(pcl::Correspondences& correspondences, double max_distance)
+    determineCorrespondences(pcl::Correspondences& correspondences,
+                             const double max_distance)
 {
   if (!initCompute())
     return;
@@ -98,7 +99,7 @@ CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar
                             (*target_normals_)[nn_indices[j]].normal_y +
                         (*source_normals_)[idx_i].normal_z *
                             (*target_normals_)[nn_indices[j]].normal_z;
-      float dist = nn_dists[j] * (2.0f - cos_angle * cos_angle);
+      const float dist = nn_dists[j] * (2.0f - cos_angle * cos_angle);
 
       if (dist < min_dist) {
         min_dist = dist;
@@ -121,7 +122,7 @@ template <typename PointSource, typename PointTarget, typename NormalT, typename
 void
 CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar>::
     determineReciprocalCorrespondences(pcl::Correspondences& correspondences,
-                                       double max_distance)
+                                       const double max_distance)
 {
   if (!initCompute())
     return;
@@ -166,7 +167,7 @@ CorrespondenceEstimationBackProjection<PointSource, PointTarget, NormalT, Scalar
                             (*target_normals_)[nn_indices[j]].normal_y +
                         (*source_normals_)[idx_i].normal_z *
                             (*target_normals_)[nn_indices[j]].normal_z;
-      float dist = nn_dists[j] * (2.0f - cos_angle * cos_angle);
+      const float dist = nn_dists[j] * (2.0f - cos_angle * cos_angle);
 
       if (dist < min_dist) {
         min_dist = dist;

--- a/registration/include/pcl/registration/impl/correspondence_estimation_normal_shooting.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_estimation_normal_shooting.hpp
@@ -66,7 +66,8 @@ CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar
 template <typename PointSource, typename PointTarget, typename NormalT, typename Scalar>
 void
 CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar>::
-    determineCorrespondences(pcl::Correspondences& correspondences, double max_distance)
+    determineCorrespondences(pcl::Correspondences& correspondences,
+                             const double max_distance)
 {
   if (!initCompute())
     return;
@@ -111,7 +112,7 @@ CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar
       Eigen::Vector3d C = N.cross(V);
 
       // Check if we have a better correspondence
-      double dist = C.dot(C);
+      const double dist = C.dot(C);
       if (dist < min_dist) {
         min_dist = dist;
         min_index = static_cast<int>(j);
@@ -133,7 +134,7 @@ template <typename PointSource, typename PointTarget, typename NormalT, typename
 void
 CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar>::
     determineReciprocalCorrespondences(pcl::Correspondences& correspondences,
-                                       double max_distance)
+                                       const double max_distance)
 {
   if (!initCompute())
     return;
@@ -186,7 +187,7 @@ CorrespondenceEstimationNormalShooting<PointSource, PointTarget, NormalT, Scalar
       Eigen::Vector3d C = N.cross(V);
 
       // Check if we have a better correspondence
-      double dist = C.dot(C);
+      const double dist = C.dot(C);
       if (dist < min_dist) {
         min_dist = dist;
         min_index = static_cast<int>(j);

--- a/registration/include/pcl/registration/impl/correspondence_estimation_organized_projection.hpp
+++ b/registration/include/pcl/registration/impl/correspondence_estimation_organized_projection.hpp
@@ -75,7 +75,8 @@ CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar>::
 template <typename PointSource, typename PointTarget, typename Scalar>
 void
 CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar>::
-    determineCorrespondences(pcl::Correspondences& correspondences, double max_distance)
+    determineCorrespondences(pcl::Correspondences& correspondences,
+                             const double max_distance)
 {
   if (!initCompute())
     return;
@@ -85,17 +86,17 @@ CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar>::
 
   for (const auto& src_idx : (*indices_)) {
     if (isFinite((*input_)[src_idx])) {
-      Eigen::Vector4f p_src(src_to_tgt_transformation_ *
-                            (*input_)[src_idx].getVector4fMap());
-      Eigen::Vector3f p_src3(p_src[0], p_src[1], p_src[2]);
-      Eigen::Vector3f uv(projection_matrix_ * p_src3);
+      const Eigen::Vector4f p_src(src_to_tgt_transformation_ *
+                                  (*input_)[src_idx].getVector4fMap());
+      const Eigen::Vector3f p_src3(p_src[0], p_src[1], p_src[2]);
+      const Eigen::Vector3f uv(projection_matrix_ * p_src3);
 
       /// Check if the point was behind the camera
       if (uv[2] <= 0)
         continue;
 
-      int u = static_cast<int>(uv[0] / uv[2]);
-      int v = static_cast<int>(uv[1] / uv[2]);
+      const int u = static_cast<int>(uv[0] / uv[2]);
+      const int v = static_cast<int>(uv[1] / uv[2]);
 
       if (u >= 0 && u < static_cast<int>(target_->width) && v >= 0 &&
           v < static_cast<int>(target_->height)) {
@@ -106,7 +107,7 @@ CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar>::
         if (std::abs(uv[2] - pt_tgt.z) > depth_threshold_)
           continue;
 
-        double dist = (p_src3 - pt_tgt.getVector3fMap()).norm();
+        const double dist = (p_src3 - pt_tgt.getVector3fMap()).norm();
         if (dist < max_distance)
           correspondences[c_index++] = pcl::Correspondence(
               src_idx, v * target_->width + u, static_cast<float>(dist));
@@ -121,7 +122,7 @@ template <typename PointSource, typename PointTarget, typename Scalar>
 void
 CorrespondenceEstimationOrganizedProjection<PointSource, PointTarget, Scalar>::
     determineReciprocalCorrespondences(pcl::Correspondences& correspondences,
-                                       double max_distance)
+                                       const double max_distance)
 {
   // Call the normal determineCorrespondences (...), as doing it both ways will not
   // improve the results


### PR DESCRIPTION
* Add const keyword to function parameters which are not meant to be modified inside the function in correspondence estimation classes

* Add const keyword to local variables which are not meant to be modified in correspondence estimation classes except for variables in clone() functions

### Background
I was looking into https://github.com/PointCloudLibrary/pcl/issues/329, https://github.com/PointCloudLibrary/pcl/pull/4901, and other when noticed some variables and parameters not being `const`. So I decided to "improve" the code when I had an opportunity.

### Variables in `clone()` functions
I didn't change constness of variable `copy` in `clone()` functions because I am just unsure about NRVO in this case. Maybe I should have added `const` in these cases. But that can be done later anyway.

### About `const` function parameters passed by value
There are multiple opinions on the usage of `const` with function parameters passed by value in the C++ community. I used `const` with function parameters in this pull request to prevent mistakes when a parameter is modified inside the function but should not be. We can discuss it and `const` in function declarations and etc. further if you need or want to.

### P.S.
I also noticed other non-critical things but, probably, I should try to prioritize tasks to do more important contributions.