### PR TITLE
CMake: Add 'USES_TERMINAL' to custom target for Ninja

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -38,7 +38,7 @@ if(EXCLUDE_TESTS)
   set(PCL_CTEST_ARGUMENTS ${PCL_CTEST_ARGUMENTS} -E "(${EXCLUDE_TESTS_REGEX})")
 endif()
 
-add_custom_target(tests "${CMAKE_CTEST_COMMAND}" ${PCL_CTEST_ARGUMENTS} -V -T Test VERBATIM)
+add_custom_target(tests "${CMAKE_CTEST_COMMAND}" ${PCL_CTEST_ARGUMENTS} -V -T Test VERBATIM USES_TERMINAL)
 
 set_target_properties(tests PROPERTIES FOLDER "Tests")
 


### PR DESCRIPTION
With the Ninja generator, output from custom target is captured and buffered, progress is only visible after the command finishes

Adding USES_TERMINAL enables real-time progress output during the custom step