### PR TITLE
[FIX] gpu approx nearest unit test

### DIFF
--- a/test/gpu/octree/test_approx_nearest.cpp
+++ b/test/gpu/octree/test_approx_nearest.cpp
@@ -121,7 +121,7 @@ TEST(PCL_OctreeGPU, approxNearesSearch)
                                                   pcl::squaredEuclideanDistance(coords[7], queries[2]) };
 
   for (size_t i = 0; i < queries.size(); ++i) {
-    ASSERT_EQ(dists_pcl[i], dists_gpu[i]);
+    ASSERT_FLOAT_EQ(dists_pcl[i], dists_gpu[i]);
     ASSERT_NEAR(dists_gpu[i], dists_device_downloaded[i], 0.001);
     ASSERT_NEAR(dists_device_downloaded[i], expected_sqr_dists[i], 0.001);
   }


### PR DESCRIPTION
This unit test failed due the precision.
The error log
```
/home/chunibyo/workspace/osc/pcl/test/gpu/octree/test_approx_nearest.cpp:129: Failure
Expected equality of these values:
  dists_pcl[i]
    Which is: 0.03
  dists_gpu[i]
    Which is: 0.03
[  FAILED  ] PCL_OctreeGPU.approxNearesSearch 
```


And we can see their binary representations are
```
00111100111101011100001010010111 (0.030000014)
00111100111101011100001010010110 (0.030000012)
```