### PR TITLE
Fix gpu module building with cuda 13.2

### DIFF
--- a/gpu/utils/include/pcl/gpu/utils/device/functional.hpp
+++ b/gpu/utils/include/pcl/gpu/utils/device/functional.hpp
@@ -40,7 +40,10 @@
 
 #include <thrust/functional.h>
 #include <cuda.h>
-#include <functional>
+
+#if CUDA_VERSION >= 13000
+#include <cuda/std/functional>
+#endif
 
 namespace pcl
 {
@@ -85,9 +88,7 @@ namespace pcl
         };
 
         // Generalized Identity Operations
-        #if CUDA_VERSION >= 13020
-        using std::identity;
-        #elif CUDA_VERSION >= 13000
+        #if CUDA_VERSION >= 13000
         using cuda::std::identity;
         #else
         using thrust::identity;

--- a/gpu/utils/include/pcl/gpu/utils/device/functional.hpp
+++ b/gpu/utils/include/pcl/gpu/utils/device/functional.hpp
@@ -40,6 +40,7 @@
 
 #include <thrust/functional.h>
 #include <cuda.h>
+#include <functional>
 
 namespace pcl
 {
@@ -84,8 +85,9 @@ namespace pcl
         };
 
         // Generalized Identity Operations
-
-        #if CUDA_VERSION >= 13000
+        #if CUDA_VERSION >= 13020
+        using std::identity;
+        #elif CUDA_VERSION >= 13000
         using cuda::std::identity;
         #else
         using thrust::identity;


### PR DESCRIPTION
Cuda 13.2 ships the identity type but it lives in the libcu++ header. We should include `<cuda/std/functional>` to ensure `cuda::std::identity` is defined. This fixes the build for CUDA 13.2.

This was tested on Ubuntu 24.04 with CUDA 13.2 and CUDA 12.9. 

Fixes https://github.com/PointCloudLibrary/pcl/issues/6423