### PR TITLE
fix cuda 13.3 errors

### DIFF
--- a/cuda/common/include/pcl/cuda/thrust.h
+++ b/cuda/common/include/pcl/cuda/thrust.h
@@ -45,3 +45,13 @@
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/sequence.h>
+
+// thrust::tuple/make_tuple/get were removed in Thrust 3.0 (CUDA 13)
+#if THRUST_MAJOR_VERSION >= 3
+#include <cuda/std/tuple>
+namespace thrust {
+    using ::cuda::std::tuple;
+    using ::cuda::std::make_tuple;
+    using ::cuda::std::get;
+}
+#endif

--- a/cuda/common/include/pcl/cuda/thrust.h
+++ b/cuda/common/include/pcl/cuda/thrust.h
@@ -45,13 +45,4 @@
 #include <thrust/copy.h>
 #include <thrust/device_ptr.h>
 #include <thrust/sequence.h>
-
-// thrust::tuple/make_tuple/get were removed in Thrust 3.0 (CUDA 13)
-#if THRUST_MAJOR_VERSION >= 3
-#include <cuda/std/tuple>
-namespace thrust {
-    using ::cuda::std::tuple;
-    using ::cuda::std::make_tuple;
-    using ::cuda::std::get;
-}
-#endif
+#include <thrust/tuple.h>


### PR DESCRIPTION
Upgrading to CUDA 13.3 included an update of thrust. This resulted in the following build failures in the cuda module:
```
pcl/cuda/common/include/pcl/cuda/point_cloud.h(287)
namespace "thrust" has no member "tuple"

pcl/cuda/common/include/pcl/cuda/point_cloud.h(301)
namespace "thrust" has no member "make_tuple"

pcl/cuda/features/include/pcl/cuda/features/normal_3d_kernels.h(172)
namespace "thrust" has no member "get"

...
```

This fixes the issue by switching to use `cuda::std` instead of `thrust` when there is a newer version of thrust.

#### Testing
This was tested by building on Ubuntu 24.04 with both CUDA 12.9 and 13.3.