### PR TITLE
Update Ubuntu-variety CI

### DIFF
--- a/.ci/azure-pipelines/ubuntu-variety.yaml
+++ b/.ci/azure-pipelines/ubuntu-variety.yaml
@@ -30,11 +30,11 @@ jobs:
   steps:
   - script: |
       POSSIBLE_VTK_VERSION=("9") \
-      POSSIBLE_CMAKE_CXX_STANDARD=("14" "17" "20" "23") \
+      POSSIBLE_CMAKE_CXX_STANDARD=("17" "20" "23" "26") \
       POSSIBLE_CMAKE_BUILD_TYPE=("None" "Debug" "Release" "RelWithDebInfo" "MinSizeRel") \
-      POSSIBLE_COMPILER_PACKAGE=("g++" "g++-11" "g++-12" "g++-13" "g++-14" "g++-15" "clang libomp-dev" "clang-14 libomp-14-dev" "clang-15 libomp-15-dev" "clang-17 libomp-17-dev" "clang-18 libomp-18-dev" "clang-19 libomp-19-dev" "clang-20 libomp-20-dev") \
-      POSSIBLE_CMAKE_C_COMPILER=("gcc" "gcc-11" "gcc-12" "gcc-13" "gcc-14" "gcc-15" "clang" "clang-14" "clang-15" "clang-17" "clang-18" "clang-19" "clang-20") \
-      POSSIBLE_CMAKE_CXX_COMPILER=("g++" "g++-11" "g++-12" "g++-13" "g++-14" "g++-15" "clang++" "clang++-14" "clang++-15" "clang++-17" "clang++-18" "clang++-19" "clang++-20") \
+      POSSIBLE_COMPILER_PACKAGE=("g++" "g++-11" "g++-12" "g++-13" "g++-14" "g++-15" "g++-16" "clang libomp-dev" "clang-17 libomp-17-dev" "clang-18 libomp-18-dev" "clang-19 libomp-19-dev" "clang-20 libomp-20-dev" "clang-21 libomp-21-dev" "clang-22 libomp-22-dev") \
+      POSSIBLE_CMAKE_C_COMPILER=("gcc" "gcc-11" "gcc-12" "gcc-13" "gcc-14" "gcc-15" "gcc-16" "clang" "clang-17" "clang-18" "clang-19" "clang-20" "clang-21" "clang-22") \
+      POSSIBLE_CMAKE_CXX_COMPILER=("g++" "g++-11" "g++-12" "g++-13" "g++-14" "g++-15" "g++-16" "clang++" "clang++-17" "clang++-18" "clang++-19" "clang++-20" "clang++-21" "clang++-22") \
       CHOSEN_COMPILER=$[RANDOM%${#POSSIBLE_COMPILER_PACKAGE[@]}] \
       dockerBuildArgs="--build-arg VTK_VERSION=${POSSIBLE_VTK_VERSION[$[RANDOM%${#POSSIBLE_VTK_VERSION[@]}]]} --build-arg CMAKE_CXX_STANDARD=${POSSIBLE_CMAKE_CXX_STANDARD[$[RANDOM%${#POSSIBLE_CMAKE_CXX_STANDARD[@]}]]} --build-arg CMAKE_BUILD_TYPE=${POSSIBLE_CMAKE_BUILD_TYPE[$[RANDOM%${#POSSIBLE_CMAKE_BUILD_TYPE[@]}]]} --build-arg COMPILER_PACKAGE=\"${POSSIBLE_COMPILER_PACKAGE[$CHOSEN_COMPILER]}\" --build-arg CMAKE_C_COMPILER=${POSSIBLE_CMAKE_C_COMPILER[$CHOSEN_COMPILER]} --build-arg CMAKE_CXX_COMPILER=${POSSIBLE_CMAKE_CXX_COMPILER[$CHOSEN_COMPILER]}" ; \
       echo "##vso[task.setvariable variable=dockerBuildArgs]$dockerBuildArgs"


### PR DESCRIPTION
- Building with C++14 no longer supported. However, make sure that PCL builds successfully when C++26 is chosen.
- Update list of available compilers, adding the newest gcc and clang compilers