### PR TITLE
[segmentation] Make RegionGrowingRGB faster

### DIFF
--- a/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing_rgb.hpp
@@ -475,14 +475,14 @@ pcl::RegionGrowingRGB<PointT, NormalT>::applyRegionMergingAlgorithm ()
       num_seg_in_homogeneous_region[i_reg] = 0;
       final_segment_number -= 1;
 
-      for (auto& nghbr : region_neighbours[reg_index])
-      {
-        if ( segment_labels_[ nghbr.second ] == reg_index )
-        {
-          nghbr.first = std::numeric_limits<float>::max ();
-          nghbr.second = 0;
-        }
-      }
+      const auto filtered_region_neighbours_reg_index_end = std::remove_if (
+        region_neighbours[reg_index].begin (),
+        region_neighbours[reg_index].end (),
+        [this, reg_index] (const auto& nghbr) { return segment_labels_[ nghbr.second ] == reg_index; });
+      const auto filtered_region_neighbours_reg_index_size = std::distance (
+        region_neighbours[reg_index].begin (), filtered_region_neighbours_reg_index_end);
+      region_neighbours[reg_index].resize (filtered_region_neighbours_reg_index_size);
+
       for (const auto& nghbr : region_neighbours[i_reg])
       {
         if ( segment_labels_[ nghbr.second ] != reg_index )
@@ -491,7 +491,11 @@ pcl::RegionGrowingRGB<PointT, NormalT>::applyRegionMergingAlgorithm ()
         }
       }
       region_neighbours[i_reg].clear ();
-      std::sort (region_neighbours[reg_index].begin (), region_neighbours[reg_index].end (), comparePair);
+      std::inplace_merge (
+        region_neighbours[reg_index].begin (),
+        std::next (region_neighbours[reg_index].begin (), filtered_region_neighbours_reg_index_size),
+        region_neighbours[reg_index].end (),
+        comparePair);
     }
   }
 


### PR DESCRIPTION
Resolve #6356 

For deterministic comparison of implementations I made the following changes:
```
--- a/segmentation/include/pcl/segmentation/impl/region_growing.hpp
+++ b/segmentation/include/pcl/segmentation/impl/region_growing.hpp
@@ -614,7 +614,7 @@ pcl::RegionGrowing<PointT, NormalT>::getColoredCloud ()
   {
     colored_cloud.reset(new pcl::PointCloud<pcl::PointXYZRGB>);
 
-    srand (static_cast<unsigned int> (time (nullptr)));
+    srand (static_cast<unsigned int> (0));
     std::vector<unsigned char> colors;
     for (std::size_t i_segment = 0; i_segment < clusters_.size (); i_segment++)
     {
@@ -664,7 +664,7 @@ pcl::RegionGrowing<PointT, NormalT>::getColoredCloudRGBA ()
   {
     colored_cloud.reset(new pcl::PointCloud<pcl::PointXYZRGBA>);
 
-    srand (static_cast<unsigned int> (time (nullptr)));
+    srand (static_cast<unsigned int> (0));
     std::vector<unsigned char> colors;
     for (std::size_t i_segment = 0; i_segment < clusters_.size (); i_segment++)
     {
```
and replaced `std::sort` with `std::stable_sort` for old implementation

Total `reg.extract (clusters)` time decreased from `16` to `4` seconds and `applyRegionMergingAlgorithm` time - from `12` to `0.3` seconds