### PR TITLE
Fixing build failure with CUDA 13.2

### DIFF
--- a/cuda/common/include/pcl/cuda/point_cloud.h
+++ b/cuda/common/include/pcl/cuda/point_cloud.h
@@ -40,6 +40,7 @@
 #include <pcl/cuda/point_types.h>
 #include <pcl/cuda/thrust.h>
 #include <pcl/memory.h>
+#include <thrust/tuple.h>
 
 namespace pcl
 {


### PR DESCRIPTION
Fixes CUDA 13.2 build failures. Verified by successfully building the latest PCL against CUDA 13.2 on Ubuntu 22.04, no functional changes are introduced.