### PR TITLE
Add degenercy-aware point-to-plane registeration method DCReg

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,7 @@
 
 #### libpcl_registration:
 
+* **[new feature]** Add DCReg degeneracy-aware point-to-plane transformation estimation.
 * add explicit instantiations to transformation estimation LM and one to ICP [[#6258](https://github.com/PointCloudLibrary/pcl/pull/6258)]
 * Make GICP use CorrespondenceEstimation [[#6278](https://github.com/PointCloudLibrary/pcl/pull/6278)]
 

--- a/registration/CMakeLists.txt
+++ b/registration/CMakeLists.txt
@@ -58,6 +58,7 @@ set(incs
   "include/pcl/${SUBSYS_NAME}/transformation_estimation_point_to_plane.h"
   "include/pcl/${SUBSYS_NAME}/transformation_estimation_point_to_plane_weighted.h"
   "include/pcl/${SUBSYS_NAME}/transformation_estimation_point_to_plane_lls.h"
+  "include/pcl/${SUBSYS_NAME}/transformation_estimation_point_to_plane_dcreg.h"
   "include/pcl/${SUBSYS_NAME}/transformation_estimation_point_to_plane_lls_weighted.h"
   "include/pcl/${SUBSYS_NAME}/transformation_estimation_symmetric_point_to_plane_lls.h"
   "include/pcl/${SUBSYS_NAME}/transformation_validation.h"
@@ -107,6 +108,7 @@ set(impl_incs
   "include/pcl/${SUBSYS_NAME}/impl/transformation_estimation_dual_quaternion.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/transformation_estimation_lm.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/transformation_estimation_point_to_plane_lls.hpp"
+  "include/pcl/${SUBSYS_NAME}/impl/transformation_estimation_point_to_plane_dcreg.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/transformation_estimation_point_to_plane_lls_weighted.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/transformation_estimation_point_to_plane_weighted.hpp"
   "include/pcl/${SUBSYS_NAME}/impl/transformation_estimation_symmetric_point_to_plane_lls.hpp"
@@ -156,6 +158,7 @@ set(srcs
   src/transformation_estimation_lm.cpp
   src/transformation_estimation_point_to_plane_weighted.cpp
   src/transformation_estimation_point_to_plane_lls.cpp
+  src/transformation_estimation_point_to_plane_dcreg.cpp
   src/transformation_estimation_point_to_plane_lls_weighted.cpp
   src/transformation_validation_euclidean.cpp
   src/sample_consensus_prerejective.cpp

--- a/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_dcreg.hpp
+++ b/registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_dcreg.hpp
@@ -1,0 +1,644 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2012-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_POINT_TO_PLANE_DCREG_HPP_
+#define PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_POINT_TO_PLANE_DCREG_HPP_
+
+#include <pcl/console/print.h>
+#include <pcl/cloud_iterator.h>
+
+#include <Eigen/Cholesky>
+#include <Eigen/Eigenvalues>
+#include <Eigen/LU>
+#include <Eigen/QR>
+#include <Eigen/SVD>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+
+namespace pcl {
+namespace registration {
+namespace detail {
+
+using Vector6d = Eigen::Matrix<double, 6, 1>;
+using Matrix6d = Eigen::Matrix<double, 6, 6>;
+
+constexpr double min_pivot = 1e-12;
+constexpr double min_eigenvalue = 1e-9;
+
+struct DCRegLinearSystem {
+  Matrix6d hessian{Matrix6d::Zero()};
+  Vector6d rhs{Vector6d::Zero()};
+  int valid_correspondences{0};
+};
+
+struct DCRegDetection {
+  bool factorization_ok{false};
+  Eigen::Vector3d lambda_rot{
+      Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN())};
+  Eigen::Vector3d lambda_trans{
+      Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN())};
+  Eigen::Matrix3d basis_rot{Eigen::Matrix3d::Identity()};
+  Eigen::Matrix3d basis_trans{Eigen::Matrix3d::Identity()};
+};
+
+struct DCRegCharacterization {
+  bool factorization_ok{false};
+  Eigen::Matrix<double, 6, 6> preconditioner{Matrix6d::Identity()};
+  double condition_number_rot{std::numeric_limits<double>::quiet_NaN()};
+  double condition_number_trans{std::numeric_limits<double>::quiet_NaN()};
+  Eigen::Vector3d aligned_lambda_rot{
+      Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN())};
+  Eigen::Vector3d aligned_lambda_trans{
+      Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN())};
+  Eigen::Vector3i weak_rot_axes{Eigen::Vector3i::Zero()};
+  Eigen::Vector3i weak_trans_axes{Eigen::Vector3i::Zero()};
+};
+
+struct DCRegSolverResult {
+  Vector6d update{Vector6d::Zero()};
+  std::string solver_type{"dense"};
+  bool pcg_converged{false};
+  int pcg_iterations{0};
+};
+
+inline double
+conditionNumber(const Eigen::Vector3d& lambda)
+{
+  return (lambda.maxCoeff() / std::max(lambda.minCoeff(), min_pivot));
+}
+
+inline double
+fullConditionNumber(const Matrix6d& hessian)
+{
+  const Eigen::JacobiSVD<Matrix6d> svd(hessian);
+  const Vector6d singular_values = svd.singularValues();
+  return (singular_values(0) / std::max(singular_values(5), min_pivot));
+}
+
+inline bool
+eigenDecomposeSymmetric(const Eigen::Matrix3d& matrix,
+                        Eigen::Vector3d& eigenvalues,
+                        Eigen::Matrix3d& eigenvectors)
+{
+  const Eigen::Matrix3d symmetric = 0.5 * (matrix + matrix.transpose());
+  const Eigen::SelfAdjointEigenSolver<Eigen::Matrix3d> solver(symmetric);
+  if (solver.info() != Eigen::Success)
+    return (false);
+
+  eigenvalues = solver.eigenvalues();
+  eigenvectors = solver.eigenvectors();
+  return (eigenvalues.allFinite() && eigenvectors.allFinite());
+}
+
+inline DCRegDetection
+detectSchurDegeneracy(const Matrix6d& hessian)
+{
+  DCRegDetection detection;
+  const Eigen::Matrix3d h_rr = hessian.block<3, 3>(0, 0);
+  const Eigen::Matrix3d h_rt = hessian.block<3, 3>(0, 3);
+  const Eigen::Matrix3d h_tr = hessian.block<3, 3>(3, 0);
+  const Eigen::Matrix3d h_tt = hessian.block<3, 3>(3, 3);
+
+  const Eigen::FullPivLU<Eigen::Matrix3d> lu_rr(h_rr);
+  const Eigen::FullPivLU<Eigen::Matrix3d> lu_tt(h_tt);
+  if (!lu_rr.isInvertible() || !lu_tt.isInvertible())
+    return (detection);
+
+  const Eigen::Matrix3d schur_rot = h_rr - h_rt * lu_tt.solve(h_tr);
+  const Eigen::Matrix3d schur_trans = h_tt - h_tr * lu_rr.solve(h_rt);
+  if (!eigenDecomposeSymmetric(schur_rot, detection.lambda_rot, detection.basis_rot) ||
+      !eigenDecomposeSymmetric(
+          schur_trans, detection.lambda_trans, detection.basis_trans))
+    return (detection);
+
+  detection.factorization_ok = true;
+  return (detection);
+}
+
+inline DCRegDetection
+detectBlockFallback(const Matrix6d& hessian)
+{
+  DCRegDetection detection;
+  if (!eigenDecomposeSymmetric(
+          hessian.block<3, 3>(0, 0), detection.lambda_rot, detection.basis_rot) ||
+      !eigenDecomposeSymmetric(
+          hessian.block<3, 3>(3, 3), detection.lambda_trans, detection.basis_trans))
+    return (detection);
+
+  detection.factorization_ok = true;
+  return (detection);
+}
+
+inline bool
+alignEigenBasisToAxes(const Eigen::Matrix3d& raw_basis,
+                      Eigen::Matrix3d& aligned_basis,
+                      std::array<int, 3>& original_indices)
+{
+  const std::array<Eigen::Vector3d, 3> reference_axes = {
+      Eigen::Vector3d::UnitX(), Eigen::Vector3d::UnitY(), Eigen::Vector3d::UnitZ()};
+  std::array<bool, 3> used = {false, false, false};
+  original_indices.fill(-1);
+  aligned_basis.setZero();
+
+  for (int axis = 0; axis < 3; ++axis) {
+    double best_score = -1.0;
+    int best_index = -1;
+    for (int candidate = 0; candidate < 3; ++candidate) {
+      if (used[candidate])
+        continue;
+      const double score = std::abs(reference_axes[axis].dot(raw_basis.col(candidate)));
+      if (score > best_score) {
+        best_score = score;
+        best_index = candidate;
+      }
+    }
+    if (best_index < 0)
+      return (false);
+    used[best_index] = true;
+    original_indices[axis] = best_index;
+    aligned_basis.col(axis) = raw_basis.col(best_index);
+    if (reference_axes[axis].dot(aligned_basis.col(axis)) < 0.0)
+      aligned_basis.col(axis) = -aligned_basis.col(axis);
+  }
+  return (true);
+}
+
+inline Eigen::Vector3i
+weakAxes(const Eigen::Vector3d& aligned_lambda, double condition_threshold)
+{
+  Eigen::Vector3i weak_axes = Eigen::Vector3i::Zero();
+  const double lambda_max = std::max(aligned_lambda.maxCoeff(), min_eigenvalue);
+  const double threshold = std::max(condition_threshold, 1.0);
+  for (int axis = 0; axis < 3; ++axis) {
+    const double condition = lambda_max / std::max(aligned_lambda(axis), min_pivot);
+    if (condition > threshold)
+      weak_axes(axis) = 1;
+  }
+  return (weak_axes);
+}
+
+inline Eigen::Vector3d
+clampWeakEigenvalues(const Eigen::Vector3d& aligned_lambda,
+                     const Eigen::Vector3i& weak_axes,
+                     double kappa_target)
+{
+  Eigen::Vector3d clamped = aligned_lambda;
+  const double lambda_max = std::max(aligned_lambda.maxCoeff(), min_eigenvalue);
+  const double weak_lambda =
+      std::max(lambda_max / std::max(kappa_target, 1.0), min_eigenvalue);
+  for (int axis = 0; axis < 3; ++axis) {
+    if (weak_axes(axis))
+      clamped(axis) = weak_lambda;
+  }
+  return (clamped);
+}
+
+inline DCRegCharacterization
+characterizeDegeneracy(const DCRegDetection& detection,
+                       double condition_threshold,
+                       double kappa_target)
+{
+  DCRegCharacterization characterization;
+  characterization.factorization_ok = detection.factorization_ok;
+  if (!detection.factorization_ok)
+    return (characterization);
+
+  Eigen::Matrix3d aligned_rot_basis;
+  Eigen::Matrix3d aligned_trans_basis;
+  std::array<int, 3> rot_indices;
+  std::array<int, 3> trans_indices;
+  if (!alignEigenBasisToAxes(detection.basis_rot, aligned_rot_basis, rot_indices) ||
+      !alignEigenBasisToAxes(
+          detection.basis_trans, aligned_trans_basis, trans_indices)) {
+    characterization.factorization_ok = false;
+    return (characterization);
+  }
+
+  for (int axis = 0; axis < 3; ++axis) {
+    characterization.aligned_lambda_rot(axis) = detection.lambda_rot(rot_indices[axis]);
+    characterization.aligned_lambda_trans(axis) =
+        detection.lambda_trans(trans_indices[axis]);
+  }
+
+  characterization.condition_number_rot =
+      conditionNumber(characterization.aligned_lambda_rot);
+  characterization.condition_number_trans =
+      conditionNumber(characterization.aligned_lambda_trans);
+  characterization.weak_rot_axes =
+      weakAxes(characterization.aligned_lambda_rot, condition_threshold);
+  characterization.weak_trans_axes =
+      weakAxes(characterization.aligned_lambda_trans, condition_threshold);
+
+  const Eigen::Vector3d clamped_rot =
+      clampWeakEigenvalues(characterization.aligned_lambda_rot,
+                           characterization.weak_rot_axes,
+                           kappa_target);
+  const Eigen::Vector3d clamped_trans =
+      clampWeakEigenvalues(characterization.aligned_lambda_trans,
+                           characterization.weak_trans_axes,
+                           kappa_target);
+
+  characterization.preconditioner.setZero();
+  characterization.preconditioner.block<3, 3>(0, 0) =
+      aligned_rot_basis *
+      clamped_rot.cwiseMax(min_eigenvalue).cwiseInverse().asDiagonal() *
+      aligned_rot_basis.transpose();
+  characterization.preconditioner.block<3, 3>(3, 3) =
+      aligned_trans_basis *
+      clamped_trans.cwiseMax(min_eigenvalue).cwiseInverse().asDiagonal() *
+      aligned_trans_basis.transpose();
+  return (characterization);
+}
+
+inline bool
+solveRankDeficientMinimumNorm(const DCRegLinearSystem& system, Vector6d& update)
+{
+  const Matrix6d hessian = 0.5 * (system.hessian + system.hessian.transpose());
+  const Eigen::SelfAdjointEigenSolver<Matrix6d> solver(hessian);
+  if (solver.info() != Eigen::Success)
+    return (false);
+
+  const Vector6d eigenvalues = solver.eigenvalues();
+  const double lambda_max = eigenvalues.cwiseAbs().maxCoeff();
+  if (lambda_max < min_pivot) {
+    update.setZero();
+    return (true);
+  }
+
+  const double nullspace_threshold = std::max(lambda_max * 1e-10, min_pivot);
+  bool rank_deficient = false;
+  Vector6d inverse_eigenvalues = Vector6d::Zero();
+  for (int i = 0; i < 6; ++i) {
+    if (eigenvalues(i) <= nullspace_threshold) {
+      rank_deficient = true;
+      continue;
+    }
+    inverse_eigenvalues(i) = 1.0 / eigenvalues(i);
+  }
+  if (!rank_deficient)
+    return (false);
+
+  update = solver.eigenvectors() * inverse_eigenvalues.asDiagonal() *
+           solver.eigenvectors().transpose() * system.rhs;
+  return (update.allFinite());
+}
+
+inline DCRegSolverResult
+solveDenseFallback(const DCRegLinearSystem& system)
+{
+  DCRegSolverResult result;
+  const Matrix6d hessian = 0.5 * (system.hessian + system.hessian.transpose());
+  const Eigen::LDLT<Matrix6d> ldlt(hessian);
+  if (ldlt.info() == Eigen::Success && ldlt.isPositive()) {
+    result.update = ldlt.solve(system.rhs);
+    if (result.update.allFinite()) {
+      result.solver_type = "dense";
+      return (result);
+    }
+  }
+
+  result.solver_type = "qr_fallback";
+  result.update = system.hessian.colPivHouseholderQr().solve(system.rhs);
+  if (!result.update.allFinite())
+    result.update.setZero();
+  return (result);
+}
+
+inline DCRegSolverResult
+solvePreconditioned(const DCRegLinearSystem& system,
+                    const DCRegCharacterization& characterization,
+                    double pcg_tolerance,
+                    int pcg_max_iterations)
+{
+  Vector6d minimum_norm_update;
+  if (solveRankDeficientMinimumNorm(system, minimum_norm_update)) {
+    DCRegSolverResult result;
+    result.update = minimum_norm_update;
+    result.solver_type = "minimum_norm";
+    return (result);
+  }
+
+  if (!characterization.factorization_ok ||
+      !characterization.preconditioner.allFinite())
+    return (solveDenseFallback(system));
+
+  const Matrix6d hessian = 0.5 * (system.hessian + system.hessian.transpose());
+  const double rhs_norm = system.rhs.norm();
+  if (rhs_norm < min_pivot) {
+    DCRegSolverResult result;
+    result.solver_type = "zero_rhs";
+    result.pcg_converged = true;
+    return (result);
+  }
+
+  Vector6d delta = Vector6d::Zero();
+  Vector6d residual = system.rhs;
+  Vector6d z = characterization.preconditioner * residual;
+  Vector6d direction = z;
+  double rz_old = residual.dot(z);
+  if (!z.allFinite() || !std::isfinite(rz_old) || std::abs(rz_old) < min_pivot)
+    return (solveDenseFallback(system));
+
+  const double tolerance = pcg_tolerance > 0.0 ? pcg_tolerance : 1e-6;
+  const double target_residual = tolerance * std::max(1.0, rhs_norm);
+  const int max_iterations = std::max(1, pcg_max_iterations);
+  int iterations = 0;
+  for (int i = 0; i < max_iterations; ++i) {
+    iterations = i + 1;
+    const Vector6d hessian_direction = hessian * direction;
+    const double denom = direction.dot(hessian_direction);
+    if (!std::isfinite(denom) || std::abs(denom) < min_pivot)
+      break;
+
+    const double alpha = rz_old / denom;
+    if (!std::isfinite(alpha))
+      break;
+
+    delta += alpha * direction;
+    residual -= alpha * hessian_direction;
+    if (!delta.allFinite() || !residual.allFinite())
+      break;
+    if (residual.norm() <= target_residual) {
+      DCRegSolverResult result;
+      result.update = delta;
+      result.solver_type = "pcg";
+      result.pcg_converged = true;
+      result.pcg_iterations = iterations;
+      return (result);
+    }
+
+    z = characterization.preconditioner * residual;
+    const double rz_new = residual.dot(z);
+    if (!z.allFinite() || !std::isfinite(rz_new) || std::abs(rz_old) < min_pivot)
+      break;
+
+    const double beta = rz_new / rz_old;
+    if (!std::isfinite(beta))
+      break;
+    direction = z + beta * direction;
+    rz_old = rz_new;
+  }
+
+  DCRegSolverResult result = solveDenseFallback(system);
+  result.pcg_iterations = iterations;
+  return (result);
+}
+
+} // namespace detail
+
+template <typename PointSource, typename PointTarget, typename Scalar>
+inline void
+TransformationEstimationPointToPlaneDCReg<PointSource, PointTarget, Scalar>::
+    estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
+                                const pcl::PointCloud<PointTarget>& cloud_tgt,
+                                Matrix4& transformation_matrix) const
+{
+  if (cloud_tgt.size() != cloud_src.size()) {
+    PCL_ERROR("[pcl::TransformationEstimationPointToPlaneDCReg::"
+              "estimateRigidTransformation] Number or points in source (%zu) differs "
+              "than target (%zu)!\n",
+              static_cast<std::size_t>(cloud_src.size()),
+              static_cast<std::size_t>(cloud_tgt.size()));
+    return;
+  }
+
+  ConstCloudIterator<PointSource> source_it(cloud_src);
+  ConstCloudIterator<PointTarget> target_it(cloud_tgt);
+  estimateRigidTransformation(source_it, target_it, transformation_matrix);
+}
+
+template <typename PointSource, typename PointTarget, typename Scalar>
+inline void
+TransformationEstimationPointToPlaneDCReg<PointSource, PointTarget, Scalar>::
+    estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
+                                const pcl::Indices& indices_src,
+                                const pcl::PointCloud<PointTarget>& cloud_tgt,
+                                Matrix4& transformation_matrix) const
+{
+  if (cloud_tgt.size() != indices_src.size()) {
+    PCL_ERROR("[pcl::TransformationEstimationPointToPlaneDCReg::"
+              "estimateRigidTransformation] Number or points in source (%zu) differs "
+              "than target (%zu)!\n",
+              indices_src.size(),
+              static_cast<std::size_t>(cloud_tgt.size()));
+    return;
+  }
+
+  ConstCloudIterator<PointSource> source_it(cloud_src, indices_src);
+  ConstCloudIterator<PointTarget> target_it(cloud_tgt);
+  estimateRigidTransformation(source_it, target_it, transformation_matrix);
+}
+
+template <typename PointSource, typename PointTarget, typename Scalar>
+inline void
+TransformationEstimationPointToPlaneDCReg<PointSource, PointTarget, Scalar>::
+    estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
+                                const pcl::Indices& indices_src,
+                                const pcl::PointCloud<PointTarget>& cloud_tgt,
+                                const pcl::Indices& indices_tgt,
+                                Matrix4& transformation_matrix) const
+{
+  if (indices_tgt.size() != indices_src.size()) {
+    PCL_ERROR("[pcl::TransformationEstimationPointToPlaneDCReg::"
+              "estimateRigidTransformation] Number or points in source (%zu) differs "
+              "than target (%zu)!\n",
+              indices_src.size(),
+              indices_tgt.size());
+    return;
+  }
+
+  ConstCloudIterator<PointSource> source_it(cloud_src, indices_src);
+  ConstCloudIterator<PointTarget> target_it(cloud_tgt, indices_tgt);
+  estimateRigidTransformation(source_it, target_it, transformation_matrix);
+}
+
+template <typename PointSource, typename PointTarget, typename Scalar>
+inline void
+TransformationEstimationPointToPlaneDCReg<PointSource, PointTarget, Scalar>::
+    estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
+                                const pcl::PointCloud<PointTarget>& cloud_tgt,
+                                const pcl::Correspondences& correspondences,
+                                Matrix4& transformation_matrix) const
+{
+  ConstCloudIterator<PointSource> source_it(cloud_src, correspondences, true);
+  ConstCloudIterator<PointTarget> target_it(cloud_tgt, correspondences, false);
+  estimateRigidTransformation(source_it, target_it, transformation_matrix);
+}
+
+template <typename PointSource, typename PointTarget, typename Scalar>
+inline void
+TransformationEstimationPointToPlaneDCReg<PointSource, PointTarget, Scalar>::
+    constructTransformationMatrix(const double& alpha,
+                                  const double& beta,
+                                  const double& gamma,
+                                  const double& tx,
+                                  const double& ty,
+                                  const double& tz,
+                                  Matrix4& transformation_matrix) const
+{
+  transformation_matrix = Matrix4::Zero();
+  transformation_matrix(0, 0) = static_cast<Scalar>(std::cos(gamma) * std::cos(beta));
+  transformation_matrix(0, 1) =
+      static_cast<Scalar>(-std::sin(gamma) * std::cos(alpha) +
+                          std::cos(gamma) * std::sin(beta) * std::sin(alpha));
+  transformation_matrix(0, 2) =
+      static_cast<Scalar>(std::sin(gamma) * std::sin(alpha) +
+                          std::cos(gamma) * std::sin(beta) * std::cos(alpha));
+  transformation_matrix(1, 0) = static_cast<Scalar>(std::sin(gamma) * std::cos(beta));
+  transformation_matrix(1, 1) =
+      static_cast<Scalar>(std::cos(gamma) * std::cos(alpha) +
+                          std::sin(gamma) * std::sin(beta) * std::sin(alpha));
+  transformation_matrix(1, 2) =
+      static_cast<Scalar>(-std::cos(gamma) * std::sin(alpha) +
+                          std::sin(gamma) * std::sin(beta) * std::cos(alpha));
+  transformation_matrix(2, 0) = static_cast<Scalar>(-std::sin(beta));
+  transformation_matrix(2, 1) = static_cast<Scalar>(std::cos(beta) * std::sin(alpha));
+  transformation_matrix(2, 2) = static_cast<Scalar>(std::cos(beta) * std::cos(alpha));
+  transformation_matrix(0, 3) = static_cast<Scalar>(tx);
+  transformation_matrix(1, 3) = static_cast<Scalar>(ty);
+  transformation_matrix(2, 3) = static_cast<Scalar>(tz);
+  transformation_matrix(3, 3) = static_cast<Scalar>(1);
+}
+
+template <typename PointSource, typename PointTarget, typename Scalar>
+void
+TransformationEstimationPointToPlaneDCReg<PointSource, PointTarget, Scalar>::
+    estimateRigidTransformation(ConstCloudIterator<PointSource>& source_it,
+                                ConstCloudIterator<PointTarget>& target_it,
+                                Matrix4& transformation_matrix) const
+{
+  detail::DCRegLinearSystem system;
+  transformation_matrix = Matrix4::Identity();
+  last_degeneracy_analysis_ = DCRegDegeneracyAnalysis();
+
+  while (source_it.isValid() && target_it.isValid()) {
+    if (!std::isfinite(source_it->x) || !std::isfinite(source_it->y) ||
+        !std::isfinite(source_it->z) || !std::isfinite(target_it->x) ||
+        !std::isfinite(target_it->y) || !std::isfinite(target_it->z) ||
+        !std::isfinite(target_it->normal_x) || !std::isfinite(target_it->normal_y) ||
+        !std::isfinite(target_it->normal_z)) {
+      ++source_it;
+      ++target_it;
+      continue;
+    }
+
+    const double sx = source_it->x;
+    const double sy = source_it->y;
+    const double sz = source_it->z;
+    const double dx = target_it->x;
+    const double dy = target_it->y;
+    const double dz = target_it->z;
+    const double nx = target_it->normal[0];
+    const double ny = target_it->normal[1];
+    const double nz = target_it->normal[2];
+
+    detail::Vector6d jacobian;
+    jacobian << nz * sy - ny * sz, nx * sz - nz * sx, ny * sx - nx * sy, nx, ny, nz;
+    const double rhs = nx * dx + ny * dy + nz * dz - nx * sx - ny * sy - nz * sz;
+    system.hessian.noalias() += jacobian * jacobian.transpose();
+    system.rhs.noalias() += jacobian * rhs;
+    ++system.valid_correspondences;
+
+    ++source_it;
+    ++target_it;
+  }
+
+  if (system.valid_correspondences == 0) {
+    last_degeneracy_analysis_.solver_type = "no_correspondences";
+    return;
+  }
+
+  last_degeneracy_analysis_.has_correspondences = true;
+  last_degeneracy_analysis_.condition_number_full =
+      detail::fullConditionNumber(system.hessian);
+
+  detail::Vector6d minimum_norm_update;
+  last_degeneracy_analysis_.is_rank_deficient =
+      detail::solveRankDeficientMinimumNorm(system, minimum_norm_update);
+
+  const detail::DCRegDetection schur_detection =
+      detail::detectSchurDegeneracy(system.hessian);
+  const detail::DCRegDetection detection =
+      schur_detection.factorization_ok ? schur_detection
+                                       : detail::detectBlockFallback(system.hessian);
+  const detail::DCRegCharacterization characterization = detail::characterizeDegeneracy(
+      detection, degeneracy_condition_threshold_, kappa_target_);
+
+  last_degeneracy_analysis_.schur_factorization_ok = schur_detection.factorization_ok;
+  if (detection.factorization_ok) {
+    last_degeneracy_analysis_.schur_eigenvalues_rotation = detection.lambda_rot;
+    last_degeneracy_analysis_.schur_eigenvalues_translation = detection.lambda_trans;
+  }
+  if (characterization.factorization_ok) {
+    last_degeneracy_analysis_.condition_number_rotation =
+        characterization.condition_number_rot;
+    last_degeneracy_analysis_.condition_number_translation =
+        characterization.condition_number_trans;
+    last_degeneracy_analysis_.axis_aligned_eigenvalues_rotation =
+        characterization.aligned_lambda_rot;
+    last_degeneracy_analysis_.axis_aligned_eigenvalues_translation =
+        characterization.aligned_lambda_trans;
+    last_degeneracy_analysis_.weak_rotation_axes = characterization.weak_rot_axes;
+    last_degeneracy_analysis_.weak_translation_axes = characterization.weak_trans_axes;
+  }
+  last_degeneracy_analysis_.is_degenerate =
+      last_degeneracy_analysis_.is_rank_deficient ||
+      last_degeneracy_analysis_.weak_rotation_axes.any() ||
+      last_degeneracy_analysis_.weak_translation_axes.any();
+
+  const detail::DCRegSolverResult result = detail::solvePreconditioned(
+      system, characterization, pcg_tolerance_, pcg_max_iterations_);
+  last_degeneracy_analysis_.solver_type = result.solver_type;
+  last_degeneracy_analysis_.pcg_converged = result.pcg_converged;
+  last_degeneracy_analysis_.pcg_iterations = result.pcg_iterations;
+
+  constructTransformationMatrix(result.update(0),
+                                result.update(1),
+                                result.update(2),
+                                result.update(3),
+                                result.update(4),
+                                result.update(5),
+                                transformation_matrix);
+}
+
+} // namespace registration
+} // namespace pcl
+
+#endif // PCL_REGISTRATION_TRANSFORMATION_ESTIMATION_POINT_TO_PLANE_DCREG_HPP_

--- a/registration/include/pcl/registration/transformation_estimation_point_to_plane_dcreg.h
+++ b/registration/include/pcl/registration/transformation_estimation_point_to_plane_dcreg.h
@@ -1,0 +1,225 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2012-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#pragma once
+
+#include <pcl/registration/transformation_estimation.h>
+#include <pcl/cloud_iterator.h>
+
+#include <Eigen/Core>
+
+#include <limits>
+#include <string>
+
+namespace pcl {
+namespace registration {
+
+/** \brief Diagnostic data produced by TransformationEstimationPointToPlaneDCReg.
+ *
+ * The weak-axis fields use physical x/y/z order. The rotation axes describe
+ * small-angle roll/pitch/yaw increments, and the translation axes describe x/y/z
+ * increments in the point-to-plane linearization frame.
+ *
+ * \ingroup registration
+ */
+struct DCRegDegeneracyAnalysis {
+  bool has_correspondences{false};
+  bool is_rank_deficient{false};
+  bool schur_factorization_ok{false};
+  bool is_degenerate{false};
+
+  double condition_number_full{std::numeric_limits<double>::quiet_NaN()};
+  double condition_number_rotation{std::numeric_limits<double>::quiet_NaN()};
+  double condition_number_translation{std::numeric_limits<double>::quiet_NaN()};
+
+  Eigen::Vector3d schur_eigenvalues_rotation{
+      Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN())};
+  Eigen::Vector3d schur_eigenvalues_translation{
+      Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN())};
+  Eigen::Vector3d axis_aligned_eigenvalues_rotation{
+      Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN())};
+  Eigen::Vector3d axis_aligned_eigenvalues_translation{
+      Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN())};
+
+  Eigen::Vector3i weak_rotation_axes{Eigen::Vector3i::Zero()};
+  Eigen::Vector3i weak_translation_axes{Eigen::Vector3i::Zero()};
+
+  std::string solver_type{"invalid"};
+  bool pcg_converged{false};
+  int pcg_iterations{0};
+};
+
+/** \brief DCReg-aware point-to-plane linear least-squares transformation estimation.
+ *
+ * This estimator keeps the same point-to-plane residual model as
+ * TransformationEstimationPointToPlaneLLS, but solves the resulting 6D normal
+ * equation with DCReg-style Schur-complement degeneracy analysis and a
+ * preconditioned conjugate-gradient solve.
+ *
+ * The implementation adapts the core solver idea from:
+ * Xiangcheng Hu et al., "DCReg: Decoupled Characterization for Efficient
+ * Degenerate LiDAR Registration", https://arxiv.org/abs/2509.06285 .
+ * Reference implementation: https://github.com/JokerJohn/DCReg .
+ *
+ * \note PointTarget must provide normal_x, normal_y, and normal_z fields.
+ * \ingroup registration
+ */
+template <typename PointSource, typename PointTarget, typename Scalar = float>
+class TransformationEstimationPointToPlaneDCReg
+: public TransformationEstimation<PointSource, PointTarget, Scalar> {
+public:
+  using Ptr = shared_ptr<
+      TransformationEstimationPointToPlaneDCReg<PointSource, PointTarget, Scalar>>;
+  using ConstPtr =
+      shared_ptr<const TransformationEstimationPointToPlaneDCReg<PointSource,
+                                                                 PointTarget,
+                                                                 Scalar>>;
+  using Matrix4 =
+      typename TransformationEstimation<PointSource, PointTarget, Scalar>::Matrix4;
+
+  TransformationEstimationPointToPlaneDCReg() = default;
+  ~TransformationEstimationPointToPlaneDCReg() override = default;
+
+  inline void
+  estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
+                              const pcl::PointCloud<PointTarget>& cloud_tgt,
+                              Matrix4& transformation_matrix) const override;
+
+  inline void
+  estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
+                              const pcl::Indices& indices_src,
+                              const pcl::PointCloud<PointTarget>& cloud_tgt,
+                              Matrix4& transformation_matrix) const override;
+
+  inline void
+  estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
+                              const pcl::Indices& indices_src,
+                              const pcl::PointCloud<PointTarget>& cloud_tgt,
+                              const pcl::Indices& indices_tgt,
+                              Matrix4& transformation_matrix) const override;
+
+  inline void
+  estimateRigidTransformation(const pcl::PointCloud<PointSource>& cloud_src,
+                              const pcl::PointCloud<PointTarget>& cloud_tgt,
+                              const pcl::Correspondences& correspondences,
+                              Matrix4& transformation_matrix) const override;
+
+  /** \brief Set the Schur condition number above which an axis is considered weak. */
+  inline void
+  setDegeneracyConditionThreshold(double threshold)
+  {
+    degeneracy_condition_threshold_ = threshold;
+  }
+
+  inline double
+  getDegeneracyConditionThreshold() const
+  {
+    return (degeneracy_condition_threshold_);
+  }
+
+  /** \brief Set the target condition number used when clamping weak eigenvalues. */
+  inline void
+  setKappaTarget(double kappa_target)
+  {
+    kappa_target_ = kappa_target;
+  }
+
+  inline double
+  getKappaTarget() const
+  {
+    return (kappa_target_);
+  }
+
+  /** \brief Set the relative stopping tolerance for the PCG solve. */
+  inline void
+  setPcgTolerance(double tolerance)
+  {
+    pcg_tolerance_ = tolerance;
+  }
+
+  inline double
+  getPcgTolerance() const
+  {
+    return (pcg_tolerance_);
+  }
+
+  /** \brief Set the maximum number of PCG iterations. */
+  inline void
+  setPcgMaxIterations(int max_iterations)
+  {
+    pcg_max_iterations_ = max_iterations;
+  }
+
+  inline int
+  getPcgMaxIterations() const
+  {
+    return (pcg_max_iterations_);
+  }
+
+  /** \brief Return diagnostics from the last transformation estimation call. */
+  inline const DCRegDegeneracyAnalysis&
+  getLastDegeneracyAnalysis() const
+  {
+    return (last_degeneracy_analysis_);
+  }
+
+protected:
+  void
+  estimateRigidTransformation(ConstCloudIterator<PointSource>& source_it,
+                              ConstCloudIterator<PointTarget>& target_it,
+                              Matrix4& transformation_matrix) const;
+
+  inline void
+  constructTransformationMatrix(const double& alpha,
+                                const double& beta,
+                                const double& gamma,
+                                const double& tx,
+                                const double& ty,
+                                const double& tz,
+                                Matrix4& transformation_matrix) const;
+
+  double degeneracy_condition_threshold_{10.0};
+  double kappa_target_{10.0};
+  double pcg_tolerance_{1e-6};
+  int pcg_max_iterations_{10};
+  mutable DCRegDegeneracyAnalysis last_degeneracy_analysis_;
+};
+
+} // namespace registration
+} // namespace pcl
+
+#include <pcl/registration/impl/transformation_estimation_point_to_plane_dcreg.hpp>

--- a/registration/src/transformation_estimation_point_to_plane_dcreg.cpp
+++ b/registration/src/transformation_estimation_point_to_plane_dcreg.cpp
@@ -1,0 +1,38 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2012-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <pcl/registration/transformation_estimation_point_to_plane_dcreg.h>

--- a/test/registration/CMakeLists.txt
+++ b/test/registration/CMakeLists.txt
@@ -18,6 +18,10 @@ PCL_ADD_TEST(correspondence_estimation test_correspondence_estimation
              FILES test_correspondence_estimation.cpp
              LINK_WITH pcl_gtest pcl_registration pcl_features)
 
+PCL_ADD_TEST(registration_dcreg test_registration_dcreg
+             FILES test_registration_dcreg.cpp
+             LINK_WITH pcl_gtest pcl_registration)
+
 if(BUILD_io)
   PCL_ADD_TEST(a_registration_test test_registration
                FILES test_registration.cpp

--- a/test/registration/test_registration_dcreg.cpp
+++ b/test/registration/test_registration_dcreg.cpp
@@ -1,0 +1,294 @@
+/*
+ * Software License Agreement (BSD License)
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2012-, Open Perception, Inc.
+ *
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the copyright holder(s) nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#include <pcl/registration/correspondence_types.h>
+#include <pcl/registration/transformation_estimation_point_to_plane_dcreg.h>
+#include <pcl/registration/transformation_estimation_point_to_plane_lls.h>
+#include <pcl/test/gtest.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+
+#include <cmath>
+#include <cstdint>
+#include <string>
+
+namespace {
+
+using PointT = pcl::PointNormal;
+using CloudT = pcl::PointCloud<PointT>;
+using DCRegEstimator =
+    pcl::registration::TransformationEstimationPointToPlaneDCReg<PointT, PointT, float>;
+
+PointT
+makePoint(float x, float y, float z, float nx, float ny, float nz)
+{
+  PointT point;
+  point.x = x;
+  point.y = y;
+  point.z = z;
+  point.normal_x = nx;
+  point.normal_y = ny;
+  point.normal_z = nz;
+  return (point);
+}
+
+void
+finishCloud(CloudT& cloud)
+{
+  cloud.width = static_cast<std::uint32_t>(cloud.size());
+  cloud.height = 1;
+  cloud.is_dense = true;
+}
+
+pcl::Correspondences
+makeIdentityCorrespondences(std::size_t size)
+{
+  pcl::Correspondences correspondences;
+  correspondences.reserve(size);
+  for (std::size_t i = 0; i < size; ++i)
+    correspondences.emplace_back(static_cast<int>(i), static_cast<int>(i), 0.0f);
+  return (correspondences);
+}
+
+CloudT
+makeTranslatedSource(const CloudT& target, const Eigen::Vector3f& translation)
+{
+  CloudT source;
+  source.reserve(target.size());
+  for (const auto& point : target) {
+    PointT source_point = point;
+    source_point.x -= translation.x();
+    source_point.y -= translation.y();
+    source_point.z -= translation.z();
+    source.push_back(source_point);
+  }
+  finishCloud(source);
+  return (source);
+}
+
+CloudT
+makeCubeTarget()
+{
+  CloudT target;
+  const float values[2] = {-0.5f, 0.5f};
+  for (const float y : values) {
+    for (const float z : values) {
+      target.push_back(makePoint(-0.5f, y, z, -1.0f, 0.0f, 0.0f));
+      target.push_back(makePoint(0.5f, y, z, 1.0f, 0.0f, 0.0f));
+    }
+  }
+  for (const float x : values) {
+    for (const float z : values) {
+      target.push_back(makePoint(x, -0.5f, z, 0.0f, -1.0f, 0.0f));
+      target.push_back(makePoint(x, 0.5f, z, 0.0f, 1.0f, 0.0f));
+    }
+  }
+  for (const float x : values) {
+    for (const float y : values) {
+      target.push_back(makePoint(x, y, -0.5f, 0.0f, 0.0f, -1.0f));
+      target.push_back(makePoint(x, y, 0.5f, 0.0f, 0.0f, 1.0f));
+    }
+  }
+  finishCloud(target);
+  return (target);
+}
+
+CloudT
+makePlaneTarget()
+{
+  CloudT target;
+  for (int ix = -2; ix <= 2; ++ix) {
+    for (int iy = -2; iy <= 2; ++iy) {
+      target.push_back(makePoint(0.1f * static_cast<float>(ix),
+                                 0.1f * static_cast<float>(iy),
+                                 0.0f,
+                                 0.0f,
+                                 0.0f,
+                                 1.0f));
+    }
+  }
+  finishCloud(target);
+  return (target);
+}
+
+CloudT
+makeCylinderTarget()
+{
+  CloudT target;
+  constexpr int kAngleSteps = 36;
+  constexpr double kPi = 3.14159265358979323846;
+  const float heights[3] = {-0.5f, 0.0f, 0.5f};
+  for (const float z : heights) {
+    for (int i = 0; i < kAngleSteps; ++i) {
+      const float angle =
+          static_cast<float>(2.0 * kPi * i / static_cast<double>(kAngleSteps));
+      const float x = std::cos(angle);
+      const float y = std::sin(angle);
+      target.push_back(makePoint(x, y, z, x, y, 0.0f));
+    }
+  }
+  finishCloud(target);
+  return (target);
+}
+
+void
+expectFiniteTransform(const Eigen::Matrix4f& transformation)
+{
+  for (int row = 0; row < 4; ++row)
+    for (int col = 0; col < 4; ++col)
+      EXPECT_TRUE(std::isfinite(transformation(row, col)));
+}
+
+} // namespace
+
+TEST(PCL, TransformationEstimationPointToPlaneDCRegParameters)
+{
+  DCRegEstimator estimator;
+  EXPECT_DOUBLE_EQ(estimator.getDegeneracyConditionThreshold(), 10.0);
+  EXPECT_DOUBLE_EQ(estimator.getKappaTarget(), 10.0);
+  EXPECT_DOUBLE_EQ(estimator.getPcgTolerance(), 1e-6);
+  EXPECT_EQ(estimator.getPcgMaxIterations(), 10);
+
+  estimator.setDegeneracyConditionThreshold(20.0);
+  estimator.setKappaTarget(15.0);
+  estimator.setPcgTolerance(1e-8);
+  estimator.setPcgMaxIterations(25);
+
+  EXPECT_DOUBLE_EQ(estimator.getDegeneracyConditionThreshold(), 20.0);
+  EXPECT_DOUBLE_EQ(estimator.getKappaTarget(), 15.0);
+  EXPECT_DOUBLE_EQ(estimator.getPcgTolerance(), 1e-8);
+  EXPECT_EQ(estimator.getPcgMaxIterations(), 25);
+  EXPECT_EQ(estimator.getLastDegeneracyAnalysis().solver_type, "invalid");
+}
+
+TEST(PCL, TransformationEstimationPointToPlaneDCRegEmptyCorrespondences)
+{
+  DCRegEstimator estimator;
+  CloudT source;
+  CloudT target;
+  pcl::Correspondences correspondences;
+  Eigen::Matrix4f transformation = Eigen::Matrix4f::Zero();
+
+  estimator.estimateRigidTransformation(
+      source, target, correspondences, transformation);
+
+  EXPECT_TRUE(transformation.isApprox(Eigen::Matrix4f::Identity()));
+  const auto& analysis = estimator.getLastDegeneracyAnalysis();
+  EXPECT_FALSE(analysis.has_correspondences);
+  EXPECT_EQ(analysis.solver_type, "no_correspondences");
+}
+
+TEST(PCL, TransformationEstimationPointToPlaneDCRegMatchesLLS)
+{
+  const CloudT target = makeCubeTarget();
+  const Eigen::Vector3f translation(0.02f, -0.03f, 0.04f);
+  const CloudT source = makeTranslatedSource(target, translation);
+  const pcl::Correspondences correspondences =
+      makeIdentityCorrespondences(target.size());
+
+  DCRegEstimator estimator;
+  pcl::registration::TransformationEstimationPointToPlaneLLS<PointT, PointT, float>
+      lls_estimator;
+  Eigen::Matrix4f dcreg_transformation;
+  Eigen::Matrix4f lls_transformation;
+
+  estimator.estimateRigidTransformation(
+      source, target, correspondences, dcreg_transformation);
+  lls_estimator.estimateRigidTransformation(
+      source, target, correspondences, lls_transformation);
+
+  EXPECT_TRUE(dcreg_transformation.isApprox(lls_transformation, 1e-4f));
+  EXPECT_TRUE((dcreg_transformation.block<3, 1>(0, 3).isApprox(translation, 1e-4f)));
+  const auto& analysis = estimator.getLastDegeneracyAnalysis();
+  EXPECT_TRUE(analysis.has_correspondences);
+  EXPECT_TRUE(std::isfinite(analysis.condition_number_full));
+  EXPECT_TRUE(std::isfinite(analysis.condition_number_rotation));
+  EXPECT_TRUE(std::isfinite(analysis.condition_number_translation));
+}
+
+TEST(PCL, TransformationEstimationPointToPlaneDCRegPlaneDegeneracy)
+{
+  const CloudT target = makePlaneTarget();
+  const CloudT source =
+      makeTranslatedSource(target, Eigen::Vector3f(0.0f, 0.0f, 0.05f));
+  const pcl::Correspondences correspondences =
+      makeIdentityCorrespondences(target.size());
+
+  DCRegEstimator estimator;
+  Eigen::Matrix4f transformation;
+  estimator.estimateRigidTransformation(
+      source, target, correspondences, transformation);
+
+  expectFiniteTransform(transformation);
+  EXPECT_LT((transformation.block<3, 1>(0, 3).norm()), 1.0f);
+  const auto& analysis = estimator.getLastDegeneracyAnalysis();
+  EXPECT_TRUE(analysis.has_correspondences);
+  EXPECT_TRUE(analysis.is_degenerate);
+  EXPECT_TRUE(analysis.is_rank_deficient || analysis.weak_translation_axes.sum() > 0);
+  EXPECT_TRUE(std::isfinite(analysis.condition_number_full));
+}
+
+TEST(PCL, TransformationEstimationPointToPlaneDCRegCylinderDegeneracy)
+{
+  const CloudT target = makeCylinderTarget();
+  const CloudT source = target;
+  const pcl::Correspondences correspondences =
+      makeIdentityCorrespondences(target.size());
+
+  DCRegEstimator estimator;
+  Eigen::Matrix4f transformation;
+  estimator.estimateRigidTransformation(
+      source, target, correspondences, transformation);
+
+  expectFiniteTransform(transformation);
+  EXPECT_TRUE(transformation.isApprox(Eigen::Matrix4f::Identity(), 1e-4f));
+  const auto& analysis = estimator.getLastDegeneracyAnalysis();
+  EXPECT_TRUE(analysis.has_correspondences);
+  EXPECT_TRUE(analysis.is_degenerate);
+  EXPECT_EQ(analysis.weak_translation_axes(2), 1);
+  EXPECT_TRUE(analysis.is_rank_deficient ||
+              analysis.condition_number_translation >
+                  estimator.getDegeneracyConditionThreshold());
+  EXPECT_FALSE(analysis.solver_type.empty());
+}
+
+int
+main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return (RUN_ALL_TESTS());
+}


### PR DESCRIPTION
This PR integrates the core DCReg degeneracy-aware point-to-plane solver idea
into PCL's registration module.

Paper:

- **DCReg: Decoupled Characterization for Efficient Degenerate LiDAR
  Registration**
- Authors: Xiangcheng Hu, Xieyuanli Chen, Mingkai Jia, Jin Wu, Ping Tan, Steven L. Waslander
- arXiv: https://arxiv.org/abs/2509.06285

Reference implementation and project documentation:

- Public source code: https://github.com/JokerJohn/DCReg
- Project wiki: https://github.com/JokerJohn/DCReg/wiki

DCReg targets degenerate LiDAR registration. Its core idea is to decouple
rotation and translation observability through Schur complements, characterize
weak physical motion axes by aligning eigenspaces to coordinate axes, and
stabilize weak directions through targeted eigenvalue clamping and
preconditioned solving.

This PR is not a direct import of the full standalone DCReg research system.
It ports the solver and diagnostic ideas into PCL's existing
`pcl::registration::TransformationEstimation` API:

- PCL continues to own point cloud containers, correspondence sets, ICP loops,
  and registration pipelines.
- The estimator uses the same point-to-plane residual model as
  `TransformationEstimationPointToPlaneLLS`.
- `PointTarget` is expected to provide `normal_x`, `normal_y`, and `normal_z`,
  matching PCL's existing point-to-plane estimator convention.
- Standalone DCReg runners, parking-lot preprocessing, YAML presets,
  visualization, benchmark scripts, and local-plane/local-frame compatibility
  helpers are intentionally out of scope for this first PCL-native PR.

## PCL integration summary

This PR adds:

- `pcl::registration::TransformationEstimationPointToPlaneDCReg`
- `pcl::registration::DCRegDegeneracyAnalysis`
- getter/setter style solver parameters:
  - `setDegeneracyConditionThreshold()` / `getDegeneracyConditionThreshold()`
  - `setKappaTarget()` / `getKappaTarget()`
  - `setPcgTolerance()` / `getPcgTolerance()`
  - `setPcgMaxIterations()` / `getPcgMaxIterations()`
- `getLastDegeneracyAnalysis()` to inspect diagnostics from the most recent
  estimation call.

The estimator builds the same 6D point-to-plane normal equation as
`TransformationEstimationPointToPlaneLLS`, then replaces the solve with:

- Schur-complement rotation and translation degeneracy analysis
- axis-aligned weak direction characterization
- weak eigenvalue clamping for a block preconditioner
- preconditioned conjugate-gradient solving
- dense / QR / minimum-norm fallback paths for non-finite or rank-deficient
  systems

## Diagnostics

`DCRegDegeneracyAnalysis` reports:

- whether correspondences were available
- full Hessian condition number
- rotation and translation Schur condition numbers
- raw Schur eigenvalues
- axis-aligned eigenvalues
- weak rotation and translation axis flags in x/y/z order
- rank-deficient state
- whether Schur factorization was available
- solver path
- PCG convergence and iteration count

Rank-deficient systems still report weak axes through eigensolver/block
fallback diagnostics.

## Tests

Added `test_registration_dcreg.cpp` covering:

- default parameters and getter/setter behavior
- empty correspondence behavior and diagnostics
- agreement with `TransformationEstimationPointToPlaneLLS` on a
  well-conditioned synthetic cube case
- finite/stable output and degeneracy reporting on a planar weak-geometry case
- cylinder degeneracy reporting with axial weak translation

## Validation

Local validation was run in `/home/xchu/CLionProjects/pcl`.

Configuration note: this machine has an old CUDA 10.1 compiler and a mismatched
system GTest installation, so local validation explicitly disabled CUDA and
nanoflann discovery and pointed PCL to a consistent `/usr/src/googletest`
source/include pair.

```bash
cmake -S . -B build-dcreg \
  -DCMAKE_BUILD_TYPE=Release \
  -DWITH_CUDA=OFF \
  -DCMAKE_DISABLE_FIND_PACKAGE_nanoflann=TRUE \
  -DGTEST_SRC_DIR=/usr/src/googletest/googletest \
  -DGTEST_INCLUDE_DIR=/usr/src/googletest/googletest/include \
  -DBUILD_registration=ON \
  -DBUILD_global_tests=ON \
  -DBUILD_tests_registration=ON \
  -DBUILD_apps=OFF \
  -DBUILD_examples=OFF \
  -DBUILD_tools=OFF \
  -DBUILD_simulation=OFF

cmake --build build-dcreg --target pcl_registration -j2
cmake --build build-dcreg --target test_registration_dcreg -j2
build-dcreg/test/registration/test_registration_dcreg
ctest --test-dir build-dcreg/test -R registration_dcreg --output-on-failure
clang-format --dry-run -Werror \
  registration/include/pcl/registration/transformation_estimation_point_to_plane_dcreg.h \
  registration/include/pcl/registration/impl/transformation_estimation_point_to_plane_dcreg.hpp \
  registration/src/transformation_estimation_point_to_plane_dcreg.cpp \
  test/registration/test_registration_dcreg.cpp
git diff --check
```

Results:

- `pcl_registration`: built successfully
- `test_registration_dcreg`: built successfully
- DCReg registration tests: 5 passed
- CTest `registration_dcreg`: passed
- clang-format dry-run: passed
- `git diff --check`: passed

## Additional non-CI comparison

I also ran a local equivalence check against the standalone DCReg code on two
representative datasets:

- shifted-cylinder synthetic degeneracy case
- parking-lot real-scene case

The standalone DCReg examples use kNN local-plane correspondences and a local
SO(3) update convention, while this PCL estimator is a point-to-plane
`TransformationEstimation` component. To make the comparison meaningful, I
converted the standalone DCReg correspondences from each case into an equivalent
PCL point-to-plane estimation problem, so both implementations solved the same
6D normal equation.

Results:

| case | original mask | PCL mask | max transform diff | PCG iterations |
| --- | --- | --- | --- | --- |
| shifted-cylinder | `000001` | `000001` | `5.30e-7` | `6 / 6` |
| parking-lot | `000100` | `000100` | `3.90e-8` | `6 / 6` |

PCL diagnostic descriptions from the same check:

- shifted-cylinder: weak translation axis `z`,
  `condition_number_translation = 26.805484784`, solver `pcg`
- parking-lot: weak translation axis `x`,
  `condition_number_translation = 14.485626824`, solver `pcg`

These checks are intentionally not added as CI tests because they depend on
external/local datasets and on the standalone DCReg runner. The CI-facing tests
use small synthetic clouds with no external data dependency.
