### PR TITLE
[filters] Reject out-of-grid centroid coordinates

### DIFF
--- a/filters/include/pcl/filters/voxel_grid.h
+++ b/filters/include/pcl/filters/voxel_grid.h
@@ -405,12 +405,19 @@ namespace pcl
                                  static_cast<int> (std::floor (z * inverse_leaf_size_[2]))};
       }
 
-      /** \brief Returns the index in the downsampled cloud corresponding to a given set of coordinates.
-        * \param[in] ijk the coordinates (i,j,k) in the grid (-1 if empty)
-        */
+      /** \brief Returns the index in the downsampled cloud corresponding to a given set
+       * of coordinates, or -1 if the cell is empty, outside the grid bounds, or the
+       * leaf layout is unavailable.
+       *
+       * \param[in] ijk the coordinates (i,j,k) in the grid
+       */
       inline int
       getCentroidIndexAt (const Eigen::Vector3i &ijk) const
       {
+        if (ijk[0] < min_b_[0] || ijk[0] > max_b_[0] || ijk[1] < min_b_[1] ||
+            ijk[1] > max_b_[1] || ijk[2] < min_b_[2] || ijk[2] > max_b_[2])
+          return (-1);
+
         int idx = ((Eigen::Vector4i() << ijk, 0).finished() - min_b_).dot (divb_mul_);
         if (idx < 0 || idx >= static_cast<int> (leaf_layout_.size ())) // this checks also if leaf_layout_.size () == 0 i.e. everything was computed as needed
         {
@@ -747,12 +754,19 @@ namespace pcl
                                  static_cast<int> (std::floor (z * inverse_leaf_size_[2]))};
       }
 
-      /** \brief Returns the index in the downsampled cloud corresponding to a given set of coordinates.
-        * \param[in] ijk the coordinates (i,j,k) in the grid (-1 if empty)
-        */
+      /** \brief Returns the index in the downsampled cloud corresponding to a given set
+       * of coordinates, or -1 if the cell is empty, outside the grid bounds, or the
+       * leaf layout is unavailable.
+       *
+       * \param[in] ijk the coordinates (i,j,k) in the grid
+       */
       inline int
       getCentroidIndexAt (const Eigen::Vector3i &ijk) const
       {
+        if (ijk[0] < min_b_[0] || ijk[0] > max_b_[0] || ijk[1] < min_b_[1] ||
+            ijk[1] > max_b_[1] || ijk[2] < min_b_[2] || ijk[2] > max_b_[2])
+          return (-1);
+
         int idx = ((Eigen::Vector4i() << ijk, 0).finished() - min_b_).dot (divb_mul_);
         if (idx < 0 || idx >= static_cast<int> (leaf_layout_.size ())) // this checks also if leaf_layout_.size () == 0 i.e. everything was computed as needed
         {

--- a/test/filters/test_filters.cpp
+++ b/test/filters/test_filters.cpp
@@ -563,6 +563,53 @@ TEST (PassThrough, Filters)
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+TEST(VoxelGrid, CentroidIndexAtBounds)
+{
+  auto input = pcl::make_shared<PointCloud<PointXYZ>>();
+  input->emplace_back(0.5f, 0.5f, 0.5f);
+  input->emplace_back(1.5f, 0.5f, 0.5f);
+  input->emplace_back(0.5f, 1.5f, 0.5f);
+  input->emplace_back(1.5f, 1.5f, 0.5f);
+  input->emplace_back(0.5f, 0.5f, 1.5f);
+  input->emplace_back(1.5f, 0.5f, 1.5f);
+  input->emplace_back(0.5f, 1.5f, 1.5f);
+  input->emplace_back(1.5f, 1.5f, 1.5f);
+
+  VoxelGrid<PointXYZ> grid;
+  grid.setInputCloud(input);
+  grid.setLeafSize(1.0f, 1.0f, 1.0f);
+  grid.setSaveLeafLayout(true);
+  PointCloud<PointXYZ> output;
+  grid.filter(output);
+  ASSERT_EQ(output.size(), 8);
+  ASSERT_EQ(grid.getLeafLayout().size(), 8);
+
+  auto input_blob = pcl::make_shared<PCLPointCloud2>();
+  toPCLPointCloud2(*input, *input_blob);
+  VoxelGrid<PCLPointCloud2> grid2;
+  grid2.setInputCloud(input_blob);
+  grid2.setLeafSize(1.0f, 1.0f, 1.0f);
+  grid2.setSaveLeafLayout(true);
+  PCLPointCloud2 output_blob;
+  grid2.filter(output_blob);
+  ASSERT_EQ(output_blob.width * output_blob.height, 8);
+  ASSERT_EQ(grid2.getLeafLayout().size(), 8);
+
+  const auto expect_outside_grid = [](const auto& voxel_grid) {
+    EXPECT_NE(voxel_grid.getCentroidIndexAt(Eigen::Vector3i(0, 0, 0)), -1);
+    EXPECT_NE(voxel_grid.getCentroidIndexAt(Eigen::Vector3i(1, 1, 1)), -1);
+    EXPECT_EQ(voxel_grid.getCentroidIndexAt(Eigen::Vector3i(2, 0, 0)), -1);
+    EXPECT_EQ(voxel_grid.getCentroidIndexAt(Eigen::Vector3i(-1, 1, 0)), -1);
+    EXPECT_EQ(voxel_grid.getCentroidIndexAt(Eigen::Vector3i(0, 2, 0)), -1);
+    EXPECT_EQ(voxel_grid.getCentroidIndexAt(Eigen::Vector3i(0, -1, 1)), -1);
+    EXPECT_EQ(voxel_grid.getCentroidIndexAt(Eigen::Vector3i(0, -2, 2)), -1);
+    EXPECT_EQ(voxel_grid.getCentroidIndexAt(Eigen::Vector3i(0, 2, -1)), -1);
+  };
+  expect_outside_grid(grid);
+  expect_outside_grid(grid2);
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 TEST (VoxelGrid, Filters)
 {
   // Test the PointCloud<PointT> method


### PR DESCRIPTION
## Summary

- reject component coordinates outside the voxel grid before flattening them
- apply the same bounds contract to the typed and `PCLPointCloud2` overloads
- add a deterministic 2x2x2 regression for positive, negative, and mixed-axis aliases

## Root cause

`getCentroidIndexAt()` flattened `(i, j, k)` into a scalar index and only checked that scalar against `leaf_layout_`. Different coordinate triples can produce the same flattened index, so an out-of-grid coordinate could return an unrelated occupied voxel instead of `-1`.

For example, in a fully occupied 2x2x2 grid, `(2, 0, 0)` is outside the grid but currently aliases the valid scalar index for `(0, 1, 0)`. The new component-wise guard rejects the coordinate before subtraction and flattening.

## Validation

- reproduced the bug on `master` in both overloads with six out-of-grid aliases
- built `test_filters` successfully
- focused regression: 100 consecutive passes
- full `test_filters` binary: 22/22 tests passed
- canonical CTest target `filters_filters`: 1/1 passed
- clang-format 14 changed-lines check and `git diff --check` passed
- rebased onto `master` at `1fdb03883`; the patch ID remained unchanged because the intervening commits only touched `PCLConfig.cmake.in`

AI assistance disclosure: OpenAI Codex helped investigate, draft, rebase, and validate this change. The checks above were run in the contribution workspace; the pull request remains subject to maintainer review.

Fixes #3529.
