### PR TITLE
Fix macOS CI build

### DIFF
--- a/.ci/azure-pipelines/build/macos.yaml
+++ b/.ci/azure-pipelines/build/macos.yaml
@@ -4,7 +4,7 @@ steps:
     fetchDepth: 10
   - script: |
       brew install cmake
-      brew install pkg-config boost eigen flann nanoflann glew libusb qhull vtk glew freeglut qt5 libpcap libomp suite-sparse zlib google-benchmark cjson
+      brew install pkg-config boost eigen flann nanoflann glew libusb qhull vtk glew freeglut qt libpcap libomp suite-sparse zlib google-benchmark cjson
       brew install brewsci/science/openni
       git clone https://github.com/abseil/googletest.git $GOOGLE_TEST_DIR # the official endpoint changed to abseil/googletest
       cd $GOOGLE_TEST_DIR && git checkout release-1.8.1
@@ -17,7 +17,6 @@ steps:
         -DCMAKE_CXX_FLAGS="$CMAKE_CXX_FLAGS" \
         -DGTEST_SRC_DIR="$GOOGLE_TEST_DIR/googletest" \
         -DGTEST_INCLUDE_DIR="$GOOGLE_TEST_DIR/googletest/include" \
-        -DQt5_DIR=/usr/local/opt/qt5/lib/cmake/Qt5 \
         -DPCL_ONLY_CORE_POINT_TYPES=ON \
         -DBUILD_surface_on_nurbs=ON -DUSE_UMFPACK=ON \
         -DBUILD_simulation=ON \


### PR DESCRIPTION
Use default Qt version instead of Qt5 specifically. PCL also works with Qt6.