### PR TITLE
Add a toggle in getFitnessScore to respect user-provided indices in Registration

### DIFF
--- a/registration/include/pcl/registration/impl/registration.hpp
+++ b/registration/include/pcl/registration/impl/registration.hpp
@@ -131,13 +131,17 @@ Registration<PointSource, PointTarget, Scalar>::getFitnessScore(
 
 template <typename PointSource, typename PointTarget, typename Scalar>
 inline double
-Registration<PointSource, PointTarget, Scalar>::getFitnessScore(double max_range)
+Registration<PointSource, PointTarget, Scalar>::getFitnessScore(double max_range,
+                                                                bool use_indices)
 {
   double fitness_score = 0.0;
 
   // Transform the input dataset using the final transformation
   PointCloudSource input_transformed;
-  transformPointCloud(*input_, input_transformed, final_transformation_);
+  if (use_indices && indices_ && indices_->size() != input_->size())
+    transformPointCloud(*input_, *indices_, input_transformed, final_transformation_);
+  else
+    transformPointCloud(*input_, input_transformed, final_transformation_);
 
   pcl::Indices nn_indices(1);
   std::vector<float> nn_dists(1);

--- a/registration/include/pcl/registration/registration.h
+++ b/registration/include/pcl/registration/registration.h
@@ -444,9 +444,12 @@ public:
   /** \brief Obtain the Euclidean fitness score (e.g., mean of squared distances from
    * the source to the target) \param[in] max_range maximum allowable distance between a
    * point and its correspondence in the target (default: double::max)
+   * \param[in] use_indices whether to use the registered indices or all points
+   * (default: false)
    */
   inline double
-  getFitnessScore(double max_range = std::numeric_limits<double>::max());
+  getFitnessScore(double max_range = std::numeric_limits<double>::max(),
+                  bool use_indices = false);
 
   /** \brief Obtain the Euclidean fitness score (e.g., mean of squared distances from
    * the source to the target) from two sets of correspondence distances (distances

--- a/test/registration/test_registration.cpp
+++ b/test/registration/test_registration.cpp
@@ -195,6 +195,44 @@ TEST(PCL, ICP_translated)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+TEST(PCL, Registration_getFitnessScore_Indices)
+{
+  pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_in(new pcl::PointCloud<pcl::PointXYZ>);
+  pcl::PointCloud<pcl::PointXYZ>::Ptr cloud_out(new pcl::PointCloud<pcl::PointXYZ>);
+
+  cloud_in->push_back(pcl::PointXYZ(0, 0, 0));
+  cloud_in->push_back(pcl::PointXYZ(0, 1, 0));
+  cloud_in->push_back(pcl::PointXYZ(0, 0, 1));
+  cloud_in->push_back(pcl::PointXYZ(10, 0, 0));
+
+  cloud_out->push_back(pcl::PointXYZ(0, 0, 0));
+  cloud_out->push_back(pcl::PointXYZ(0, 1, 0));
+  cloud_out->push_back(pcl::PointXYZ(0, 0, 1));
+  cloud_out->push_back(pcl::PointXYZ(10, 0, 0.5)); // Dist squared = 0.25
+
+  RegistrationWrapper<pcl::PointXYZ, pcl::PointXYZ> reg;
+  reg.setInputSource(cloud_in);
+  reg.setInputTarget(cloud_out);
+
+  pcl::IndicesPtr indices(new pcl::Indices());
+  indices->push_back(0);
+  indices->push_back(1);
+  indices->push_back(2);
+  reg.setIndices(indices);
+
+  pcl::PointCloud<pcl::PointXYZ> final_cloud;
+  reg.align(final_cloud);
+
+  // With use_indices = false (default), should calculate score using all points
+  // mean of squared distances: (0 + 0 + 0 + 0.25) / 4 = 0.0625
+  EXPECT_NEAR(reg.getFitnessScore(1.0, false), 0.0625, 1e-4);
+
+  // With use_indices = true, should calculate score using only indices (points 0, 1, 2)
+  // mean of squared distances: (0 + 0 + 0) / 3 = 0.0
+  EXPECT_NEAR(reg.getFitnessScore(1.0, true), 0.0, 1e-4);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (PCL, IterativeClosestPoint)
 {
   IterativeClosestPoint<PointXYZ, PointXYZ> reg;


### PR DESCRIPTION
This PR resolves #6437 where Registration::getFitnessScore() completely ignored the indices_ member set via setIndices(). Previously, it evaluated the fitness score across the entire source cloud without a direct way to limit it.

Changes:
- Added an optional use_indices = false parameter to pcl::Registration::getFitnessScore. 
- Updated the getFitnessScore implementation in impl/registration.hpp so that when use_indices = true and indices_ are present
- Added TEST(PCL, Registration_getFitnessScore_Indices) in test_registration.cpp