### PR TITLE
Replace some deprecated Eigen and VTK functions

### DIFF
--- a/apps/src/face_detection/filesystem_face_detection.cpp
+++ b/apps/src/face_detection/filesystem_face_detection.cpp
@@ -98,7 +98,7 @@ run(pcl::RFFaceDetectorTrainer& fdrf,
     bool result = face_detection_apps_utils::readMatrixFromFile(pose_file, pose_mat);
 
     if (result) {
-#if (EIGEN_WORLD_VERSION > 3 || (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 5))
+#if EIGEN_VERSION_AT_LEAST(5, 0, 0)
       Eigen::Vector3f ea = pose_mat.topLeftCorner<3, 3>().canonicalEulerAngles(0, 1, 2);
 #else
       Eigen::Vector3f ea = pose_mat.topLeftCorner<3, 3>().eulerAngles(0, 1, 2);

--- a/apps/src/face_detection/filesystem_face_detection.cpp
+++ b/apps/src/face_detection/filesystem_face_detection.cpp
@@ -98,7 +98,11 @@ run(pcl::RFFaceDetectorTrainer& fdrf,
     bool result = face_detection_apps_utils::readMatrixFromFile(pose_file, pose_mat);
 
     if (result) {
+#if (EIGEN_WORLD_VERSION > 3 || (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 5))
+      Eigen::Vector3f ea = pose_mat.topLeftCorner<3, 3>().canonicalEulerAngles(0, 1, 2);
+#else
       Eigen::Vector3f ea = pose_mat.topLeftCorner<3, 3>().eulerAngles(0, 1, 2);
+#endif
       Eigen::Vector3f trans_vector =
           Eigen::Vector3f(pose_mat(0, 3), pose_mat(1, 3), pose_mat(2, 3));
       std::cout << ea << std::endl;

--- a/recognition/src/face_detection/face_detector_data_provider.cpp
+++ b/recognition/src/face_detection/face_detector_data_provider.cpp
@@ -93,7 +93,11 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
 
     if (readMatrixFromFile (pose_file, pose_mat))
     {
+#if (EIGEN_WORLD_VERSION > 3 || (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 5))
+      Eigen::Vector3f ea = pose_mat.topLeftCorner<3, 3> ().canonicalEulerAngles (0, 1, 2);
+#else
       Eigen::Vector3f ea = pose_mat.topLeftCorner<3, 3> ().eulerAngles (0, 1, 2);
+#endif
       ea *= 57.2957795f; //transform it to degrees to do the binning
       int y = static_cast<int>(pcl_round ((ea[0] + static_cast<float>(std::abs (min_yaw))) / res_yaw));
       int p = static_cast<int>(pcl_round ((ea[1] + static_cast<float>(std::abs (min_pitch))) / res_pitch));
@@ -354,7 +358,11 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
     pose_mat.setIdentity (4, 4);
     readMatrixFromFile (pose_file, pose_mat);
 
+#if (EIGEN_WORLD_VERSION > 3 || (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 5))
+    Eigen::Vector3f ea = pose_mat.topLeftCorner<3, 3> ().canonicalEulerAngles (0, 1, 2);
+#else
     Eigen::Vector3f ea = pose_mat.topLeftCorner<3, 3> ().eulerAngles (0, 1, 2);
+#endif
     Eigen::Vector3f trans_vector = Eigen::Vector3f (pose_mat (0, 3), pose_mat (1, 3), pose_mat (2, 3));
 
     pcl::PointXYZ center_point;

--- a/recognition/src/face_detection/face_detector_data_provider.cpp
+++ b/recognition/src/face_detection/face_detector_data_provider.cpp
@@ -93,7 +93,7 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
 
     if (readMatrixFromFile (pose_file, pose_mat))
     {
-#if (EIGEN_WORLD_VERSION > 3 || (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 5))
+#if EIGEN_VERSION_AT_LEAST(5, 0, 0)
       Eigen::Vector3f ea = pose_mat.topLeftCorner<3, 3> ().canonicalEulerAngles (0, 1, 2);
 #else
       Eigen::Vector3f ea = pose_mat.topLeftCorner<3, 3> ().eulerAngles (0, 1, 2);
@@ -358,7 +358,7 @@ void pcl::face_detection::FaceDetectorDataProvider<FeatureType, DataSet, LabelTy
     pose_mat.setIdentity (4, 4);
     readMatrixFromFile (pose_file, pose_mat);
 
-#if (EIGEN_WORLD_VERSION > 3 || (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 5))
+#if EIGEN_VERSION_AT_LEAST(5, 0, 0)
     Eigen::Vector3f ea = pose_mat.topLeftCorner<3, 3> ().canonicalEulerAngles (0, 1, 2);
 #else
     Eigen::Vector3f ea = pose_mat.topLeftCorner<3, 3> ().eulerAngles (0, 1, 2);

--- a/recognition/src/face_detection/rf_face_detector_trainer.cpp
+++ b/recognition/src/face_detection/rf_face_detector_trainer.cpp
@@ -519,7 +519,7 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
       head_clusters_centers_[i][1] = icp_trans (1, 3);
       head_clusters_centers_[i][2] = icp_trans (2, 3);
 
-#if (EIGEN_WORLD_VERSION > 3 || (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 5))
+#if EIGEN_VERSION_AT_LEAST(5, 0, 0)
       Eigen::Vector3f ea = icp_trans.topLeftCorner<3, 3> ().canonicalEulerAngles (0, 1, 2);
 #else
       Eigen::Vector3f ea = icp_trans.topLeftCorner<3, 3> ().eulerAngles (0, 1, 2);

--- a/recognition/src/face_detection/rf_face_detector_trainer.cpp
+++ b/recognition/src/face_detection/rf_face_detector_trainer.cpp
@@ -519,7 +519,11 @@ void pcl::RFFaceDetectorTrainer::detectFaces()
       head_clusters_centers_[i][1] = icp_trans (1, 3);
       head_clusters_centers_[i][2] = icp_trans (2, 3);
 
+#if (EIGEN_WORLD_VERSION > 3 || (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 5))
+      Eigen::Vector3f ea = icp_trans.topLeftCorner<3, 3> ().canonicalEulerAngles (0, 1, 2);
+#else
       Eigen::Vector3f ea = icp_trans.topLeftCorner<3, 3> ().eulerAngles (0, 1, 2);
+#endif
       head_clusters_rotation_[i][0] = ea[0];
       head_clusters_rotation_[i][1] = ea[1];
       head_clusters_rotation_[i][2] = ea[2];

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -116,7 +116,7 @@ NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeTransform
   // Convert initial guess matrix to 6 element transformation vector
   Eigen::Matrix<double, 6, 1> transform, score_gradient;
   Vector3 init_translation = eig_transformation.translation();
-#if (EIGEN_WORLD_VERSION > 3 || (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 5))
+#if EIGEN_VERSION_AT_LEAST(5, 0, 0)
   Vector3 init_rotation = eig_transformation.rotation().canonicalEulerAngles(0, 1, 2);
 #else
   Vector3 init_rotation = eig_transformation.rotation().eulerAngles(0, 1, 2);

--- a/registration/include/pcl/registration/impl/ndt.hpp
+++ b/registration/include/pcl/registration/impl/ndt.hpp
@@ -116,7 +116,11 @@ NormalDistributionsTransform<PointSource, PointTarget, Scalar>::computeTransform
   // Convert initial guess matrix to 6 element transformation vector
   Eigen::Matrix<double, 6, 1> transform, score_gradient;
   Vector3 init_translation = eig_transformation.translation();
+#if (EIGEN_WORLD_VERSION > 3 || (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 5))
+  Vector3 init_rotation = eig_transformation.rotation().canonicalEulerAngles(0, 1, 2);
+#else
   Vector3 init_rotation = eig_transformation.rotation().eulerAngles(0, 1, 2);
+#endif
   transform << init_translation.template cast<double>(),
       init_rotation.template cast<double>();
 

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_torus.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_torus.hpp
@@ -213,7 +213,11 @@ pcl::SampleConsensusModelTorus<PointT, PointNT>::computeModelCoefficients(
     B << -d.dot(p0), -d.dot(p1), -d.dot(p2), -d.dot(p3);
 
     Eigen::Matrix<float, -1, -1> sol;
+#if (EIGEN_WORLD_VERSION > 3 || (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 5))
+    sol = A.jacobiSvd<Eigen::ComputeThinU | Eigen::ComputeThinV>().solve(B);
+#else
     sol = A.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(B);
+#endif
 
     const float r_min = -sol(0);
     const float D = sol(1);

--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_torus.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_torus.hpp
@@ -213,7 +213,7 @@ pcl::SampleConsensusModelTorus<PointT, PointNT>::computeModelCoefficients(
     B << -d.dot(p0), -d.dot(p1), -d.dot(p2), -d.dot(p3);
 
     Eigen::Matrix<float, -1, -1> sol;
-#if (EIGEN_WORLD_VERSION > 3 || (EIGEN_WORLD_VERSION == 3 && EIGEN_MAJOR_VERSION >= 5))
+#if EIGEN_VERSION_AT_LEAST(5, 0, 0)
     sol = A.jacobiSvd<Eigen::ComputeThinU | Eigen::ComputeThinV>().solve(B);
 #else
     sol = A.jacobiSvd(Eigen::ComputeThinU | Eigen::ComputeThinV).solve(B);

--- a/visualization/src/image_viewer.cpp
+++ b/visualization/src/image_viewer.cpp
@@ -66,7 +66,10 @@ pcl::visualization::ImageViewer::ImageViewer (const std::string& window_title)
 {
   // Prepare for image flip
   algo_->SetInterpolationModeToCubic ();
+#if (VTK_MAJOR_VERSION < 9 || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION < 6))
+  // starting with VTK 9.6.0, this is a no-op and marked deprecated
   algo_->PreserveImageExtentOn ();
+#endif
   algo_->FlipAboutOriginOn ();
   algo_->SetFilteredAxis (1);
 

--- a/visualization/src/point_picking_event.cpp
+++ b/visualization/src/point_picking_event.cpp
@@ -212,8 +212,11 @@ pcl::visualization::PointPickingCallback::performAreaPick (vtkRenderWindowIntera
 
     vtkPolyData* selected = glyph_filter->GetOutput ();
     vtkIdTypeArray* global_ids  = vtkIdTypeArray::SafeDownCast (selected->GetPointData ()->GetArray ("Indices"));
-
+#if (VTK_MAJOR_VERSION > 9 || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7))
+    if (!global_ids->GetCapacity () || !selected->GetNumberOfPoints ())
+#else
     if (!global_ids->GetSize () || !selected->GetNumberOfPoints ())
+#endif
       continue;
 
     Indices actor_indices;


### PR DESCRIPTION
- Use `canonicalEulerAngles` instead of `eulerAngles` if Eigen version is 5.0.0 or newer
- Specify options as template parameters in `jacobiSvd` if Eigen version is 5.0.0 or newer
- Do not call `PreserveImageExtentOn` if VTK version is 9.6.0 or newer
- Use `GetCapacity` insstead of `GetSize` if VTK version is 9.7.0 or newer