### PR TITLE
Add x11 on linux when vtk 9.6+

### DIFF
--- a/visualization/CMakeLists.txt
+++ b/visualization/CMakeLists.txt
@@ -140,6 +140,11 @@ endif()
 
 target_link_libraries("${LIB_NAME}" pcl_common pcl_io pcl_kdtree pcl_geometry pcl_search ${OPENGL_LIBRARIES})
 
+if(${VTK_VERSION} VERSION_GREATER_EQUAL 9.6 AND UNIX AND NOT ANDROID AND NOT APPLE AND NOT APPLE_IOS)
+  find_package(X11 REQUIRED)
+  target_link_libraries("${LIB_NAME}" ${X11_LIBRARIES})
+endif()
+
 if(${VTK_VERSION} VERSION_GREATER_EQUAL 9.0)
   #Some libs are referenced through depending on IO
   target_link_libraries("${LIB_NAME}"


### PR DESCRIPTION
It seems that `vtk` is no longer required `x11`, it is an optional. So I think it should be added explicitely here for safety.
