### PR TITLE
Replace deprecated VTK function

### DIFF
--- a/visualization/src/histogram_visualizer.cpp
+++ b/visualization/src/histogram_visualizer.cpp
@@ -170,7 +170,7 @@ void
 pcl::visualization::PCLHistogramVisualizer::reCreateActor (
     const vtkSmartPointer<vtkDoubleArray> &xy_array, RenWinInteract* renwinupd, const int hsize)
 {
-  renwinupd->ren_->RemoveActor2D (renwinupd->xy_plot_);
+  renwinupd->ren_->RemoveViewProp (renwinupd->xy_plot_);
   renwinupd->xy_plot_->RemoveAllDataSetInputConnections ();
   
   double min_max[2];


### PR DESCRIPTION
On the VTK master branch, the function is already removed. Related to https://github.com/PointCloudLibrary/pcl/pull/6314/commits/7e4f6e844bfd1a54a61337324ae23cf49113e800