### PR TITLE
Fix in PCLVisualizer::convertPointCloudToVTKPolyData: do not re-use v…

### DIFF
--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -227,7 +227,7 @@ pcl::visualization::PCLVisualizer::convertPointCloudToVTKPolyData (
   }
 
   // Create the supporting structures
-  vertices = polydata->GetVerts ();
+  //vertices = polydata->GetVerts (); // Using the return value of GetVerts() in SetVerts() does not guarantee consistent internal data in polydata
   if (!vertices)
     vertices = vtkSmartPointer<vtkCellArray>::New ();
 
@@ -329,7 +329,7 @@ pcl::visualization::PCLVisualizer::convertPointCloudToVTKPolyData (
   vtkIdType nr_points = points->GetNumberOfPoints ();
 
   // Create the supporting structures
-  vertices = polydata->GetVerts ();
+  //vertices = polydata->GetVerts (); // Using the return value of GetVerts() in SetVerts() does not guarantee consistent internal data in polydata
   if (!vertices)
     vertices = vtkSmartPointer<vtkCellArray>::New ();
 

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -227,7 +227,9 @@ pcl::visualization::PCLVisualizer::convertPointCloudToVTKPolyData (
   }
 
   // Create the supporting structures
-  //vertices = polydata->GetVerts (); // Using the return value of GetVerts() in SetVerts() does not guarantee consistent internal data in polydata
+#ifndef VTK_CELL_ARRAY_V2
+  vertices = polydata->GetVerts (); // Using the return value of GetVerts() in SetVerts() does not guarantee consistent internal data in polydata
+#endif
   if (!vertices)
     vertices = vtkSmartPointer<vtkCellArray>::New ();
 
@@ -329,7 +331,9 @@ pcl::visualization::PCLVisualizer::convertPointCloudToVTKPolyData (
   vtkIdType nr_points = points->GetNumberOfPoints ();
 
   // Create the supporting structures
-  //vertices = polydata->GetVerts (); // Using the return value of GetVerts() in SetVerts() does not guarantee consistent internal data in polydata
+#ifndef VTK_CELL_ARRAY_V2
+  vertices = polydata->GetVerts (); // Using the return value of GetVerts() in SetVerts() does not guarantee consistent internal data in polydata
+#endif
   if (!vertices)
     vertices = vtkSmartPointer<vtkCellArray>::New ();
 

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1278,7 +1278,9 @@ pcl::visualization::PCLVisualizer::convertPointCloudToVTKPolyData (
   vtkIdType nr_points = points->GetNumberOfPoints ();
 
   // Create the supporting structures
-  // vertices = polydata->GetVerts (); // Using the return value of GetVerts() in SetVerts() does not guarantee consistent internal data in polydata
+#ifndef VTK_CELL_ARRAY_V2
+  vertices = polydata->GetVerts (); // Using the return value of GetVerts() in SetVerts() does not guarantee consistent internal data in polydata
+#endif
   if (!vertices)
     vertices = vtkSmartPointer<vtkCellArray>::New ();
 

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -1278,7 +1278,7 @@ pcl::visualization::PCLVisualizer::convertPointCloudToVTKPolyData (
   vtkIdType nr_points = points->GetNumberOfPoints ();
 
   // Create the supporting structures
-  vertices = polydata->GetVerts ();
+  // vertices = polydata->GetVerts (); // Using the return value of GetVerts() in SetVerts() does not guarantee consistent internal data in polydata
   if (!vertices)
     vertices = vtkSmartPointer<vtkCellArray>::New ();
 


### PR DESCRIPTION
…ertices

vtkPolyData::SetVerts checks if the given vertices are different from the ones that vtkPolyData already has, and only then it updates some internal data structures (see also https://github.com/Kitware/VTK/blob/9ca1503e1c3c65c571ebd256d2aeabf777944ad6/Common/DataModel/vtkPolyData.cxx#L427 ). This means, if we call GetVerts(), and vtkPolyData returns some existing vertices, which we then modify and pass to SetVerts(), there is no guarantee that the internal data structures of vtkPolyData are all correctly updated. The fix is that we do not call GetVerts(), instead we always recreate the vertices array from scratch.

Fixes https://github.com/PointCloudLibrary/pcl/issues/6434