### PR TITLE
sample_consensus: optimize Ellipse3D solver with computeDirect

### DIFF
--- a/sample_consensus/include/pcl/sample_consensus/impl/sac_model_ellipse3d.hpp
+++ b/sample_consensus/include/pcl/sample_consensus/impl/sac_model_ellipse3d.hpp
@@ -174,7 +174,8 @@ pcl::SampleConsensusModelEllipse3D<PointT>::computeModelCoefficients (const Indi
     .finished();
 
   // Calculate the eigenvalues and eigenvectors of matrix M
-  const Eigen::SelfAdjointEigenSolver<Eigen::Matrix2f> solver_M(M, Eigen::EigenvaluesOnly);
+  Eigen::SelfAdjointEigenSolver<Eigen::Matrix2f> solver_M;
+  solver_M.computeDirect(M, Eigen::EigenvaluesOnly);
 
   Eigen::Vector2f eigvals_M = solver_M.eigenvalues();
 


### PR DESCRIPTION
This is a follow-up to #6430. As suggested by @mvieth, switch to the specialized analytic computeDirect solver for the eigenvalue problem (from SelfAdjointEigenSolver::compute() to the analytic computeDirect())

## analysis
Runtime is about the same, even though the math kernel is faster and has slightly shorter build times. Testing shows float retains sufficient accuracy, but double can be used if higher precision is ever needed

[analysis_before.txt](https://github.com/user-attachments/files/27375568/analysis_before.txt), [analysis_after.txt](https://github.com/user-attachments/files/27375643/analysis_after.txt)
| Metric | base | computeDirect() | Improvement |
| :--- | :--- | :--- | :--- |
| Runtime (Avg.) | 14.23 ms | 14.27 ms | none |
| Math Kernel (10M calls) | 703 ms | 10 ms | ~70x Speedup |
| Parsing (Frontend) | 7.6 s | 6.6 s | 13% Reduction |
| Codegen (Backend) | 10.2 s | 9.6 s | 6% Reduction |
| Total Build Time | 17.8 s | 16.2 s | ~10% Reduction |