### PR TITLE
Bump ci checkout version

### DIFF
--- a/.github/workflows/clang-tidy.yml
+++ b/.github/workflows/clang-tidy.yml
@@ -8,7 +8,7 @@ jobs:
     container:
       image: 'pointcloudlibrary/env:24.04'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Run clang-tidy
         run: >
           bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"


### PR DESCRIPTION
I noticed in a recent CI run checkout gave the following warning:
```
Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

This just bumps up the checkout action to the latest version to fix this warning. 