### PR TITLE
Reduce docker image size

### DIFF
--- a/.dev/docker/env/Dockerfile
+++ b/.dev/docker/env/Dockerfile
@@ -77,7 +77,7 @@ RUN apt-get update \
  && if [ "$(lsb_release -sr)" = "18.04" ]; then \
        apt-get -V install -y nvidia-cuda-toolkit g++-6 ; \
      else \
-       apt-get -V install -y nvidia-cuda-toolkit-gcc ; \
+       apt-get -V --no-install-recommends install -y nvidia-cuda-toolkit-gcc ; \
      fi \
  && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Azure pipelines currently fails because 24.04 image is too large. This should make it smaller.

For example: https://dev.azure.com/PointCloudLibrary/pcl/_build/results?buildId=26459&view=logs&j=b29c579b-56da-5a9f-b5ad-e9e014f41171&t=418601a5-22f2-4cef-838e-a95b4950b9c4

Failing Winx86 Docker build is unrelated, and failing Ubuntu 24.04 build will hopefully be fixed once this PR is merged and the new (smaller) image pushed to the docker hub.