### PR TITLE
[io] Fix out-of-bounds read/write when parsing OBJ face indices

### DIFF
--- a/io/src/obj_io.cpp
+++ b/io/src/obj_io.cpp
@@ -37,6 +37,7 @@
  */
 #include <pcl/io/obj_io.h>
 #include <fstream>
+#include <exception>
 #include <pcl/common/io.h>
 #include <pcl/common/pcl_filesystem.h>
 #include <pcl/console/time.h>
@@ -654,6 +655,12 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
 
           int v = std::stoi(f_st[0]);
           v = (v < 0) ? point_idx + v : v - 1;
+          if (v < 0 || static_cast<std::size_t> (v) >= cloud.width)
+          {
+            PCL_ERROR ("[pcl::OBJReader::read] Vertex index out of bounds in line %s\n", line.c_str ());
+            fs.close ();
+            return (-1);
+          }
           face_vertices.vertices[i - 1] = v;
 
           //handle normals
@@ -661,7 +668,12 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
           {
             int n = std::stoi(n_st);
             n = (n < 0) ? normal_idx + n : n - 1;
-
+            if (normal_mapping.empty() || n < 0 || static_cast<std::size_t> (n) >= normals.size())
+            {
+              PCL_ERROR ("[pcl::OBJReader::read] Normal index out of bounds in line %s\n", line.c_str ());
+              fs.close ();
+              return (-1);
+            }
             normal_mapping[v] += normals[n];
             normal_mapping_used = true;
           }
@@ -673,6 +685,12 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PCLPointCloud2 &cloud,
   catch (const char *exception)
   {
     PCL_ERROR ("[pcl::OBJReader::read] %s\n", exception);
+    fs.close ();
+    return (-1);
+  }
+  catch (const std::exception &exception)
+  {
+    PCL_ERROR ("[pcl::OBJReader::read] %s\n", exception.what ());
     fs.close ();
     return (-1);
   }
@@ -899,6 +917,12 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
 
           int v = std::stoi(f_st[0]);
           v = (v < 0) ? v_idx + v : v - 1;
+          if (v < 0 || static_cast<std::size_t> (v) >= mesh.cloud.width)
+          {
+            PCL_ERROR ("[pcl::OBJReader::read] Vertex index out of bounds in line %s\n", line.c_str ());
+            fs.close ();
+            return (-1);
+          }
           face_vertices.vertices[i - 1] = v;
 
           //handle normals
@@ -906,7 +930,12 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
           {
             int n = std::stoi(n_st);
             n = (n < 0) ? vn_idx + n : n - 1;
-
+            if (normal_mapping.empty() || n < 0 || static_cast<std::size_t> (n) >= normals.size())
+            {
+              PCL_ERROR ("[pcl::OBJReader::read] Normal index out of bounds in line %s\n", line.c_str ());
+              fs.close ();
+              return (-1);
+            }
             normal_mapping[v] += normals[n];
           }
 
@@ -914,7 +943,12 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
           {
             int vt = std::stoi(vt_st);
             vt = (vt < 0) ? vt_idx + vt : vt - 1;
-
+            if (vt < 0 || static_cast<std::size_t> (vt) >= vt_idx)
+            {
+              PCL_ERROR ("[pcl::OBJReader::read] Texture coordinate index out of bounds in line %s\n", line.c_str ());
+              fs.close ();
+              return (-1);
+            }
             tex_indices.vertices.push_back(vt);
           }
         }
@@ -928,6 +962,12 @@ pcl::OBJReader::read (const std::string &file_name, pcl::TextureMesh &mesh,
   catch (const char *exception)
   {
     PCL_ERROR ("[pcl::OBJReader::read] %s\n", exception);
+    fs.close ();
+    return (-1);
+  }
+  catch (const std::exception &exception)
+  {
+    PCL_ERROR ("[pcl::OBJReader::read] %s\n", exception.what ());
     fs.close ();
     return (-1);
   }
@@ -1097,6 +1137,12 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PolygonMesh &mesh,
 
           int v = std::stoi(f_st[0]);
           v = (v < 0) ? v_idx + v : v - 1;
+          if (v < 0 || static_cast<std::size_t> (v) >= mesh.cloud.width)
+          {
+            PCL_ERROR ("[pcl::OBJReader::read] Vertex index out of bounds in line %s\n", line.c_str ());
+            fs.close ();
+            return (-1);
+          }
           face_vertices.vertices[i - 1] = v;
 
           //handle normals
@@ -1104,7 +1150,12 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PolygonMesh &mesh,
           {
             int n = std::stoi(n_st);
             n = (n < 0) ? vn_idx + n : n - 1;
-              
+            if (normal_mapping.empty() || n < 0 || static_cast<std::size_t> (n) >= normals.size())
+            {
+              PCL_ERROR ("[pcl::OBJReader::read] Normal index out of bounds in line %s\n", line.c_str ());
+              fs.close ();
+              return (-1);
+            }
             normal_mapping[v] += normals[n];
             normal_mapping_used = true;
           }
@@ -1117,6 +1168,12 @@ pcl::OBJReader::read (const std::string &file_name, pcl::PolygonMesh &mesh,
   catch (const char *exception)
   {
     PCL_ERROR ("[pcl::OBJReader::read] %s\n", exception);
+    fs.close ();
+    return (-1);
+  }
+  catch (const std::exception &exception)
+  {
+    PCL_ERROR ("[pcl::OBJReader::read] %s\n", exception.what ());
     fs.close ();
     return (-1);
   }

--- a/test/io/test_io.cpp
+++ b/test/io/test_io.cpp
@@ -48,6 +48,7 @@
 #include <pcl/io/ply_io.h>
 #include <pcl/io/ascii_io.h>
 #include <pcl/io/obj_io.h>
+#include <pcl/PolygonMesh.h>
 #include <fstream>
 #include <iomanip> // for setprecision
 #include <locale>
@@ -1168,6 +1169,83 @@ TEST(PCL, loadOBJWithoutFaces)
   EXPECT_NEAR(point_cloud[1].normal_y, 0.0, 1e-5);
   EXPECT_NEAR(point_cloud[3].normal_z, 0.0, 1e-5);
   remove ("test_obj.obj");
+}
+
+TEST(PCL, OBJReadMalformedFaceIndices)
+{
+  const std::string fname = "test_obj_malformed.obj";
+
+  const std::string header =
+      "v 0.0 0.0 0.0\n"
+      "v 1.0 0.0 0.0\n"
+      "v 0.0 1.0 0.0\n"
+      "vn 0.0 0.0 1.0\n"
+      "vt 0.0 0.0\n"
+      "usemtl None\n";
+
+  const std::vector<std::string> bad_faces = {
+    "f 4//1 2//1 3//1\n",
+    "f 999999//1 2//1 3//1\n",
+    "f 1//999999 2//1 3//1\n",
+    "f 0//1 2//1 3//1\n",
+    "f -999//1 2//1 3//1\n",
+    "f abc//1 2//1 3//1\n",
+    "f 99999999999//1 2//1 3//1\n",
+  };
+
+  for (const auto &bad_face : bad_faces)
+  {
+    std::ofstream fs (fname);
+    fs << header << bad_face;
+    fs.close ();
+
+    pcl::OBJReader objreader;
+
+    pcl::PCLPointCloud2 blob;
+    EXPECT_EQ (objreader.read (fname, blob), -1) << "blob reader accepted: " << bad_face;
+
+    pcl::PolygonMesh poly_mesh;
+    EXPECT_EQ (objreader.read (fname, poly_mesh), -1) << "PolygonMesh reader accepted: " << bad_face;
+
+    pcl::TextureMesh tex_mesh;
+    EXPECT_EQ (objreader.read (fname, tex_mesh), -1) << "TextureMesh reader accepted: " << bad_face;
+  }
+
+  {
+    std::ofstream fs (fname);
+    fs << header << "f 1/999999/1 2/1/1 3/1/1\n";
+    fs.close ();
+
+    pcl::OBJReader objreader;
+    pcl::TextureMesh tex_mesh;
+    EXPECT_EQ (objreader.read (fname, tex_mesh), -1);
+  }
+
+  remove (fname.c_str ());
+}
+
+TEST(PCL, OBJReadValidRelativeIndices)
+{
+  const std::string fname = "test_obj_relative.obj";
+  std::ofstream fs (fname);
+  fs << "v 0.0 0.0 0.0\n"
+        "v 1.0 0.0 0.0\n"
+        "v 0.0 1.0 0.0\n"
+        "vn 0.0 0.0 1.0\n"
+        "f -3//-1 -2//-1 -1//-1\n";
+  fs.close ();
+
+  pcl::OBJReader objreader;
+
+  pcl::PCLPointCloud2 blob;
+  EXPECT_EQ (objreader.read (fname, blob), 0);
+  EXPECT_EQ (blob.width, 3);
+
+  pcl::PolygonMesh poly_mesh;
+  EXPECT_EQ (objreader.read (fname, poly_mesh), 0);
+  EXPECT_EQ (poly_mesh.polygons.size (), 1);
+
+  remove (fname.c_str ());
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The OBJ reader used the vertex, normal and texture-coordinate indices taken verbatim from a face ("f") line to index fixed-size vectors with no bounds checking, most importantly `normal_mapping[v] += normals[n]`. These indices are fully controlled by the input file, so a crafted face such as `f 999999//1` turned that line into a read-modify-write of an Eigen::Vector3f at an arbitrary heap offset, and a short or empty normal list produced out-of-bounds reads.

Malformed numeric tokens were a second problem: std::stoi throws std::invalid_argument/std::out_of_range, neither of which the surrounding `catch (const char*)` handled, so a bad file aborted the caller with an uncaught exception.

Validate each index against its container's size (and guard the empty normal case) before use, erroring out cleanly when out of range, and broaden the handler to std::exception so unparsable indices fail the read instead of crashing. All three read overloads (PCLPointCloud2, PolygonMesh, TextureMesh) are fixed. Regression tests cover the rejected malformed faces and confirm that valid relative (negative) indices still load.