### PR TITLE
Replace deprecated/removed VTK functions

### DIFF
--- a/test/visualization/test_visualization.cpp
+++ b/test/visualization/test_visualization.cpp
@@ -219,7 +219,7 @@ TEST(PCL, PCLVisualizer_updateColorHandlerIndex) {
   viewer_ptr->addPointCloud(rgb_cloud2_ptr,
                             color_handler_ptr,
                             Eigen::Vector4f::Zero(),
-                            Eigen::Quaternionf(),
+                            Eigen::Quaternionf::Identity(),
                             cloud_name,
                             0);
   EXPECT_TRUE(viewer_ptr->updateColorHandlerIndex(cloud_name, 0));

--- a/test/visualization/test_visualization.cpp
+++ b/test/visualization/test_visualization.cpp
@@ -361,6 +361,18 @@ TEST(PCL, ColorHandlerGenericField_datatypes)
   }
 }
 
+TEST(PCL, PCLVisualizer_addCorrespondences)
+{
+  pcl::Correspondences corrs;
+  corrs.emplace_back(0, cloud->size()-3, 0.0f);
+  corrs.emplace_back(1, cloud->size()-2, 0.0f);
+  corrs.emplace_back(2, cloud->size()-1, 0.0f);
+
+  pcl::visualization::PCLVisualizer::Ptr viewer(new pcl::visualization::PCLVisualizer("3D Viewer"));
+  viewer->addCorrespondences<pcl::PointXYZ>(cloud, cloud, corrs, 1);
+  viewer->spinOnce(100);
+}
+
 /* ---[ */
 int
 main (int argc, char** argv)

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -45,6 +45,7 @@
 #include <vtkVectorText.h>
 #include <vtkAlgorithmOutput.h>
 #include <vtkFollower.h>
+#include <vtkLine.h>
 #include <vtkMath.h>
 #include <vtkSphereSource.h>
 #include <vtkProperty2D.h>
@@ -1226,7 +1227,14 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
     overwrite = false; // Correspondences doesn't exist, add them instead of updating them
   }
 
-  int n_corr = static_cast<int>(correspondences.size () / nth);
+  Eigen::Affine3f source_transformation;
+  source_transformation.linear () = source_points->sensor_orientation_.matrix ();
+  source_transformation.translation () = source_points->sensor_origin_.template head<3> ();
+  Eigen::Affine3f target_transformation;
+  target_transformation.linear () = target_points->sensor_orientation_.matrix ();
+  target_transformation.translation () = target_points->sensor_origin_.template head<3> ();
+
+  int n_corr = static_cast<int>(std::ceil(static_cast<float>(correspondences.size ()) / nth));
   vtkSmartPointer<vtkPolyData> line_data = vtkSmartPointer<vtkPolyData>::New ();
 
   // Prepare colors
@@ -1237,13 +1245,52 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
 
   // Prepare coordinates
   vtkSmartPointer<vtkPoints> line_points = vtkSmartPointer<vtkPoints>::New ();
-  line_points->SetNumberOfPoints (2 * n_corr);
+  vtkSmartPointer<vtkCellArray> line_cells = vtkSmartPointer<vtkCellArray>::New ();
 
+#if VTK_MAJOR_VERSION > 9 || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 6)
+  int j = 0;
+  // Draw lines between the best corresponding points
+  for (std::size_t i = 0; i < correspondences.size (); i += nth)
+  {
+    if (correspondences[i].index_match == UNAVAILABLE)
+    {
+      PCL_WARN ("[addCorrespondences] No valid index_match for correspondence %d\n", i);
+      continue;
+    }
+
+    PointT p_src ((*source_points)[correspondences[i].index_query]);
+    PointT p_tgt ((*target_points)[correspondences[i].index_match]);
+
+    p_src.getVector3fMap () = source_transformation * p_src.getVector3fMap ();
+    p_tgt.getVector3fMap () = target_transformation * p_tgt.getVector3fMap ();
+
+    int id1 = j * 2, id2 = j * 2 + 1;
+    // Set the points
+    line_points->InsertNextPoint(p_src.x, p_src.y, p_src.z);
+    line_points->InsertNextPoint(p_tgt.x, p_tgt.y, p_tgt.z);
+
+    vtkNew<vtkLine> line;
+    line->GetPointIds()->SetId(0, id1);
+    line->GetPointIds()->SetId(1, id2);
+    line_cells->InsertNextCell(line);
+
+    float rgb[3];
+    rgb[0] = vtkMath::Random (32, 255); // min / max
+    rgb[1] = vtkMath::Random (32, 255);
+    rgb[2] = vtkMath::Random (32, 255);
+    line_colors->InsertTuple (j, rgb);
+    ++j;
+  }
+
+  line_data->SetPoints (line_points);
+  line_data->SetLines (line_cells);
+  line_data->GetCellData ()->SetScalars (line_colors);
+#else
+  line_points->SetNumberOfPoints (2 * n_corr);
   vtkSmartPointer<vtkIdTypeArray> line_cells_id = vtkSmartPointer<vtkIdTypeArray>::New ();
   line_cells_id->SetNumberOfComponents (3);
   line_cells_id->SetNumberOfTuples (n_corr);
   vtkIdType *line_cell_id = line_cells_id->GetPointer (0);
-  vtkSmartPointer<vtkCellArray> line_cells = vtkSmartPointer<vtkCellArray>::New ();
 
   vtkSmartPointer<vtkFloatArray> line_tcoords = vtkSmartPointer<vtkFloatArray>::New ();
   line_tcoords->SetNumberOfComponents (1);
@@ -1252,16 +1299,9 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
 
   double tc[3] = {0.0, 0.0, 0.0};
 
-  Eigen::Affine3f source_transformation;
-  source_transformation.linear () = source_points->sensor_orientation_.matrix ();
-  source_transformation.translation () = source_points->sensor_origin_.template head<3> ();
-  Eigen::Affine3f target_transformation;
-  target_transformation.linear () = target_points->sensor_orientation_.matrix ();
-  target_transformation.translation () = target_points->sensor_origin_.template head<3> ();
-
   int j = 0;
   // Draw lines between the best corresponding points
-  for (std::size_t i = 0; i < correspondences.size (); i += nth, ++j)
+  for (std::size_t i = 0; i < correspondences.size (); i += nth)
   {
     if (correspondences[i].index_match == UNAVAILABLE)
     {
@@ -1291,7 +1331,8 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
     rgb[0] = vtkMath::Random (32, 255); // min / max
     rgb[1] = vtkMath::Random (32, 255);
     rgb[2] = vtkMath::Random (32, 255);
-    line_colors->InsertTuple (i, rgb);
+    line_colors->InsertTuple (j, rgb);
+    ++j;
   }
   line_colors->SetNumberOfTuples (j);
   line_cells_id->SetNumberOfTuples (j);
@@ -1304,6 +1345,7 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
   line_data->SetLines (line_cells);
   line_data->GetPointData ()->SetTCoords (line_tcoords);
   line_data->GetCellData ()->SetScalars (line_colors);
+#endif
 
   // Create an Actor
   if (!overwrite)
@@ -1719,11 +1761,10 @@ pcl::visualization::PCLVisualizer::addPolygonMesh (
     // Create polys from polyMesh.polygons
     vtkSmartPointer<vtkCellArray> cell_array = vtkSmartPointer<vtkCellArray>::New ();
     
-    const auto idx = details::fillCells(lookup,vertices,cell_array, max_size_of_polygon);
+    details::fillCells(lookup,vertices,cell_array, max_size_of_polygon);
 
     vtkSmartPointer<vtkPolyData> polydata;
     allocVtkPolyData (polydata);
-    cell_array->GetData ()->SetNumberOfValues (idx);
     cell_array->Squeeze ();
     polydata->SetPolys (cell_array);
     polydata->SetPoints (points);
@@ -1873,9 +1914,8 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
   // Update the cells
   cells = vtkSmartPointer<vtkCellArray>::New ();
   
-  const auto idx = details::fillCells(lookup, verts, cells, max_size_of_polygon);
+  details::fillCells(lookup, verts, cells, max_size_of_polygon);
 
-  cells->GetData ()->SetNumberOfValues (idx);
   cells->Squeeze ();
   // Set the the vertices
   polydata->SetPolys (cells);

--- a/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
+++ b/visualization/include/pcl/visualization/impl/pcl_visualizer.hpp
@@ -66,6 +66,8 @@
 #include <pcl/common/utils.h> // pcl::utils::ignore
 #include <pcl/visualization/common/shapes.h>
 
+#include <cmath>
+
 // Support for VTK 7.1 upwards
 #ifdef vtkGenericDataArray_h
 #define SetTupleValue SetTypedTuple
@@ -1234,7 +1236,7 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
   target_transformation.linear () = target_points->sensor_orientation_.matrix ();
   target_transformation.translation () = target_points->sensor_origin_.template head<3> ();
 
-  int n_corr = static_cast<int>(std::ceil(static_cast<float>(correspondences.size ()) / nth));
+  const int n_corr = static_cast<int>(std::ceil(static_cast<float>(correspondences.size ()) / nth));
   vtkSmartPointer<vtkPolyData> line_data = vtkSmartPointer<vtkPolyData>::New ();
 
   // Prepare colors
@@ -1281,7 +1283,7 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
     line_colors->InsertTuple (j, rgb);
     ++j;
   }
-
+  line_colors->SetNumberOfTuples (j);
   line_data->SetPoints (line_points);
   line_data->SetLines (line_cells);
   line_data->GetCellData ()->SetScalars (line_colors);
@@ -1336,7 +1338,7 @@ pcl::visualization::PCLVisualizer::addCorrespondences (
   }
   line_colors->SetNumberOfTuples (j);
   line_cells_id->SetNumberOfTuples (j);
-  line_cells->SetCells (n_corr, line_cells_id);
+  line_cells->SetCells (j, line_cells_id);
   line_points->SetNumberOfPoints (j*2);
   line_tcoords->SetNumberOfTuples (j*2);
  

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -126,6 +126,9 @@
 vtkIdType
 pcl::visualization::details::fillCells(std::vector<int>& lookup, const std::vector<pcl::Vertices>& vertices, vtkSmartPointer<vtkCellArray> cell_array, int max_size_of_polygon)
 {
+  const auto idx = vertices.size() + std::accumulate(vertices.begin(), vertices.end(), static_cast<vtkIdType>(0),
+    [](const auto& sum, const auto& vertex) { return sum + vertex.vertices.size(); });
+
 #ifdef VTK_CELL_ARRAY_V2
   pcl::utils::ignore(max_size_of_polygon);
 
@@ -172,10 +175,8 @@ pcl::visualization::details::fillCells(std::vector<int>& lookup, const std::vect
         *cell++ = vertj;
     }
   }
+  cell_array->GetData ()->SetNumberOfValues (idx);
 #endif
-
-  const auto idx = vertices.size() + std::accumulate(vertices.begin(), vertices.end(), static_cast<vtkIdType>(0),
-    [](const auto& sum, const auto& vertex) { return sum + vertex.vertices.size(); });
 
   return idx;
 }
@@ -3178,9 +3179,8 @@ pcl::visualization::PCLVisualizer::updatePolygonMesh (
   // Update the cells
   cells = vtkSmartPointer<vtkCellArray>::New ();
 
-  const auto idx = details::fillCells(lookup, verts, cells, max_size_of_polygon);
+  details::fillCells(lookup, verts, cells, max_size_of_polygon);
 
-  cells->GetData ()->SetNumberOfValues (idx);
   cells->Squeeze ();
   // Set the the vertices
   polydata->SetStrips (cells);
@@ -4075,7 +4075,12 @@ pcl::visualization::PCLVisualizer::fromHandlersToScreen (
   // Save the pointer/ID pair to the global actor map
   CloudActor& cloud_actor = (*cloud_actor_map_)[id];
   cloud_actor.actor = actor;
+#if VTK_MAJOR_VERSION > 9 || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 6)
+  cloud_actor.cells = vtkSmartPointer<vtkIdTypeArray>::New ();
+  reinterpret_cast<vtkPolyDataMapper*>(actor->GetMapper ())->GetInput ()->GetVerts ()->ExportLegacyFormat (cloud_actor.cells);
+#else
   cloud_actor.cells = reinterpret_cast<vtkPolyDataMapper*>(actor->GetMapper ())->GetInput ()->GetVerts ()->GetData ();
+#endif
   cloud_actor.geometry_handlers.push_back (geometry_handler);
   cloud_actor.color_handlers.push_back (color_handler);
 


### PR DESCRIPTION
Fixes https://github.com/PointCloudLibrary/pcl/issues/6453

Several VTK functions are marked as deprecated in VTK 9.6.0 and removed in VTK 9.7.0:
- `SetCells` in `line_cells->SetCells (n_corr, line_cells_id);` is deprecated/removed. I added a new branch (for VTK >= 9.6.0) that uses the modern approach `line_cells->InsertNextCell(line);`. I also fixed the computation of `n_corr`.
- `GetData` in `cell_array->GetData ()->SetNumberOfValues (idx);` is deprecated/removed. I moved it into `details::fillCell`, into the "old" branch where `VTK_CELL_ARRAY_V2` is not defined. As far as I see, the new branch in `details::fillCell` does not need the `SetNumberOfValues` call because it uses `InsertNextCell` and `InsertCellPoint`
- `GetData` in `reinterpret_cast<vtkPolyDataMapper*>(actor->GetMapper ())->GetInput ()->GetVerts ()->GetData ();` is deprecated/removed. I replaced it with `ExportLegacyFormat`, although I am not sure whether it makes sense to keep `cloud_actor.cells` in the long term (might be worth to discuss again in the future, but not high priority)