### PR TITLE
Remove unused linking with 'pcl_visualization'

### DIFF
--- a/test/outofcore/CMakeLists.txt
+++ b/test/outofcore/CMakeLists.txt
@@ -12,4 +12,4 @@ endif()
 
 PCL_ADD_TEST (outofcore_test test_outofcore
               FILES test_outofcore.cpp
-              LINK_WITH pcl_gtest pcl_common pcl_io pcl_filters pcl_outofcore pcl_visualization)
+              LINK_WITH pcl_gtest pcl_common pcl_io pcl_filters pcl_outofcore)


### PR DESCRIPTION
'pcl_visualization' is not used by 'outofcore_test'. This will fix the '-D BUILD_visualization=OFF -D BUILD_global_tests=ON' configuration