### PR TITLE
Remove unnecessary Cocoa import from vtkRenderWindowInteractorFix.mm

### DIFF
--- a/visualization/include/pcl/visualization/vtk/vtkRenderWindowInteractorFix.mm
+++ b/visualization/include/pcl/visualization/vtk/vtkRenderWindowInteractorFix.mm
@@ -35,7 +35,6 @@
   *
   */
 
-#import <Cocoa/Cocoa.h>
 #include <pcl/visualization/vtk/vtkRenderWindowInteractorFix.h>
 #include <vtkCocoaRenderWindow.h>
 #include <vtkCocoaRenderWindowInteractor.h>


### PR DESCRIPTION
Hopefully fixes failing macOS 15 CI. The import was a leftover, now it is not needed any more (see https://github.com/PointCloudLibrary/pcl/commit/cff04c50c6509e943ed844e93a7f134762f48d69 )