### PR TITLE
Fix bug in RegionGrowing and RegionGrowingRGB

### DIFF
--- a/segmentation/include/pcl/segmentation/impl/region_growing.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing.hpp
@@ -332,7 +332,7 @@ pcl::RegionGrowing<PointT, NormalT>::findPointNeighbours ()
     for (const auto& point_index: (*indices_))
     {
       neighbours.clear ();
-      search_->nearestKSearch (point_index, neighbour_number_, neighbours, distances);
+      search_->nearestKSearch ((*input_)[point_index], neighbour_number_, neighbours, distances);
       point_neighbours_[point_index].swap (neighbours);
     }
   }
@@ -343,7 +343,7 @@ pcl::RegionGrowing<PointT, NormalT>::findPointNeighbours ()
       if (!pcl::isFinite ((*input_)[point_index]))
         continue;
       neighbours.clear ();
-      search_->nearestKSearch (point_index, neighbour_number_, neighbours, distances);
+      search_->nearestKSearch ((*input_)[point_index], neighbour_number_, neighbours, distances);
       point_neighbours_[point_index].swap (neighbours);
     }
   }

--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -278,7 +278,7 @@ pcl::RegionGrowingRGB<PointT, NormalT>::findPointNeighbours ()
   {
     neighbours.clear ();
     distances.clear ();
-    search_->nearestKSearch (point_index, region_neighbour_number_, neighbours, distances);
+    search_->nearestKSearch ((*input_)[point_index], region_neighbour_number_, neighbours, distances);
     point_neighbours_[point_index].swap (neighbours);
     point_distances_[point_index].swap (distances);
   }

--- a/test/segmentation/test_segmentation.cpp
+++ b/test/segmentation/test_segmentation.cpp
@@ -78,6 +78,27 @@ TEST (RegionGrowingRGBTest, Segment)
   EXPECT_NE (0, num_of_segments);
 }
 
+TEST (RegionGrowingRGBTest, SegmentWithIndices)
+{
+  // Same test as before, but now we pass a reduced set of indices to RegionGrowingRGB, which results in fewer clusters
+  pcl::IndicesPtr indices (new pcl::Indices(colored_cloud->size()-611));
+  std::iota(indices->begin(), indices->end(), 611);
+
+  RegionGrowingRGB<pcl::PointXYZRGB> rg;
+
+  rg.setInputCloud (colored_cloud);
+  rg.setIndices (indices);
+  rg.setDistanceThreshold (10);
+  rg.setRegionColorThreshold (5);
+  rg.setPointColorThreshold (6);
+  rg.setMinClusterSize (20);
+
+  std::vector <pcl::PointIndices> clusters;
+  rg.extract (clusters);
+  const auto num_of_segments = clusters.size ();
+  EXPECT_EQ (5, num_of_segments);
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (RegionGrowingTest, Segment)
 {
@@ -89,6 +110,30 @@ TEST (RegionGrowingTest, Segment)
   rg.extract (clusters);
   const auto num_of_segments = clusters.size ();
   EXPECT_NE (0, num_of_segments);
+}
+
+TEST (RegionGrowingTest, SegmentWithIndices)
+{
+  // use colored_cloud, but with a reduced set of indices (colors are ignored)
+  pcl::IndicesPtr indices (new pcl::Indices(colored_cloud->size()-611));
+  std::iota(indices->begin(), indices->end(), 611);
+  // create dummy normals that all point into the same direction
+  pcl::PointCloud<pcl::Normal>::Ptr normals (new pcl::PointCloud<pcl::Normal>);
+  normals->resize(colored_cloud->size());
+  for(auto& normal: *normals) {
+    normal.normal_x = normal.normal_y = 0.0f;
+    normal.normal_z = 1.0f;
+  }
+
+  pcl::RegionGrowing<pcl::PointXYZRGB, pcl::Normal> rg;
+  rg.setInputCloud (colored_cloud);
+  rg.setInputNormals (normals);
+  rg.setIndices (indices);
+
+  std::vector <pcl::PointIndices> clusters;
+  rg.extract (clusters);
+  const auto num_of_segments = clusters.size ();
+  EXPECT_EQ (5, num_of_segments);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The bug was introduced in https://github.com/PointCloudLibrary/pcl/commit/053995b7ed94140a2acae62c8f12608a48d1311e It occurs when indices are given to RegionGrowing(RGB) that are not a complete set of indices. For example, in the [RegionGrowing tutorial](https://pcl.readthedocs.io/projects/tutorials/en/master/region_growing_segmentation.html), if milk_cartoon_all_small_clorox.pcd is used instead of region_growing_tutorial.pcd (the first file contains NaNs but the second one does not). If PCL was compiled in debug mode, an assertion triggers here: https://github.com/PointCloudLibrary/pcl/blob/f5fd21531b6cb19724227490949e66b5ce171075/search/include/pcl/search/impl/search.hpp#L106 Otherwise, the segmentation results are just very bad. Fixes https://github.com/PointCloudLibrary/pcl/issues/6348