### PR TITLE
Replace deprecated VTK and thrust functions, fix other problems with thrust

### DIFF
--- a/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/mesh_source.h
+++ b/apps/3d_rec_framework/include/pcl/apps/3d_rec_framework/pc_source/mesh_source.h
@@ -12,7 +12,12 @@
 #include <pcl/apps/render_views_tesselated_sphere.h>
 #include <pcl/io/pcd_io.h>
 
+#include <vtkVersion.h>
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+#include <vtkTransformFilter.h>
+#else
 #include <vtkTransformPolyDataFilter.h>
+#endif
 
 #include <functional>
 
@@ -153,13 +158,22 @@ public:
       trans->Modified();
       trans->Update();
 
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+      vtkSmartPointer<vtkTransformFilter> filter_scale =
+          vtkSmartPointer<vtkTransformFilter>::New();
+#else
       vtkSmartPointer<vtkTransformPolyDataFilter> filter_scale =
           vtkSmartPointer<vtkTransformPolyDataFilter>::New();
+#endif
       filter_scale->SetTransform(trans);
       filter_scale->SetInputConnection(reader->GetOutputPort());
       filter_scale->Update();
 
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+      vtkSmartPointer<vtkPolyData> mapper = filter_scale->GetPolyDataOutput();
+#else
       vtkSmartPointer<vtkPolyData> mapper = filter_scale->GetOutput();
+#endif
 
       // generate views
       pcl::apps::RenderViewsTesselatedSphere render_views;

--- a/cuda/io/src/disparity_to_cloud.cu
+++ b/cuda/io/src/disparity_to_cloud.cu
@@ -222,14 +222,14 @@ DisparityToCloud::compute (const std::uint16_t* depth_image,
 
     for (int iter = 0; iter < smoothing_nr_iterations; iter++)
     {
-      transform (
+      thrust::transform (
           thrust::make_zip_iterator (make_tuple (depth.begin (), thrust::counting_iterator<int>(0))),
           thrust::make_zip_iterator (make_tuple (depth.begin (), thrust::counting_iterator<int>(0))) + output_size,
           depth.begin (), DisparityClampedSmoothing (thrust::raw_pointer_cast(&depth[0]), thrust::raw_pointer_cast(&disp_helper_map[0]), width, height, smoothing_filter_size));
     }
 
     // Send the data to the device
-    transform (
+    thrust::transform (
         thrust::make_zip_iterator (make_tuple (depth.begin (), rgb.begin(), thrust::counting_iterator<int>(0))),
         thrust::make_zip_iterator (make_tuple (depth.begin (), rgb.begin(), thrust::counting_iterator<int>(0))) + output_size,
         output->points.begin (), 
@@ -238,7 +238,7 @@ DisparityToCloud::compute (const std::uint16_t* depth_image,
   }
   else
   {
-    transform (
+    thrust::transform (
         thrust::make_zip_iterator (make_tuple (depth.begin(), rgb.begin(), thrust::counting_iterator<int>(0))),
         thrust::make_zip_iterator (make_tuple (depth.begin(), rgb.begin(), thrust::counting_iterator<int>(0))) + output_size,
         output->points.begin (), 
@@ -356,14 +356,14 @@ DisparityToCloud::compute (const openni_wrapper::DepthImage::Ptr& depth_image,
 
     for (int iter = 0; iter < smoothing_nr_iterations; iter++)
     {
-      transform (
+      thrust::transform (
           thrust::make_zip_iterator (make_tuple (depth.begin (), thrust::counting_iterator<int>(0))),
           thrust::make_zip_iterator (make_tuple (depth.begin (), thrust::counting_iterator<int>(0))) + output_size,
           depth.begin (), DisparityClampedSmoothing (thrust::raw_pointer_cast(&depth[0]), thrust::raw_pointer_cast(&disp_helper_map[0]), output->width, output->height, smoothing_filter_size));
     }
 
     // Send the data to the device
-    transform (
+    thrust::transform (
         thrust::make_zip_iterator (make_tuple (depth.begin (), rgb.begin (), thrust::counting_iterator<int>(0))),
         thrust::make_zip_iterator (make_tuple (depth.begin (), rgb.begin (), thrust::counting_iterator<int>(0))) + output_size,
         output->points.begin (), 
@@ -404,7 +404,7 @@ DisparityToCloud::compute (const openni_wrapper::DepthImage::Ptr& depth_image,
     else
     {
       // Send the data to the device
-      transform (
+      thrust::transform (
           thrust::make_zip_iterator (make_tuple (depth.begin (), rgb.begin (), thrust::counting_iterator<int>(0))),
           thrust::make_zip_iterator (make_tuple (depth.begin (), rgb.begin (), thrust::counting_iterator<int>(0))) + output_size,
           output->points.begin (), 
@@ -415,7 +415,7 @@ DisparityToCloud::compute (const openni_wrapper::DepthImage::Ptr& depth_image,
   else
   {
     // Send the data to the device
-    transform (
+    thrust::transform (
         thrust::make_zip_iterator (make_tuple (depth.begin (), thrust::counting_iterator<int>(0))),
         thrust::make_zip_iterator (make_tuple (depth.begin (), thrust::counting_iterator<int>(0))) + 
                            output->width * output->height,

--- a/gpu/features/src/centroid.cu
+++ b/gpu/features/src/centroid.cu
@@ -36,6 +36,7 @@
 
 #include "internal.hpp"
 
+#include <thrust/version.h>
 #include <thrust/tuple.h>
 #include <thrust/device_ptr.h>
 #include <thrust/transform_reduce.h>
@@ -123,7 +124,11 @@ float3 pcl::device::getMaxDistance(const DeviceArray<PointT>& cloud, const float
     thrust::counting_iterator<int> ce = cf + cloud.size();
 
     thrust::tuple<float, int> init(0.f, 0);
+#if THRUST_VERSION >= 300100
+    cuda::maximum<thrust::tuple<float, int>> op;
+#else
     thrust::maximum<thrust::tuple<float, int>> op;
+#endif
 
     thrust::tuple<float, int> res =
         thrust::transform_reduce(
@@ -151,7 +156,11 @@ float3 pcl::device::getMaxDistance(const DeviceArray<PointT>& cloud, const Indic
     thrust::counting_iterator<int> ce = cf + indices.size();
 
     thrust::tuple<float, int> init(0.f, 0);
+#if THRUST_VERSION >= 300100
+    cuda::maximum<thrust::tuple<float, int>> op;
+#else
     thrust::maximum<thrust::tuple<float, int>> op;
+#endif
 
     thrust::tuple<float, int> res = thrust::transform_reduce(
         make_zip_iterator(make_tuple( make_permutation_iterator(src_beg, map_beg), cf )),

--- a/gpu/surface/src/cuda/convex_hull.cu
+++ b/gpu/surface/src/cuda/convex_hull.cu
@@ -44,6 +44,7 @@
 //#include <pcl/gpu/utils/device/funcattrib.hpp>
 #include <pcl/gpu/utils/safe_call.hpp>
 
+#include <thrust/distance.h>
 #include <thrust/tuple.h>
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
@@ -136,7 +137,11 @@ namespace pcl
       int transform_reduce_index(It beg, It end, Unary unop, Init init, Binary binary)
 	  {
 	    thrust::counting_iterator<int> cbeg(0);
+#if THRUST_VERSION >= 300100
+		thrust::counting_iterator<int> cend = cbeg + cuda::std::distance(beg, end);
+#else
 		thrust::counting_iterator<int> cend = cbeg + thrust::distance(beg, end);
+#endif
 
 	    thrust::tuple<float, int> t = thrust::transform_reduce(
 		  thrust::make_zip_iterator(thrust::make_tuple(beg, cbeg)),

--- a/outofcore/include/pcl/outofcore/visualization/axes.h
+++ b/outofcore/include/pcl/outofcore/visualization/axes.h
@@ -33,7 +33,11 @@ public:
     axes_->Update ();
 
     vtkSmartPointer<vtkFloatArray> axes_colors = vtkSmartPointer<vtkFloatArray>::New ();
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+    axes_colors->ReserveValues (6);
+#else
     axes_colors->Allocate (6);
+#endif
     axes_colors->InsertNextValue (0.0);
     axes_colors->InsertNextValue (0.0);
     axes_colors->InsertNextValue (0.5);

--- a/tools/obj_rec_ransac_accepted_hypotheses.cpp
+++ b/tools/obj_rec_ransac_accepted_hypotheses.cpp
@@ -50,7 +50,11 @@
 #include <vtkVersion.h>
 #include <vtkPolyDataReader.h>
 #include <vtkRenderWindow.h>
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+#include <vtkTransformFilter.h>
+#else
 #include <vtkTransformPolyDataFilter.h>
+#endif
 #include <vtkDoubleArray.h>
 #include <vtkDataArray.h>
 #include <vtkPointData.h>
@@ -321,7 +325,11 @@ update (CallbackParameters* params)
     vtkSmartPointer<vtkTransform> vtk_transform = vtkSmartPointer<vtkTransform>::New ();
     vtk_transform->SetMatrix (vtk_mat);
     // Setup the transformator
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+    vtkSmartPointer<vtkTransformFilter> vtk_transformator = vtkSmartPointer<vtkTransformFilter>::New ();
+#else
     vtkSmartPointer<vtkTransformPolyDataFilter> vtk_transformator = vtkSmartPointer<vtkTransformPolyDataFilter>::New ();
+#endif
     vtk_transformator->SetTransform (vtk_transform);
     vtk_transformator->SetInputData (vtk_model);
     vtk_transformator->Update ();
@@ -329,7 +337,11 @@ update (CallbackParameters* params)
     // Visualize
     vtkSmartPointer<vtkActor> vtk_actor = vtkSmartPointer<vtkActor>::New();
     vtkSmartPointer<vtkPolyDataMapper> vtk_mapper = vtkSmartPointer<vtkPolyDataMapper>::New ();
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+    vtk_mapper->SetInputData (vtk_transformator->GetPolyDataOutput ());
+#else
     vtk_mapper->SetInputData (vtk_transformator->GetOutput ());
+#endif
     vtk_actor->SetMapper(vtk_mapper);
     // Set the appearance & add to the renderer
     vtk_actor->GetProperty ()->SetColor (0.6, 0.7, 0.9);

--- a/tools/obj_rec_ransac_result.cpp
+++ b/tools/obj_rec_ransac_result.cpp
@@ -53,7 +53,11 @@
 #include <vtkDataArray.h>
 #include <vtkPointData.h>
 #include <vtkHedgeHog.h>
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+#include <vtkTransformFilter.h>
+#else
 #include <vtkTransformPolyDataFilter.h>
+#endif
 #include <vtkRenderer.h>
 #include <vtkRenderWindow.h>
 #include <vtkTransform.h>
@@ -279,7 +283,11 @@ update (CallbackParameters* params)
     vtk_transform->SetMatrix (vtk_mat);
 
     // Setup the transformator
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+    vtkSmartPointer<vtkTransformFilter> vtk_transformator = vtkSmartPointer<vtkTransformFilter>::New ();
+#else
     vtkSmartPointer<vtkTransformPolyDataFilter> vtk_transformator = vtkSmartPointer<vtkTransformPolyDataFilter>::New ();
+#endif
     vtk_transformator->SetTransform (vtk_transform);
     vtk_transformator->SetInputData (vtk_model);
     vtk_transformator->Update ();
@@ -287,7 +295,11 @@ update (CallbackParameters* params)
     // Visualize
     vtkSmartPointer<vtkActor> vtk_actor = vtkSmartPointer<vtkActor>::New();
     vtkSmartPointer<vtkPolyDataMapper> vtk_mapper = vtkSmartPointer<vtkPolyDataMapper>::New ();
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+    vtk_mapper->SetInputData (vtk_transformator->GetPolyDataOutput ());
+#else
     vtk_mapper->SetInputData (vtk_transformator->GetOutput ());
+#endif
     vtk_actor->SetMapper(vtk_mapper);
     // Set the appearance & add to the renderer
     vtk_actor->GetProperty ()->SetColor (0.6, 0.7, 0.9);

--- a/tools/virtual_scanner.cpp
+++ b/tools/virtual_scanner.cpp
@@ -56,6 +56,7 @@
 #include <pcl/common/pcl_filesystem.h>
 #include <pcl/console/parse.h>
 
+#include <vtkVersion.h>
 #include <vtkGeneralTransform.h>
 #include <vtkPlatonicSolidSource.h>
 #include <vtkPolyDataReader.h> // for vtkPolyDataReader
@@ -241,7 +242,10 @@ main (int argc, char** argv)
   vtkSmartPointer<vtkCellLocator> tree = vtkSmartPointer<vtkCellLocator>::New ();
   tree->SetDataSet (data);
   tree->CacheCellBoundsOn ();
+#if (VTK_MAJOR_VERSION < 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION < 7)
+  // deprecated because it is a no-op, starting with VTK 9.7.0
   tree->SetTolerance (0.0);
+#endif
   tree->SetNumberOfCellsPerBucket (1);
   tree->AutomaticOn ();
   tree->BuildLocator ();

--- a/visualization/src/common/shapes.cpp
+++ b/visualization/src/common/shapes.cpp
@@ -38,10 +38,15 @@
 #include <pcl/ModelCoefficients.h>
 #include <pcl/visualization/common/shapes.h>
 #include <pcl/common/angles.h>
+#include <vtkVersion.h>
 #include <vtkLineSource.h>
 #include <vtkTubeFilter.h>
 #include <vtkConeSource.h>
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+#include <vtkTransformFilter.h>
+#else
 #include <vtkTransformPolyDataFilter.h>
+#endif
 #include <vtkTransform.h>
 #include <vtkSphereSource.h>
 #include <vtkDiskSource.h>
@@ -81,7 +86,11 @@ pcl::visualization::createSphere (const pcl::ModelCoefficients &coefficients, in
   s_sphere->SetThetaResolution (res);
   s_sphere->LatLongTessellationOff ();
   
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+  vtkSmartPointer<vtkTransformFilter> tf = vtkSmartPointer<vtkTransformFilter>::New ();
+#else
   vtkSmartPointer<vtkTransformPolyDataFilter> tf = vtkSmartPointer<vtkTransformPolyDataFilter>::New ();
+#endif
   tf->SetTransform (t);
   tf->SetInputConnection (s_sphere->GetOutputPort ());
   tf->Update ();
@@ -107,7 +116,11 @@ pcl::visualization::createCube (const pcl::ModelCoefficients &coefficients)
   cube->SetYLength (coefficients.values[8]);
   cube->SetZLength (coefficients.values[9]);
   
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+  vtkSmartPointer<vtkTransformFilter> tf = vtkSmartPointer<vtkTransformFilter>::New ();
+#else
   vtkSmartPointer<vtkTransformPolyDataFilter> tf = vtkSmartPointer<vtkTransformPolyDataFilter>::New ();
+#endif
   tf->SetTransform (t);
   tf->SetInputConnection (cube->GetOutputPort ());
   tf->Update ();
@@ -133,7 +146,11 @@ pcl::visualization::createCube (const Eigen::Vector3f &translation, const Eigen:
   cube->SetYLength (height);
   cube->SetZLength (depth);
   
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+  vtkSmartPointer<vtkTransformFilter> tf = vtkSmartPointer<vtkTransformFilter>::New ();
+#else
   vtkSmartPointer<vtkTransformPolyDataFilter> tf = vtkSmartPointer<vtkTransformPolyDataFilter>::New ();
+#endif
   tf->SetTransform (t);
   tf->SetInputConnection (cube->GetOutputPort ());
   tf->Update ();
@@ -243,7 +260,11 @@ pcl::visualization::create2DCircle (const pcl::ModelCoefficients &coefficients, 
   t->Identity (); 
   t->Translate (coefficients.values[0], coefficients.values[1], z);
 
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+  vtkSmartPointer<vtkTransformFilter> tf = vtkSmartPointer<vtkTransformFilter>::New ();
+#else
   vtkSmartPointer<vtkTransformPolyDataFilter> tf = vtkSmartPointer<vtkTransformPolyDataFilter>::New ();
+#endif
   tf->SetTransform (t);
   tf->SetInputConnection (disk->GetOutputPort ());
   tf->Update ();
@@ -287,7 +308,11 @@ pcl::visualization::createSphere (const Eigen::Vector4f &center, double radius, 
   s_sphere->SetThetaResolution (res);
   s_sphere->LatLongTessellationOff ();
   
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+  vtkSmartPointer<vtkTransformFilter> tf = vtkSmartPointer<vtkTransformFilter>::New ();
+#else
   vtkSmartPointer<vtkTransformPolyDataFilter> tf = vtkSmartPointer<vtkTransformPolyDataFilter>::New ();
+#endif
   tf->SetTransform (t);
   tf->SetInputConnection (s_sphere->GetOutputPort ());
   tf->Update ();
@@ -323,7 +348,11 @@ pcl::visualization::createEllipsoid (const Eigen::Isometry3d &transform,
   vtkSmartPointer<vtkParametricFunctionSource> s_ellipsoid = vtkSmartPointer<vtkParametricFunctionSource>::New ();
   s_ellipsoid->SetParametricFunction (ellipsoid);
 
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+  vtkSmartPointer<vtkTransformFilter> tf = vtkSmartPointer<vtkTransformFilter>::New ();
+#else
   vtkSmartPointer<vtkTransformPolyDataFilter> tf = vtkSmartPointer<vtkTransformPolyDataFilter>::New ();
+#endif
   tf->SetTransform (t);
   tf->SetInputConnection (s_ellipsoid->GetOutputPort ());
   tf->Update ();

--- a/visualization/src/pcl_visualizer.cpp
+++ b/visualization/src/pcl_visualizer.cpp
@@ -669,7 +669,11 @@ pcl::visualization::PCLVisualizer::addCoordinateSystem (double scale, const std:
   axes->Update ();
 
   vtkSmartPointer<vtkFloatArray> axes_colors = vtkSmartPointer<vtkFloatArray>::New ();
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+  axes_colors->ReserveValues (6);
+#else
   axes_colors->Allocate (6);
+#endif
   axes_colors->InsertNextValue (0.0);
   axes_colors->InsertNextValue (0.0);
   axes_colors->InsertNextValue (0.5);
@@ -710,7 +714,11 @@ pcl::visualization::PCLVisualizer::addCoordinateSystem (double scale, float x, f
   axes->Update ();
 
   vtkSmartPointer<vtkFloatArray> axes_colors = vtkSmartPointer<vtkFloatArray>::New ();
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+  axes_colors->ReserveValues (6);
+#else
   axes_colors->Allocate (6);
+#endif
   axes_colors->InsertNextValue (0.0);
   axes_colors->InsertNextValue (0.0);
   axes_colors->InsertNextValue (0.5);
@@ -782,7 +790,11 @@ pcl::visualization::PCLVisualizer::addCoordinateSystem (double scale, const Eige
   axes->Update ();
 
   vtkSmartPointer<vtkFloatArray> axes_colors = vtkSmartPointer<vtkFloatArray>::New ();
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+  axes_colors->ReserveValues (6);
+#else
   axes_colors->Allocate (6);
+#endif
   axes_colors->InsertNextValue (0.0);
   axes_colors->InsertNextValue (0.0);
   axes_colors->InsertNextValue (0.5);

--- a/visualization/src/point_cloud_handlers.cpp
+++ b/visualization/src/point_cloud_handlers.cpp
@@ -42,6 +42,7 @@
 #include <pcl/common/io.h>
 #include <pcl/impl/instantiate.hpp>
 #include <pcl/point_types.h>
+#include <vtkVersion.h>
 
 ///////////////////////////////////////////////////////////////////////////////////////////
 vtkSmartPointer<vtkDataArray>
@@ -618,7 +619,11 @@ pcl::visualization::PointCloudGeometryHandler<pcl::PCLPointCloud2>::getGeometry 
   
   vtkIdType nr_points = cloud_->width * cloud_->height;
   
+#if (VTK_MAJOR_VERSION > 9) || (VTK_MAJOR_VERSION == 9 && VTK_MINOR_VERSION >= 7)
+  if (!data->ReserveTuples(nr_points))
+#else
   if (!data->Resize(nr_points))
+#endif
   {
     PCL_ERROR("[point_cloud_handlers::getGeometry] Failed to allocate space for points in VTK array.\n");
     throw std::bad_alloc();


### PR DESCRIPTION
- Replace deprecated `vtkTransformPolyDataFilter` with `vtkTransformFilter`
- Add `thrust::` namespace to `transform` functions to resolve ambiguity
- Replace deprecated `thrust::maximum` with `cuda::maximum`
- Replace deprecated `thrust:distance` with `cuda::std::distance`
- Replace deprecated `Allocate` with `ReserveValues` and `Resize` with `ReserveTuples` (VTK)