### PR TITLE
Fixing build failure with CUDA 13.2

### DIFF
--- a/cuda/features/src/normal_3d.cu
+++ b/cuda/features/src/normal_3d.cu
@@ -36,6 +36,7 @@
  */
 
 #include "pcl/cuda/features/normal_3d_kernels.h"
+#include <thrust/tuple.h>
 
 namespace pcl
 {


### PR DESCRIPTION
Fixes CUDA 13.2 build failures. Verified by successfully building the latest PCL against CUDA 13.2 on Ubuntu 22.04, no functional changes are introduced.