### PR TITLE
 Fix typo in docs of getMaxBoxCoordinates functions in voxel grid

### DIFF
--- a/filters/include/pcl/filters/voxel_grid.h
+++ b/filters/include/pcl/filters/voxel_grid.h
@@ -325,7 +325,7 @@ namespace pcl
       inline Eigen::Vector3i
       getMinBoxCoordinates () const { return (min_b_.head<3> ()); }
 
-      /** \brief Get the minimum coordinates of the bounding box (after
+      /** \brief Get the maximum coordinates of the bounding box (after
         * filtering is performed).
         */
       inline Eigen::Vector3i
@@ -645,7 +645,7 @@ namespace pcl
       inline Eigen::Vector3i
       getMinBoxCoordinates () const { return (min_b_.head<3> ()); }
 
-      /** \brief Get the minimum coordinates of the bounding box (after
+      /** \brief Get the maximum coordinates of the bounding box (after
         * filtering is performed).
         */
       inline Eigen::Vector3i


### PR DESCRIPTION
_Edited:_ Fix typo in documentation of getMaxBoxCoordinates functions in voxel grid