### PR TITLE
Update custom point type doc (4th coordinate is not set to 1)

### DIFF
--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -165,7 +165,7 @@ namespace pcl
     namespace traits
     {
       template<typename FeaturePointT> struct descriptorSize {};
-   
+
       template<> struct descriptorSize<PFHSignature125> { static constexpr const int value = 125; };
       template<> struct descriptorSize<PFHRGBSignature250> { static constexpr const int value = 250; };
       template<> struct descriptorSize<ShapeContext1980> { static constexpr const int value = 1980; };
@@ -189,7 +189,7 @@ namespace pcl
       static constexpr int descriptorSize_v = descriptorSize<FeaturePointT>::value;
     }
   }
-  
+
   using Vector2fMap = Eigen::Map<Eigen::Vector2f>;
   using Vector2fMapConst = const Eigen::Map<const Eigen::Vector2f>;
   using Array3fMap = Eigen::Map<Eigen::Array3f>;
@@ -215,6 +215,8 @@ namespace pcl
       float x; \
       float y; \
       float z; \
+      /* ensure last homogeneous component is 1 for affine transformations */ \
+      float _w  = 1; \
     }; \
   };
 
@@ -460,7 +462,7 @@ namespace pcl
     inline constexpr PointXYZI (float _intensity = 0.f) : PointXYZI(0.f, 0.f, 0.f, _intensity) {}
 
     inline constexpr PointXYZI (float _x, float _y, float _z, float _intensity = 0.f) : _PointXYZI{{{_x, _y, _z, 1.0f}}, {{_intensity}}} {}
-    
+
     friend std::ostream& operator << (std::ostream& os, const PointXYZI& p);
   };
 
@@ -689,7 +691,7 @@ namespace pcl
   PCL_EXPORTS std::ostream& operator << (std::ostream& os, const PointXYZHSV& p);
   struct EIGEN_ALIGN16 PointXYZHSV : public _PointXYZHSV
   {
-    inline constexpr PointXYZHSV (const _PointXYZHSV &p) : 
+    inline constexpr PointXYZHSV (const _PointXYZHSV &p) :
       PointXYZHSV{p.x, p.y, p.z, p.h, p.s, p.v} {}
 
     inline constexpr PointXYZHSV (): PointXYZHSV (0.f, 0.f, 0.f) {}
@@ -714,10 +716,10 @@ namespace pcl
   // NOLINTBEGIN(modernize-use-default-member-init)
   struct PointXY
   {
-    union 
-    { 
-      float data[2]; 
-      struct 
+    union
+    {
+      float data[2];
+      struct
       {
         float x;
         float y;
@@ -729,7 +731,7 @@ namespace pcl
 
     inline pcl::Vector2fMap getVector2fMap () { return (pcl::Vector2fMap (data)); }
     inline pcl::Vector2fMapConst getVector2fMap () const { return (pcl::Vector2fMapConst (data)); }
-    
+
     friend std::ostream& operator << (std::ostream& os, const PointXY& p);
   };
   // NOLINTEND(modernize-use-default-member-init)
@@ -929,8 +931,8 @@ namespace pcl
     inline constexpr PointXYZRGBNormal (float _x, float _y, float _z, std::uint8_t _r, std::uint8_t _g, std::uint8_t _b,
                               float n_x, float n_y, float n_z, float _curvature = 0.f) :
       _PointXYZRGBNormal{
-        {{_x, _y, _z, 1.0f}}, 
-        {{n_x, n_y, n_z, 0.0f}}, 
+        {{_x, _y, _z, 1.0f}},
+        {{n_x, n_y, n_z, 0.0f}},
         {{ {{{_b, _g, _r, 255u}}}, _curvature }}
       }
     {}
@@ -938,8 +940,8 @@ namespace pcl
     inline constexpr PointXYZRGBNormal (float _x, float _y, float _z, std::uint8_t _r, std::uint8_t _g, std::uint8_t _b,
                               std::uint8_t _a, float n_x, float n_y, float n_z, float _curvature = 0.f) :
       _PointXYZRGBNormal{
-        {{_x, _y, _z, 1.0f}}, 
-        {{n_x, n_y, n_z, 0.0f}}, 
+        {{_x, _y, _z, 1.0f}},
+        {{n_x, n_y, n_z, 0.0f}},
         {{ {{{_b, _g, _r, _a}}}, _curvature }}
       }
     {}
@@ -981,8 +983,8 @@ namespace pcl
     inline constexpr PointXYZINormal (float _x, float _y, float _z, float _intensity,
                             float n_x, float n_y, float n_z, float _curvature = 0.f) :
       _PointXYZINormal{
-        {{_x, _y, _z, 1.0f}}, 
-        {{n_x, n_y, n_z, 0.0f}}, 
+        {{_x, _y, _z, 1.0f}},
+        {{n_x, n_y, n_z, 0.0f}},
         {{_intensity, _curvature}}
       }
     {}
@@ -1024,11 +1026,11 @@ namespace pcl
     inline constexpr PointXYZLNormal (float _x, float _y, float _z, std::uint32_t _label,
                             float n_x, float n_y, float n_z, float _curvature = 0.f) :
       _PointXYZLNormal{
-        {{_x, _y, _z, 1.0f}}, 
-        {{n_x, n_y, n_z, 0.0f}}, 
+        {{_x, _y, _z, 1.0f}},
+        {{n_x, n_y, n_z, 0.0f}},
         {{_label, _curvature}}
       }
-    {} 
+    {}
 
     friend std::ostream& operator << (std::ostream& os, const PointXYZLNormal& p);
   };
@@ -1636,7 +1638,7 @@ namespace pcl
     inline constexpr PointWithScale (float _x, float _y, float _z, float _scale = 1.f,
                            float _angle = -1.f, float _response = 0.f, int _octave = 0) :
       _PointWithScale{{{_x, _y, _z, 1.0f}}, {_scale}, _angle, _response, _octave } {}
-    
+
     friend std::ostream& operator << (std::ostream& os, const PointWithScale& p);
   };
 
@@ -1673,11 +1675,11 @@ namespace pcl
       PointSurfel{0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0.0f, 0u, 0u, 0u, 0u, 0.0f, 0.0f, 0.0f} {}
 
     inline constexpr PointSurfel (float _x, float _y, float _z, float _nx,
-                           float _ny, float _nz, std::uint8_t _r, std::uint8_t _g, std::uint8_t _b, std::uint8_t _a, 
+                           float _ny, float _nz, std::uint8_t _r, std::uint8_t _g, std::uint8_t _b, std::uint8_t _a,
                            float _radius, float _confidence, float _curvature) :
       _PointSurfel{
-        {{_x, _y, _z, 1.0f}}, 
-        {{_nx, _ny, _nz, 0.0f}}, 
+        {{_x, _y, _z, 1.0f}},
+        {{_nx, _ny, _nz, 0.0f}},
         {{{{{_b, _g, _r, _a}}}, _radius, _confidence, _curvature}}
       } {}
 
@@ -1702,7 +1704,7 @@ namespace pcl
   {
     inline constexpr PointDEM (const _PointDEM &p) :
       PointDEM{p.x, p.y, p.z, p.intensity, p.intensity_variance, p.height_variance} {}
-   
+
     inline constexpr PointDEM (): PointDEM (0.f, 0.f, 0.f) {}
 
     inline constexpr PointDEM (float _x, float _y, float _z): PointDEM (_x, _y, _z, 0.f, 0.f, 0.f) {}
@@ -1710,7 +1712,7 @@ namespace pcl
     inline constexpr PointDEM (float _x, float _y, float _z, float _intensity,
                      float _intensity_variance, float _height_variance) :
       _PointDEM{{{_x, _y, _z, 1.0f}}, _intensity, _intensity_variance, _height_variance} {}
-    
+
     friend std::ostream& operator << (std::ostream& os, const PointDEM& p);
   };
 
@@ -2294,4 +2296,3 @@ namespace traits
 #endif
 
 } // namespace pcl
-

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -210,13 +210,12 @@ namespace pcl
 
 #define PCL_ADD_UNION_POINT4D \
   union EIGEN_ALIGN16 { \
-    float data[4]; \
+      /* ensure last homogeneous component is 1 for affine transformations */ \
+    float data[4] {0, 0, 0, 1}; \
     struct { \
       float x; \
       float y; \
       float z; \
-      /* ensure last homogeneous component is 1 for affine transformations */ \
-      float _w  = 1; \
     }; \
   };
 

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -208,16 +208,6 @@ namespace pcl
   using Vector4cMap = Eigen::Map<Vector4c, Eigen::Aligned>;
   using Vector4cMapConst = const Eigen::Map<const Vector4c, Eigen::Aligned>;
 
-struct W_Initializer {
-    float w;
-    // Default constructor sets the value to 1.0
-    W_Initializer() : w(1.0f) {}
-    // Allow it to be treated like a normal float
-    operator float&() { return w; }
-    operator float() const { return w; }
-    W_Initializer& operator=(float v) { w = v; return *this; }
-};
-
 // note: 4th homogeneous coordinate is uninitialized, has to be set to 1
 // explicitly if needed for matrix operations.
 #define PCL_ADD_UNION_POINT4D \

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -208,15 +208,26 @@ namespace pcl
   using Vector4cMap = Eigen::Map<Vector4c, Eigen::Aligned>;
   using Vector4cMapConst = const Eigen::Map<const Vector4c, Eigen::Aligned>;
 
+struct W_Initializer {
+    float w;
+    // Default constructor sets the value to 1.0
+    W_Initializer() : w(1.0f) {}
+    // Allow it to be treated like a normal float
+    operator float&() { return w; }
+    operator float() const { return w; }
+    W_Initializer& operator=(float v) { w = v; return *this; }
+};
+
 #define PCL_ADD_UNION_POINT4D \
-  union EIGEN_ALIGN16 { \
+  union EIGEN_ALIGN16 _data_u { \
       /* ensure last homogeneous component is 1 for affine transformations */ \
-    float data[4] {0, 0, 0, 1}; \
+    float data[4]; \
     struct { \
       float x; \
       float y; \
       float z; \
     }; \
+    _data_u() { data[3] = 1.0f; } \
   };
 
 #define PCL_ADD_EIGEN_MAPS_POINT4D \

--- a/common/include/pcl/impl/point_types.hpp
+++ b/common/include/pcl/impl/point_types.hpp
@@ -218,16 +218,16 @@ struct W_Initializer {
     W_Initializer& operator=(float v) { w = v; return *this; }
 };
 
+// note: 4th homogeneous coordinate is uninitialized, has to be set to 1
+// explicitly if needed for matrix operations.
 #define PCL_ADD_UNION_POINT4D \
-  union EIGEN_ALIGN16 _data_u { \
-      /* ensure last homogeneous component is 1 for affine transformations */ \
+  union EIGEN_ALIGN16 { \
     float data[4]; \
     struct { \
       float x; \
       float y; \
       float z; \
     }; \
-    _data_u() { data[3] = 1.0f; } \
   };
 
 #define PCL_ADD_EIGEN_MAPS_POINT4D \

--- a/doc/tutorials/content/adding_custom_ptype.rst
+++ b/doc/tutorials/content/adding_custom_ptype.rst
@@ -813,9 +813,9 @@ for any classes that you expose (from PCL our outside PCL).
 .. note::
    Starting with PCL-1.7 you need to define PCL_NO_PRECOMPILE before you include
    any PCL headers to include the templated algorithms as well.
-   
+
 .. note::
-   The invocation of `POINT_CLOUD_REGISTER_POINT_STRUCT` must be in the global 
+   The invocation of `POINT_CLOUD_REGISTER_POINT_STRUCT` must be in the global
    namespace and the name of the new point type must be fully qualified.
 
 Example
@@ -864,3 +864,34 @@ data (SSE padded), together with a test float.
 
      pcl::io::savePCDFile ("test.pcd", cloud);
    }
+
+.. note::
+   The custom point type will not default-initialize its `data` field so that it can be
+   viewed as a homogeneous vector (i.e. the 4th coordinate is 1). This may lead to problems
+   when code expects this to be true and does math with the vector maps of the point type
+   (e.g. `getVector4fMap()`). If this is needed, you have to take care of this yourself,
+   e.g. like this:
+
+  .. code-block:: cpp
+     :linenos:
+
+     struct _MyPointType {
+        PCL_ADD_POINT4D;
+        float test;
+        PCL_MAKE_ALIGNED_OPERATOR_NEW
+      };
+
+      struct MyPointType : public _MyPointType {
+        inline constexpr MyPointType(const _MyPointType& p) :
+            MyPointType(p.x, p.y, p.z) {
+        }
+
+        inline constexpr MyPointType() : MyPointType(0.f, 0.f, 0.f) {
+        }
+
+        inline constexpr MyPointType(float _x,
+                                    float _y,
+                                    float _z) :
+            _MyPointType({{{_x, _y, _z, 1.f}}}) {   // <- make sure that 4th coordinate is set to 1 on construction
+        }
+      };


### PR DESCRIPTION
The 4th homogeneous coordinate of custom point types is not set to 1.

Got bitten by this since i made a custom point type without custom constructor and a library was expecting the points to be homogeneous and computed hard to debug garbage.