### PR TITLE
OctreeSearch: also support leaf types without getPointIndicesVector()…

### DIFF
--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -45,6 +45,39 @@ namespace pcl {
 
 namespace octree {
 
+namespace detail {
+template <class T, class = void>
+struct has_getPointIndicesVector : std::false_type {};
+
+template <class T>
+struct has_getPointIndicesVector<
+    T,
+    std::void_t<decltype(std::declval<const T&>().getPointIndicesVector())>>
+: std::true_type {};
+
+/** If leaf has function getPointIndicesVector(), call it. Otherwise call
+ * leaf.getPointIndices().
+ */
+template <class T, std::enable_if_t<has_getPointIndicesVector<T>::value, int> = 0>
+auto
+getPointIndices(const T& leaf)
+{
+  return leaf.getPointIndicesVector();
+}
+
+/** If leaf has function getPointIndicesVector(), call it. Otherwise call
+ * leaf.getPointIndices().
+ */
+template <class T, std::enable_if_t<!has_getPointIndicesVector<T>::value, int> = 0>
+pcl::Indices
+getPointIndices(const T& leaf)
+{
+  pcl::Indices decoded_point_vector;
+  leaf.getPointIndices(decoded_point_vector);
+  return decoded_point_vector;
+}
+} // namespace detail
+
 template <typename PointT, typename LeafContainerT, typename BranchContainerT>
 bool
 OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::voxelSearch(
@@ -400,7 +433,7 @@ OctreePointCloudSearch<PointT, LeafContainerT, BranchContainerT>::
         const auto* child_leaf = static_cast<const LeafNode*>(child_node);
 
         // Linearly iterate over all points in the leaf
-        for (const auto& index : (*child_leaf)->getPointIndicesVector()) {
+        for (const auto& index : detail::getPointIndices(*(*child_leaf))) {
           const PointT& candidate_point = this->getPointByIndex(index);
 
           // calculate point distance to search point

--- a/octree/include/pcl/octree/impl/octree_search.hpp
+++ b/octree/include/pcl/octree/impl/octree_search.hpp
@@ -40,6 +40,8 @@
 #define PCL_OCTREE_SEARCH_IMPL_H_
 
 #include <cassert>
+#include <type_traits> // for std::false_type, std::true_type, std::void_t
+#include <utility>     // for std::declval
 
 namespace pcl {
 
@@ -59,7 +61,7 @@ struct has_getPointIndicesVector<
  * leaf.getPointIndices().
  */
 template <class T, std::enable_if_t<has_getPointIndicesVector<T>::value, int> = 0>
-auto
+decltype(auto)
 getPointIndices(const T& leaf)
 {
   return leaf.getPointIndicesVector();


### PR DESCRIPTION
… function

Use getPointIndicesVector() if the leaf type has it, otherwise fall back to the previous leaf.getPointIndices() (which likely copies indices).

Fixes https://github.com/PointCloudLibrary/pcl/issues/6466