### PR TITLE
Update docker image Ubuntu versions

### DIFF
--- a/.ci/azure-pipelines/env.yml
+++ b/.ci/azure-pipelines/env.yml
@@ -42,25 +42,21 @@ jobs:
   strategy:
     matrix:
       # Test the oldest supported version of Ubuntu
-      Ubuntu 20.04:
-        UBUNTU_VERSION: 20.04
-        VTK_VERSION: 7
-        TAG: 20.04
       Ubuntu 22.04:
         UBUNTU_VERSION: 22.04
-        VTK_VERSION: 9
+        VTK_VERSION: 7
         TAG: 22.04
       # Test the latest LTS version of Ubuntu
       Ubuntu 24.04:
         UBUNTU_VERSION: 24.04
         VTK_VERSION: 9
         TAG: 24.04
-      # Test the latest version of Ubuntu (non LTS)
-      Ubuntu 24.10:
-        UBUNTU_VERSION: 24.10
+      # Test the latest version of Ubuntu (LTS or non-LTS)
+      Ubuntu 26.04:
+        UBUNTU_VERSION: 26.04
         USE_LATEST_CMAKE: true
         VTK_VERSION: 9
-        TAG: 24.10
+        TAG: 26.04
   steps:
   - script: |
       dockerBuildArgs="" ; \


### PR DESCRIPTION
Now, docker images for Ubuntu 22.04, 24.04, and 26.04 are built.