### PR TITLE
Feature/bench kdtree flann vs nanoflann

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -39,3 +39,7 @@ PCL_ADD_BENCHMARK(sample_consensus_sac_model_cylinder FILES sample_consensus/sac
 PCL_ADD_BENCHMARK(search_radius_search FILES search/radius_search.cpp
                   LINK_WITH pcl_io pcl_search pcl_filters
                   ARGUMENTS "${PCL_SOURCE_DIR}/test/table_scene_mug_stereo_textured.pcd")
+
+PCL_ADD_BENCHMARK(search_kdtree_flann_vs_nanoflann FILES search/bench_kdtree.cpp
+                  LINK_WITH pcl_io pcl_search pcl_kdtree
+                  ARGUMENTS "${PCL_SOURCE_DIR}/test/table_scene_mug_stereo_textured.pcd")

--- a/benchmarks/search/bench_kdtree.cpp
+++ b/benchmarks/search/bench_kdtree.cpp
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: BSD-3-Clause
+// Benchmark: pcl::search::KdTree (FLANN) vs pcl::search::KdTreeNanoflann
+// Covers: tree construction, kNN query, radius search
+// Motivation: PCL 1.15.1 added nanoflann support (#6250); this benchmark
+//             provides a regression guard and documents expected speedups.
+//
+// Usage:
+//   ./search_kdtree_flann_vs_nanoflann                  # synthetic 100k pts
+//   ./search_kdtree_flann_vs_nanoflann cloud.pcd        # real PCD file
+
+#include <benchmark/benchmark.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl/search/kdtree.h>
+#include <pcl/search/flann_search.h>
+
+#ifdef PCL_HAVE_NANOFLANN
+#include <pcl/search/kdtree_nanoflann.h>
+#endif
+
+#include <iostream>
+#include <random>
+
+// ---------------------------------------------------------------------------
+// Global cloud — loaded once, shared across all benchmarks
+// ---------------------------------------------------------------------------
+
+static pcl::PointCloud<pcl::PointXYZ>::Ptr g_cloud;
+
+static pcl::PointCloud<pcl::PointXYZ>::Ptr
+makeCloud(int N, float range = 100.f, unsigned seed = 42)
+{
+  auto cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+  cloud->reserve(N);
+  std::mt19937 rng(seed);
+  std::uniform_real_distribution<float> dist(-range, range);
+  for (int i = 0; i < N; ++i)
+    cloud->emplace_back(dist(rng), dist(rng), dist(rng));
+  cloud->width  = N;
+  cloud->height = 1;
+  cloud->is_dense = true;
+  return cloud;
+}
+
+// ---------------------------------------------------------------------------
+// FLANN KdTree — construction
+// ---------------------------------------------------------------------------
+
+static void BM_FlannKdTree_Build(benchmark::State& state)
+{
+  auto cloud = makeCloud(static_cast<int>(state.range(0)));
+  for (auto _ : state) {
+    pcl::search::KdTree<pcl::PointXYZ> tree;
+    tree.setInputCloud(cloud);
+    benchmark::DoNotOptimize(tree);
+  }
+  state.SetItemsProcessed(state.iterations() * state.range(0));
+  state.SetLabel("FLANN build");
+}
+BENCHMARK(BM_FlannKdTree_Build)
+  ->Arg(10000)->Arg(100000)->Arg(500000)
+  ->Unit(benchmark::kMillisecond);
+
+// ---------------------------------------------------------------------------
+// FLANN KdTree — kNN query
+// ---------------------------------------------------------------------------
+
+static void BM_FlannKdTree_kNN(benchmark::State& state)
+{
+  const int k = static_cast<int>(state.range(0));
+
+  pcl::search::KdTree<pcl::PointXYZ> tree;
+  tree.setInputCloud(g_cloud);
+
+  pcl::PointXYZ query(0.f, 0.f, 0.f);
+  std::vector<int>   indices(k);
+  std::vector<float> dists(k);
+
+  for (auto _ : state)
+    benchmark::DoNotOptimize(tree.nearestKSearch(query, k, indices, dists));
+
+  state.SetItemsProcessed(state.iterations());
+  state.SetLabel("FLANN kNN");
+}
+BENCHMARK(BM_FlannKdTree_kNN)
+  ->Arg(1)->Arg(5)->Arg(20)->Arg(50)
+  ->Unit(benchmark::kMicrosecond);
+
+// ---------------------------------------------------------------------------
+// FLANN KdTree — radius search
+// ---------------------------------------------------------------------------
+
+static void BM_FlannKdTree_Radius(benchmark::State& state)
+{
+  const float r = static_cast<float>(state.range(0));
+
+  pcl::search::KdTree<pcl::PointXYZ> tree;
+  tree.setInputCloud(g_cloud);
+
+  pcl::PointXYZ query(0.f, 0.f, 0.f);
+  std::vector<int>   indices;
+  std::vector<float> dists;
+
+  for (auto _ : state)
+    benchmark::DoNotOptimize(tree.radiusSearch(query, r, indices, dists));
+
+  state.SetItemsProcessed(state.iterations());
+  state.SetLabel("FLANN radius");
+}
+BENCHMARK(BM_FlannKdTree_Radius)
+  ->Arg(5)->Arg(10)->Arg(20)
+  ->Unit(benchmark::kMicrosecond);
+
+// ---------------------------------------------------------------------------
+// Nanoflann KdTree — same benchmarks
+// ---------------------------------------------------------------------------
+
+#ifdef PCL_HAVE_NANOFLANN
+
+static void BM_NanoflannKdTree_Build(benchmark::State& state)
+{
+  auto cloud = makeCloud(static_cast<int>(state.range(0)));
+  for (auto _ : state) {
+    pcl::search::KdTreeNanoflann<pcl::PointXYZ> tree;
+    tree.setInputCloud(cloud);
+    benchmark::DoNotOptimize(tree);
+  }
+  state.SetItemsProcessed(state.iterations() * state.range(0));
+  state.SetLabel("nanoflann build");
+}
+BENCHMARK(BM_NanoflannKdTree_Build)
+  ->Arg(10000)->Arg(100000)->Arg(500000)
+  ->Unit(benchmark::kMillisecond);
+
+static void BM_NanoflannKdTree_kNN(benchmark::State& state)
+{
+  const int k = static_cast<int>(state.range(0));
+
+  pcl::search::KdTreeNanoflann<pcl::PointXYZ> tree;
+  tree.setInputCloud(g_cloud);
+
+  pcl::PointXYZ query(0.f, 0.f, 0.f);
+  std::vector<int>   indices(k);
+  std::vector<float> dists(k);
+
+  for (auto _ : state)
+    benchmark::DoNotOptimize(tree.nearestKSearch(query, k, indices, dists));
+
+  state.SetItemsProcessed(state.iterations());
+  state.SetLabel("nanoflann kNN");
+}
+BENCHMARK(BM_NanoflannKdTree_kNN)
+  ->Arg(1)->Arg(5)->Arg(20)->Arg(50)
+  ->Unit(benchmark::kMicrosecond);
+
+static void BM_NanoflannKdTree_Radius(benchmark::State& state)
+{
+  const float r = static_cast<float>(state.range(0));
+
+  pcl::search::KdTreeNanoflann<pcl::PointXYZ> tree;
+  tree.setInputCloud(g_cloud);
+
+  pcl::PointXYZ query(0.f, 0.f, 0.f);
+  std::vector<int>   indices;
+  std::vector<float> dists;
+
+  for (auto _ : state)
+    benchmark::DoNotOptimize(tree.radiusSearch(query, r, indices, dists));
+
+  state.SetItemsProcessed(state.iterations());
+  state.SetLabel("nanoflann radius");
+}
+BENCHMARK(BM_NanoflannKdTree_Radius)
+  ->Arg(5)->Arg(10)->Arg(20)
+  ->Unit(benchmark::kMicrosecond);
+
+#endif  // PCL_HAVE_NANOFLANN
+
+// ---------------------------------------------------------------------------
+// main — load cloud from argv[1] or fall back to synthetic 100k points
+// ---------------------------------------------------------------------------
+
+int main(int argc, char** argv)
+{
+  if (argc > 1) {
+    g_cloud = std::make_shared<pcl::PointCloud<pcl::PointXYZ>>();
+    if (pcl::io::loadPCDFile(argv[1], *g_cloud) < 0) {
+      std::cerr << "Failed to load " << argv[1] << " — using synthetic cloud\n";
+      g_cloud = makeCloud(100000);
+    } else {
+      std::cout << "Loaded " << g_cloud->size() << " pts from " << argv[1] << "\n";
+    }
+  } else {
+    g_cloud = makeCloud(100000);
+  }
+
+  ::benchmark::Initialize(&argc, argv);
+  ::benchmark::RunSpecifiedBenchmarks();
+  ::benchmark::Shutdown();
+  return 0;
+}

--- a/benchmarks/search/bench_kdtree.cpp
+++ b/benchmarks/search/bench_kdtree.cpp
@@ -15,7 +15,7 @@
 #include <pcl/search/kdtree.h>
 #include <pcl/search/flann_search.h>
 
-#ifdef PCL_HAVE_NANOFLANN
+#ifdef PCL_HAS_NANOFLANN
 #include <pcl/search/kdtree_nanoflann.h>
 #endif
 
@@ -116,7 +116,7 @@ BENCHMARK(BM_FlannKdTree_Radius)
 // Nanoflann KdTree — same benchmarks
 // ---------------------------------------------------------------------------
 
-#ifdef PCL_HAVE_NANOFLANN
+#ifdef PCL_HAS_NANOFLANN
 
 static void BM_NanoflannKdTree_Build(benchmark::State& state)
 {
@@ -175,7 +175,7 @@ BENCHMARK(BM_NanoflannKdTree_Radius)
   ->Arg(5)->Arg(10)->Arg(20)
   ->Unit(benchmark::kMicrosecond);
 
-#endif  // PCL_HAVE_NANOFLANN
+#endif  // PCL_HAS_NANOFLANN
 
 // ---------------------------------------------------------------------------
 // main — load cloud from argv[1] or fall back to synthetic 100k points


### PR DESCRIPTION
Closes #3860 (partial — search module benchmark)

### What
Adds the first benchmark to the `search` module: `benchmarks/search/bench_kdtree.cpp`

Benchmarks `pcl::search::KdTree` (FLANN) vs `pcl::search::KdTreeNanoflann`
across three axes:
- **Tree construction**: 10k / 100k / 500k points
- **kNN query**: k = 1, 5, 20, 50
- **Radius search**: r = 5, 10, 20 m

### Results
Hardware: 12 threads / Ubuntu 24.04 / GCC 13 / `-O3 -mavx2`  
Cloud: `table_scene_mug_stereo_textured.pcd` (307,200 pts) for query benchmarks;
synthetic uniform random for build benchmarks  
Repetitions: 3 — mean reported  

> absolute timings may vary slightly

#### Tree construction (ms, lower is better)

| Points | FLANN (ms) | nanoflann (ms) | Speedup |
|--------|-----------|----------------|---------|
| 10k    | 1.15      | 0.979          | 1.17×   |
| 100k   | 16.2      | 13.1           | 1.24×   |
| 500k   | 129       | 94.4           | **1.37×** |

#### kNN query (µs, lower is better)

| k  | FLANN (µs) | nanoflann (µs) | Speedup |
|----|-----------|----------------|---------|
| 1  | 0.831     | 0.244          | **3.41×** |
| 5  | 1.43      | 0.466          | **3.07×** |
| 20 | 2.18      | 0.912          | **2.39×** |
| 50 | 5.10      | 2.97           | **1.72×** |

#### Radius search (µs, lower is better)

| radius (m) | FLANN (µs) | nanoflann (µs) | Speedup |
|------------|-----------|----------------|---------|
| 5          | 12,735    | 1,521          | **8.37×** |
| 10         | 12,991    | 1,536          | **8.46×** |
| 20         | 13,244    | 1,539          | **8.60×** |

**nanoflann is 1.2–1.4× faster to build, 1.7–3.4× faster on kNN, and
8.4× faster on radius search** — making it the clear default for
localization and mapping pipelines that call `radiusSearch` in tight loops
(normal estimation, ICP, GICP, NDT).

### Notes
- Accepts optional PCD path as `argv[1]`; falls back to synthetic 100k-pt cloud
- nanoflann benchmarks compiled in automatically when `PCL_HAS_NANOFLANN` is defined
- Ready to extend with `registration` / `features` benchmarks in follow-up PRs