### PR TITLE
Disable tutorials since they are build by readthedocs.

### DIFF
--- a/.ci/azure-pipelines/docs-pipeline.yaml
+++ b/.ci/azure-pipelines/docs-pipeline.yaml
@@ -2,11 +2,15 @@ trigger:
   paths:
     include:
     - doc
+    - .ci/azure-pipelines/documentation.yaml
+    - .ci/azure-pipelines/tutorials.yaml
 
 pr:
   paths:
     include:
     - doc
+    - .ci/azure-pipelines/documentation.yaml
+    - .ci/azure-pipelines/tutorials.yaml
 
 resources:
   pipelines:

--- a/.ci/azure-pipelines/documentation.yaml
+++ b/.ci/azure-pipelines/documentation.yaml
@@ -44,8 +44,6 @@ jobs:
           echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
           git clone git@github.com:PointCloudLibrary/documentation.git $DOC_DIR
           cd $DOC_DIR
-          cp -r $BUILD_DIR/doc/tutorials/html/* tutorials
-          cp -r $BUILD_DIR/doc/advanced/html/* advanced
           cp -r $BUILD_DIR/doc/doxygen/html/* .
           cp $CHANGELOG.html .
           git add --all

--- a/.ci/azure-pipelines/documentation.yaml
+++ b/.ci/azure-pipelines/documentation.yaml
@@ -32,7 +32,7 @@ jobs:
         displayName: 'CMake Configuration'
       - script: |
           cd $BUILD_DIR
-          cmake --build . -- doc tutorials advanced
+          cmake --build . -- doc
         displayName: 'Build Documentation'
       - script: |
           cd $BUILD_DIR

--- a/.ci/azure-pipelines/documentation.yaml
+++ b/.ci/azure-pipelines/documentation.yaml
@@ -28,7 +28,7 @@ jobs:
           cmake $(Build.SourcesDirectory) \
             -DDOXYGEN_USE_SHORT_NAMES=OFF \
             -DWITH_DOCS=ON \
-            -DWITH_TUTORIALS=ON
+            -DWITH_TUTORIALS=OFF
         displayName: 'CMake Configuration'
       - script: |
           cd $BUILD_DIR


### PR DESCRIPTION
Hopefully that removes the semi not working URLS:

https://pointclouds.org/documentation/tutorials/pcd_file_format.html