### PR TITLE
Fix randomly failing sample consensus test

### DIFF
--- a/test/sample_consensus/test_sample_consensus.cpp
+++ b/test/sample_consensus/test_sample_consensus.cpp
@@ -111,27 +111,19 @@ TYPED_TEST(SacTest, InfiniteLoop)
   SampleConsensusModelSpherePtr model (new SampleConsensusModelSphere<PointXYZ> (cloud.makeShared ()));
   TypeParam sac (model, 0.03);
 
-  // This test sometimes fails for LMedS on azure, but always passes when run locally.
-  // Enable all output for LMedS, so that when it fails next time, we hopefully see why.
-  // This can be removed again when the failure reason is found and fixed.
-  int debug_verbosity_level = 0;
-  const auto previous_verbosity_level = pcl::console::getVerbosityLevel();
-  if (std::is_same<TypeParam, LeastMedianSquares<PointXYZ>>::value) {
-    debug_verbosity_level = 2;
-    pcl::console::setVerbosityLevel(pcl::console::L_VERBOSE);
-  }
-
   // Set up timed conditions
   std::condition_variable cv;
   std::mutex mtx;
+  bool done = false; // set to true when computeModel() has returned
 
   // Create the RANSAC object
   std::thread thread ([&] ()
   {
-    sac.computeModel (debug_verbosity_level);
+    sac.computeModel (0);
 
     // Notify things are done
     std::lock_guard<std::mutex> lock (mtx);
+    done = true;
     cv.notify_one ();
   });
 
@@ -139,15 +131,13 @@ TYPED_TEST(SacTest, InfiniteLoop)
   // Waits for the delay
   std::unique_lock<std::mutex> lock (mtx);
   #if defined(DEBUG) || defined(_DEBUG)
-    EXPECT_EQ (std::cv_status::no_timeout, cv.wait_for (lock, 15s));
+    ASSERT_TRUE (cv.wait_for (lock, 15s, [&done]{ return done; }));
   #else
-    EXPECT_EQ (std::cv_status::no_timeout, cv.wait_for (lock, 2s));
+    ASSERT_TRUE (cv.wait_for (lock, 2s, [&done]{ return done; }));
   #endif
   // release lock to avoid deadlock
   lock.unlock();
   thread.join ();
-
-  pcl::console::setVerbosityLevel(previous_verbosity_level); // reset verbosity level
 }
 
 int


### PR DESCRIPTION
The problem seems to be a lost wakeup: LMedS only does very few iterations (much fewer than the other sac methods) and sac.computeModel() accordingly returns quickly. In rare cases, it seems to be done before the main thread is listening/waiting for the condition_variable notification, so it is missed and the test fails after the timeout. The fix is to add a `bool done` that is set to true after sac.computeModel() is finished, and use the other overload of cv.wait_for() that returns the value of `done` (only true if finished before the timeout).

Reverts https://github.com/PointCloudLibrary/pcl/commit/11ab21b71c8e9fd3e35d86143743b35aaa6dcc71 because the verbose output is no longer necessary.

See e.g. https://www.modernescpp.com/index.php/c-core-guidelines-be-aware-of-the-traps-of-condition-variables/