### PR TITLE
Fix PMF maximum window size precision

### DIFF
--- a/segmentation/include/pcl/segmentation/approximate_progressive_morphological_filter.h
+++ b/segmentation/include/pcl/segmentation/approximate_progressive_morphological_filter.h
@@ -72,11 +72,15 @@ namespace pcl
       
       ~ApproximateProgressiveMorphologicalFilter () override;
 
-      /** \brief Get the maximum window size to be used in filtering ground returns. */
+      /** \brief Get the maximum window size to be used in filtering ground returns.
+        * \return the maximum window size in number of grid cells
+        */
       inline int
       getMaxWindowSize () const { return (max_window_size_); }
 
-      /** \brief Set the maximum window size to be used in filtering ground returns. */
+      /** \brief Set the maximum window size to be used in filtering ground returns.
+        * \param[in] max_window_size the maximum window size in number of grid cells
+        */
       inline void
       setMaxWindowSize (int max_window_size) { max_window_size_ = max_window_size; }
 
@@ -143,7 +147,8 @@ namespace pcl
 
     protected:
 
-      /** \brief Maximum window size to be used in filtering ground returns. */
+      /** \brief Maximum window size to be used in filtering ground returns, in
+        * number of grid cells. */
       int max_window_size_{33};
 
       /** \brief Slope value to be used in computing the height threshold. */

--- a/segmentation/include/pcl/segmentation/progressive_morphological_filter.h
+++ b/segmentation/include/pcl/segmentation/progressive_morphological_filter.h
@@ -71,13 +71,19 @@ namespace pcl
       
       ~ProgressiveMorphologicalFilter () override;
 
-      /** \brief Get the maximum window size to be used in filtering ground returns. */
-      inline int
+      /** \brief Get the maximum window size to be used in filtering ground returns.
+        * \return the maximum window size in the same units as the input cloud
+        * coordinates
+        */
+      inline float
       getMaxWindowSize () const { return (max_window_size_); }
 
-      /** \brief Set the maximum window size to be used in filtering ground returns. */
+      /** \brief Set the maximum window size to be used in filtering ground returns.
+        * \param[in] max_window_size the maximum window size in the same units as the
+        * input cloud coordinates
+        */
       inline void
-      setMaxWindowSize (int max_window_size) { max_window_size_ = max_window_size; }
+      setMaxWindowSize (float max_window_size) { max_window_size_ = max_window_size; }
 
       /** \brief Get the slope value to be used in computing the height threshold. */
       inline float
@@ -136,8 +142,9 @@ namespace pcl
 
     protected:
 
-      /** \brief Maximum window size to be used in filtering ground returns. */
-      int max_window_size_{33};
+      /** \brief Maximum window size to be used in filtering ground returns, in the
+        * same units as the input cloud coordinates. */
+      float max_window_size_{33.0f};
 
       /** \brief Slope value to be used in computing the height threshold. */
       float slope_{0.7f};

--- a/test/segmentation/CMakeLists.txt
+++ b/test/segmentation/CMakeLists.txt
@@ -20,6 +20,10 @@ PCL_ADD_TEST(a_segmentation_test test_segmentation
              LINK_WITH pcl_gtest pcl_io pcl_segmentation pcl_features pcl_kdtree pcl_search pcl_common
              ARGUMENTS "${PCL_SOURCE_DIR}/test/bun0.pcd" "${PCL_SOURCE_DIR}/test/car6.pcd" "${PCL_SOURCE_DIR}/test/colored_cloud.pcd")
 
+PCL_ADD_TEST(progressive_morphological_filter test_progressive_morphological_filter
+             FILES test_progressive_morphological_filter.cpp
+             LINK_WITH pcl_gtest pcl_segmentation)
+
 PCL_ADD_TEST(a_prism_test test_concave_prism
              FILES test_concave_prism.cpp
              LINK_WITH pcl_gtest pcl_segmentation pcl_common)

--- a/test/segmentation/test_progressive_morphological_filter.cpp
+++ b/test/segmentation/test_progressive_morphological_filter.cpp
@@ -1,0 +1,33 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ *  Point Cloud Library (PCL) - www.pointclouds.org
+ *  Copyright (c) 2026-, Open Perception Inc.
+ *
+ *  All rights reserved
+ */
+
+#include <pcl/segmentation/progressive_morphological_filter.h>
+#include <pcl/test/gtest.h>
+#include <pcl/point_types.h>
+
+#include <type_traits>
+
+TEST(ProgressiveMorphologicalFilter, FractionalMaximumWindowSize)
+{
+  pcl::ProgressiveMorphologicalFilter<pcl::PointXYZ> filter;
+  static_assert(std::is_same_v<decltype(filter.getMaxWindowSize()), float>);
+
+  filter.setMaxWindowSize(6.25f);
+
+  EXPECT_FLOAT_EQ(filter.getMaxWindowSize(), 6.25f);
+}
+
+/* ---[ */
+int
+main(int argc, char** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return (RUN_ALL_TESTS());
+}
+/* ]--- */


### PR DESCRIPTION
## Summary

- store `ProgressiveMorphologicalFilter`'s maximum window size as `float`
- document that PMF uses input-coordinate units while `ApproximateProgressiveMorphologicalFilter` intentionally uses grid-cell counts
- add a regression test that checks both the API type and preservation of a fractional value

## Motivation

PMF computes each window size as `cell_size * (2 * base^iteration + 1)` and passes that coordinate-space value to the morphological operator. Comparing it with an integer maximum truncates valid fractional thresholds. The approximate implementation has different, existing semantics: its maximum is a number of cells, so this change deliberately leaves that API as `int`.

Fixes #6414

## Testing

- built and linked the new `test_progressive_morphological_filter` target with GCC 15.2 and `PCL_ONLY_CORE_POINT_TYPES=ON`
- confirmed a baseline type probe fails because `getMaxWindowSize()` returns `int`, while the updated API compiles as `float`
- ran a `PCL_NO_PRECOMPILE` runtime probe; setting `6.25f` returned `6.25`
- `g++ -std=c++17 -fsyntax-only test/segmentation/test_progressive_morphological_filter.cpp` with the configured PCL include paths
- `clang-format --dry-run --Werror test/segmentation/test_progressive_morphological_filter.cpp`
- `git diff --check`