### PR TITLE
registration: parallelize SAC-IA error metric with OpenMP

### DIFF
--- a/registration/include/pcl/registration/ia_ransac.h
+++ b/registration/include/pcl/registration/ia_ransac.h
@@ -150,6 +150,7 @@ public:
     corr_dist_threshold_ = 100.0f;
     transformation_estimation_.reset(
         new pcl::registration::TransformationEstimationSVD<PointSource, PointTarget>);
+    setNumberOfThreads();
   };
 
   /** \brief Provide a shared pointer to the source point cloud's feature descriptors
@@ -229,6 +230,13 @@ public:
   {
     return (k_correspondences_);
   }
+
+  /** \brief Initialize the scheduler and set the number of threads to use.
+   * \param nr_threads the number of hardware threads to use (0 sets the value back to
+   * automatic)
+   */
+  void
+  setNumberOfThreads(unsigned int nr_threads = 0);
 
   /** \brief Specify the error function to minimize
    * \note This call is optional.  TruncatedError will be used by default
@@ -315,6 +323,9 @@ protected:
   /** \brief The number of neighbors to use when selecting a random feature
    * correspondence. */
   int k_correspondences_{10};
+
+  /** \brief The number of threads the scheduler should use. */
+  unsigned int threads_{1};
 
   /** \brief The KdTree used to compare feature descriptors. */
   FeatureKdTreePtr feature_tree_;

--- a/registration/include/pcl/registration/impl/ia_ransac.hpp
+++ b/registration/include/pcl/registration/impl/ia_ransac.hpp
@@ -172,12 +172,16 @@ SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::computeErro
   std::vector<float> nn_distance(1);
 
   const ErrorFunctor& compute_error = *error_functor_;
+  const auto tree = tree_;
   float error = 0;
 
-  for (const auto& point : cloud) {
+#pragma omp parallel for default(none) shared(cloud, tree, compute_error)              \
+    firstprivate(nn_index, nn_distance) reduction(+ : error)
+  for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(cloud.size()); ++i) {
+    const auto& point = cloud[static_cast<std::size_t>(i)];
     // Find the distance between point and its nearest neighbor in the target point
     // cloud
-    tree_->nearestKSearch(point, 1, nn_index, nn_distance);
+    tree->nearestKSearch(point, 1, nn_index, nn_distance);
 
     // Compute the error
     error += compute_error(nn_distance[0]);

--- a/registration/include/pcl/registration/impl/ia_ransac.hpp
+++ b/registration/include/pcl/registration/impl/ia_ransac.hpp
@@ -48,6 +48,28 @@ namespace pcl {
 
 template <typename PointSource, typename PointTarget, typename FeatureT>
 void
+SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::setNumberOfThreads(
+    unsigned int nr_threads)
+{
+#ifdef _OPENMP
+  if (nr_threads == 0)
+    threads_ = omp_get_num_procs();
+  else
+    threads_ = nr_threads;
+  PCL_DEBUG("[pcl::%s::setNumberOfThreads] Setting number of threads to %u.\n",
+            getClassName().c_str(),
+            threads_);
+#else
+  threads_ = 1;
+  if (nr_threads != 1)
+    PCL_WARN("[pcl::%s::setNumberOfThreads] Parallelization is requested, but OpenMP "
+             "is not available! Continuing without parallelization.\n",
+             getClassName().c_str());
+#endif // _OPENMP
+}
+
+template <typename PointSource, typename PointTarget, typename FeatureT>
+void
 SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::setSourceFeatures(
     const FeatureCloudConstPtr& features)
 {
@@ -172,11 +194,11 @@ SampleConsensusInitialAlignment<PointSource, PointTarget, FeatureT>::computeErro
   std::vector<float> nn_distance(1);
 
   const ErrorFunctor& compute_error = *error_functor_;
-  const auto tree = tree_;
+  const auto& tree = tree_;
   float error = 0;
 
 #pragma omp parallel for default(none) shared(cloud, tree, compute_error)              \
-    firstprivate(nn_index, nn_distance) reduction(+ : error)
+    firstprivate(nn_index, nn_distance) reduction(+ : error) num_threads(threads_)
   for (std::ptrdiff_t i = 0; i < static_cast<std::ptrdiff_t>(cloud.size()); ++i) {
     const auto& point = cloud[static_cast<std::size_t>(i)];
     // Find the distance between point and its nearest neighbor in the target point


### PR DESCRIPTION
## Summary

This PR parallelizes the error accumulation loop in `SampleConsensusInitialAlignment::computeErrorMetric()` using OpenMP.

The change uses an OpenMP `parallel for` with a `reduction(+ : error)` and thread-local nearest-neighbor buffers via `firstprivate(...)`, so the accumulated registration error can be computed in parallel while preserving the original behavior.

## Changes

- parallelized the per-point loop in `registration/include/pcl/registration/impl/ia_ransac.hpp`
- added OpenMP reduction for the `error` accumulator
- kept nearest-neighbor index/distance buffers thread-local inside the parallel region

## Validation

Built and ran the existing SAC-IA registration test locally on Windows/MSVC:

```bash
cmake --build D:\pcl\build --config Release --target test_sac_ia
ctest --test-dir D:\pcl\build\test -C Release -R sac_ia --output-on-failure
